### PR TITLE
fix: 🐛  cannot get correct row data

### DIFF
--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -6,6 +6,7 @@ import { BaseTooltip } from '../tooltip';
 import { S2DataConfig, safetyDataConfig, Data, DataItem } from './s2DataConfig';
 import { S2Options, safetyOptions } from './s2Options';
 import { CustomInteraction } from './interaction';
+import { ResizeInfo } from '../../facet/header/interface';
 
 export { S2DataConfig, safetyDataConfig, S2Options, safetyOptions, Data };
 
@@ -453,4 +454,10 @@ export interface ColWidthCache {
 export interface CellPosition {
   x: number;
   y: number;
+}
+
+export interface CellAppendInfo<T = Node> extends Partial<ResizeInfo> {
+  isCornerHeaderText?: boolean;
+  isRowHeaderText?: boolean;
+  cellData?: T;
 }


### PR DESCRIPTION
1. 增加 单元格 append Info 的类型定义
2. 重构单元格点击获取当前行的数据不正确的场景
   - 明细模式
   - 树状模式
   - 聚合模式
   - 单元格名字一样的情况 (之前的实现是直接用名字是否相等判断是否是当前行, 如果数据名一样就会有bug)
 3. 完善类型定义