### PR TITLE
chore(build): update external using regex

### DIFF
--- a/packages/s2-core/rollup.config.js
+++ b/packages/s2-core/rollup.config.js
@@ -56,7 +56,7 @@ const plugins = [
   }),
 ];
 
-const external = ['react', 'react-dom', '@ant-design/icons', 'antd'];
+const external = ['react', 'react-dom', '@ant-design/icons', /antd/];
 
 if (format === 'umd') {
   output.file = 'dist/s2.min.js';


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🔧 Chore

- 更新 rollup 的 external 配置，用正则匹配 antd，避免 antd/lib 和 antd 的 locale 文件被一起打包进去，会造成如下报错
![image](https://user-images.githubusercontent.com/10339692/133737522-40d5601c-4df8-4187-8ae9-3d8f2c371297.png)



