### PR TITLE
fix: brush selection range mask not show when rerender

### DIFF
--- a/packages/s2-core/src/interaction/brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection.ts
@@ -43,27 +43,23 @@ export class BrushSelection extends BaseInteraction {
   }
 
   private initPrepareSelectMaskShape() {
-    if (this.prepareSelectMaskShape) {
-      this.hidePrepareSelectMaskShape();
-      return;
-    }
+    const { foregroundGroup } = this.spreadsheet;
+    foregroundGroup.removeChild(this.prepareSelectMaskShape);
+
     const prepareSelectMaskTheme = this.getPrepareSelectMaskTheme();
-    this.prepareSelectMaskShape = this.spreadsheet.foregroundGroup.addShape(
-      'rect',
-      {
-        visible: false,
-        attrs: {
-          width: 0,
-          height: 0,
-          x: 0,
-          y: 0,
-          fill: prepareSelectMaskTheme?.backgroundColor,
-          fillOpacity: prepareSelectMaskTheme?.backgroundOpacity,
-          zIndex: FRONT_GROUND_GROUP_BRUSH_SELECTION_Z_INDEX,
-        },
-        capture: false,
+    this.prepareSelectMaskShape = foregroundGroup.addShape('rect', {
+      visible: false,
+      attrs: {
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        fill: prepareSelectMaskTheme?.backgroundColor,
+        fillOpacity: prepareSelectMaskTheme?.backgroundOpacity,
+        zIndex: FRONT_GROUND_GROUP_BRUSH_SELECTION_Z_INDEX,
       },
-    );
+      capture: false,
+    });
   }
 
   private setBrushSelectionStage(stage: InteractionBrushSelectionStage) {

--- a/packages/s2-core/src/sheet-type/index.ts
+++ b/packages/s2-core/src/sheet-type/index.ts
@@ -536,7 +536,6 @@ export class SpreadSheet extends EE {
     } else {
       this.facet = new TableFacet(facetCfg);
     }
-    // render facet
     this.facet.render();
   };
 


### PR DESCRIPTION
修复表格重新渲染后, 刷选蒙层不显示的问题

原因: 
每次重新渲染会先清空 对应 group 的 shape
![image](https://user-images.githubusercontent.com/21015895/130744160-63367d7f-d3af-4c43-95c6-a7323a252dc6.png)

第二次加载时, prepareSelectMaskShape 实例还存在,  但是重新渲染前已经清空了 对应的 shape, 相当于是个空引用了, 导致第二次加载不会显示

![image](https://user-images.githubusercontent.com/21015895/130744532-fea37e23-a945-49d6-bae9-75af1a182dd5.png)
