### PR TITLE
fix: cannot get correctly row data for tree hierarchy type

### DIFF
--- a/packages/s2-core/src/interaction/row-header-text-click.ts
+++ b/packages/s2-core/src/interaction/row-header-text-click.ts
@@ -1,9 +1,9 @@
 import { Event, Point } from '@antv/g-canvas';
-import * as _ from 'lodash';
 import { isMobile } from '../utils/is-mobile';
 import { KEY_JUMP_HREF } from '../common/constant';
 import { HoverInteraction } from './hover-interaction';
-import { Data, ViewMeta } from '../common/interface';
+import { ViewMeta } from '../common/interface';
+import { head, isEmpty, get, each, set } from 'lodash';
 
 /**
  * Row header click navigation interaction
@@ -20,45 +20,37 @@ export class RowHeaderTextClick extends HoverInteraction {
   }
 
   protected start(ev: Event) {
-    this.targetPoint = _.get(ev, 'target.cfg.startPoint');
+    this.targetPoint = get(ev, 'target.cfg.startPoint');
   }
 
   protected end(ev: Event) {
-    if (this.targetPoint !== _.get(ev, 'target.cfg.startPoint')) {
+    if (this.targetPoint !== get(ev, 'target.cfg.startPoint')) {
       return;
     }
-    const appendInfo = _.get(ev.target, 'attrs.appendInfo', {}) as {
+    const appendInfo = get(ev.target, 'attrs.appendInfo', {}) as {
       isRowHeaderText: boolean;
       cellData: ViewMeta;
     };
     if (appendInfo.isRowHeaderText) {
-      // 行头内的文本
       const { cellData } = appendInfo;
       const key = cellData.key;
-      // 从当前节点出发往上遍历树拿到数据，如点中的是西湖区，则需要拿到 { 省份: 浙江省, 城市: 杭州市, 区县: 西湖区 }
+      // get current root data, eg. { province: 'A', city: 'B', area: 'C' }
       let node = cellData;
       const record = {};
       while (node.parent) {
         record[node.key] = node.value;
         node = node.parent;
       }
-      // 聚合模式-字段全在行头的情况下获取不到rowIndex, 只能用坐标去算
-      const rowIndex =
-        cellData.rowIndex ?? Math.floor(cellData.y / cellData.height);
-      // 透传本行所有数据，供跳转时解析参数
-      const currentRowData = _.find(
-        this.spreadsheet.dataCfg.data,
-        (row: Data, index: number) =>
-          row[key] === cellData.value && index === rowIndex,
-      );
-      if (!_.isEmpty(currentRowData)) {
-        _.each(currentRowData, (v, k) => {
+      const rowIndex = this.getRowIndex(cellData);
+      const currentRowData = get(this.spreadsheet.dataCfg.data, rowIndex);
+      if (!isEmpty(currentRowData)) {
+        each(currentRowData, (v, k) => {
           record[k] = v;
         });
       }
-      // 明细表需要增加rowIndex透出
-      if (!_.get(this, 'spreadsheet.options.spreadsheetType')) {
-        _.set(record, 'rowIndex', rowIndex);
+      // list view need row index
+      if (!this.spreadsheet?.options?.spreadsheetType) {
+        set(record, 'rowIndex', rowIndex);
       }
       this.spreadsheet.emit(KEY_JUMP_HREF, {
         key,
@@ -66,4 +58,18 @@ export class RowHeaderTextClick extends HoverInteraction {
       });
     }
   }
+
+  private getRowIndex = (cellData: ViewMeta) => {
+    const isTree = this.spreadsheet?.options.hierarchyType === 'tree';
+    if (isTree) {
+      let child = cellData;
+      while (!isEmpty(child.children)) {
+        child = head(child.children);
+      }
+      return cellData.rowIndex ?? child.rowIndex;
+    }
+    // It is possible for a list view to get a cell row index
+    const rowIndex = Math.floor(cellData.y / cellData.height);
+    return cellData.rowIndex ?? rowIndex;
+  };
 }


### PR DESCRIPTION
获取当前数据行数据, 由于没有主键唯一标识, 不应该单纯用 文本是否相等 `row[key] === cellData.value` 或者 `index` 相等判断, 对于树状聚合模式, 就会有问题
解法: 由于基础数据 data 肯定是扁平的, 所以要取当前🌲 的叶子节点, 取它的rowIndex, 然后隐射到 data 的 index, 获取到正确的数据