### PR TITLE
fix: disable mobile rerender for zoom

### DIFF
--- a/packages/s2-core/src/sheet-type/base-spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/base-spread-sheet.ts
@@ -43,6 +43,7 @@ import { StrategyDataCell } from '../cell';
 import { LruCache } from '../facet/layout/util/lru-cache';
 import { DebuggerUtil } from '../common/debug';
 import { safetyDataCfg, safetyOptions } from '../utils/safety-config';
+import { isMobile } from '../utils/is-mobile';
 
 const matrixTransform = ext.transform;
 export default abstract class BaseSpreadSheet extends EE {
@@ -590,6 +591,9 @@ export default abstract class BaseSpreadSheet extends EE {
   }
 
   private renderByZoomScale = debounce((e) => {
+    if (isMobile()) {
+      return;
+    }
     const ratio = Math.max(e.target.scale, window.devicePixelRatio);
     if (ratio > 1) {
       this.renderByDevicePixelRatio(ratio);


### PR DESCRIPTION
visualViewport resize 在 iOS 的 safari 滚动的时候也会触发, iPhone12 的DPR是3, 如果进行高DPR适配的话, 一旦报表很多, 会触发safari 255MB内存的限制