### PR TITLE
chore: auto set label by pr type

### DIFF
--- a/.github/workflows/pr-auto-set-label.yml
+++ b/.github/workflows/pr-auto-set-label.yml
@@ -1,0 +1,63 @@
+name: PR Auto Set Label
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  set-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set fix label
+        if: startsWith(github.event.pull_request.title, 'fix')
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'set-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'pr(fix)'
+
+      - name: Set chore label
+        if: startsWith(github.event.pull_request.title, 'chore')
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'set-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'pr(chore)'
+
+      - name: Set feat label
+        if: startsWith(github.event.pull_request.title, 'feat')
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'set-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'pr(feature)'
+
+      - name: Set refactor label
+        if: startsWith(github.event.pull_request.title, 'refactor')
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'set-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'pr(refactor)'
+
+      - name: Set test label
+        if: startsWith(github.event.pull_request.title, 'test')
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'set-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'pr(test)'
+
+      - name: Set docs label
+        if: startsWith(github.event.pull_request.title, 'docs')
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'set-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          labels: 'pr(documentation)'


### PR DESCRIPTION
根据缨缨之前的 配置的 lerna changelog labels, 增加一个自动化脚本,  根据pr 标题前缀 (fix, feat ....), 自动添加 label, 我用我自己的repo 测试了下 [效果如下](https://github.com/lijinke666/css3-demos/pull/4) 

![image](https://user-images.githubusercontent.com/21015895/125060340-da9cc200-e0de-11eb-95bc-593f47b5e595.png)
