### PR TITLE
fix: correct the row and corner cell alignment

### DIFF
--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -1,6 +1,3 @@
-import { Group, IShape, Point, ShapeAttrs } from '@antv/g-canvas';
-import { isEmpty, isEqual } from 'lodash';
-import { HeaderCell } from './header-cell';
 import {
   CellTypes,
   EXTRA_FIELD,
@@ -14,6 +11,9 @@ import { getTextPosition, getVerticalPosition } from '@/utils/cell/cell';
 import { renderRect, renderText, renderTreeIcon } from '@/utils/g-renders';
 import { isIPhoneX } from '@/utils/is-mobile';
 import { getEllipsisText } from '@/utils/text';
+import { Group, IShape, Point, ShapeAttrs } from '@antv/g-canvas';
+import { isEmpty, isEqual } from 'lodash';
+import { HeaderCell } from './header-cell';
 
 export class CornerCell extends HeaderCell {
   protected headerConfig: CornerHeaderConfig;
@@ -45,7 +45,6 @@ export class CornerCell extends HeaderCell {
     const { x, y, height } = this.getCellArea();
 
     const textStyle = this.getTextStyle();
-    const iconStyle = this.getStyle().icon;
     const { formattedValue } = this.getFormattedFieldValue();
 
     // 当为树状结构下需要计算文本前收起展开的icon占的位置
@@ -69,14 +68,13 @@ export class CornerCell extends HeaderCell {
 
     const { x: textX } = getTextPosition(
       {
-        x: x + this.getTreeIconWidth() + iconStyle.margin.right,
+        x: x + this.getTreeIconWidth(),
         y: y,
         width: maxWidth,
         height: height,
       },
       textStyle,
     );
-
     const textY = y + (isEmpty(secondLine) ? height / 2 : height / 4);
     // first line
     this.textShapes.push(
@@ -216,7 +214,7 @@ export class CornerCell extends HeaderCell {
   }
 
   protected getMaxTextWidth(): number {
-    const { width } = this.getContentArea();
+    const { width } = this.getCellArea();
     return width - this.getTreeIconWidth();
   }
 

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -1,7 +1,3 @@
-import { Event, Group, Point } from '@antv/g-canvas';
-import { GM } from '@antv/g-gesture';
-import { each, forEach } from 'lodash';
-import { HeaderCell } from './header-cell';
 import {
   CellTypes,
   ID_SEPARATOR,
@@ -13,9 +9,14 @@ import { GuiIcon } from '@/common/icons';
 import { FormatResult, TextTheme } from '@/common/interface';
 import { ResizeInfo } from '@/facet/header/interface';
 import { RowHeaderConfig } from '@/facet/header/row';
+import { getTextPosition } from '@/utils/cell/cell';
 import { renderLine, renderRect, renderTreeIcon } from '@/utils/g-renders';
 import { getAllChildrenNodeHeight } from '@/utils/get-all-children-node-height';
 import { getAdjustPosition } from '@/utils/text-absorption';
+import { Event, Group, Point } from '@antv/g-canvas';
+import { GM } from '@antv/g-gesture';
+import { each, forEach } from 'lodash';
+import { HeaderCell } from './header-cell';
 
 export class RowCell extends HeaderCell {
   protected headerConfig: RowHeaderConfig;
@@ -332,7 +333,12 @@ export class RowCell extends HeaderCell {
     const { isLeaf, isTotals } = this.meta;
     const { text, bolderText } = this.getStyle();
     const style = isLeaf && !isTotals ? text : bolderText;
-    return { ...style, textAlign: 'left', textBaseline: 'top' };
+
+    return {
+      ...style,
+      textAlign: this.spreadsheet.isHierarchyTreeType() ? 'left' : 'center',
+      textBaseline: 'top',
+    };
   }
 
   protected getFormattedFieldValue(): FormatResult {
@@ -356,14 +362,15 @@ export class RowCell extends HeaderCell {
   }
 
   protected getTextPosition(): Point {
-    const { x, y, height: contentHeight } = this.getContentArea();
+    const { y, height: contentHeight } = this.getContentArea();
     const { offset, height } = this.headerConfig;
 
     const { fontSize } = this.getTextStyle();
     const textIndent = this.getTextIndent();
     const textY = getAdjustPosition(y, contentHeight, offset, height, fontSize);
-    const textX = x + textIndent;
-
+    const textX =
+      getTextPosition(this.getContentArea(), this.getTextStyle()).x +
+      textIndent;
     return { x: textX, y: textY };
   }
 


### PR DESCRIPTION
Row and corner cell text alignment should be both centers in grid mode and left in tree mode.

Before:
![image](https://user-images.githubusercontent.com/17964556/132458120-d990f559-d87a-4e12-bda0-992a55f9de1a.png)

After:
![image](https://user-images.githubusercontent.com/17964556/132457944-bc31e2fd-bc07-4c77-9f11-b30176ae67a5.png)

