### PR TITLE
fix(dataset): getDimensionValues return empty when second field in compact mode

### DIFF
--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -416,10 +416,7 @@ export class PivotDataSet extends BaseDataSet {
 
     if (this.sortedDimensionValues.has(field)) {
       return filterUndefined(
-        getIntersections(
-          [...this.sortedDimensionValues.get(field)],
-          [...meta.keys()],
-        ),
+          [...this.sortedDimensionValues.get(field)]
       );
     }
     return filterUndefined([...meta.keys()]);


### PR DESCRIPTION
修复紧凑模式下文字被隐藏的问题，原因是 getDimensionValues 在某些场景（第二个维度值）下返回空数组

![image](https://user-images.githubusercontent.com/3271828/131068864-a365a0b5-0581-41e7-a4ea-01d1120aa7e9.png)
