### PR TITLE
chore: upgrade sharp version to support M1

### DIFF
--- a/s2-site/package.json
+++ b/s2-site/package.json
@@ -27,7 +27,8 @@
   },
   "resolutions": {
     "monaco-editor-webpack-plugin": "2.0.0",
-    "monaco-editor": "0.21.0"
+    "monaco-editor": "0.21.0",
+    "sharp":"0.29.0"
   },
   "dependencies": {
     "@antv/gatsby-theme-antv": "^1.1.8",


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🔧 Chore

- [x] Upgrade sharp version 

### 📝 Description

Currently, `gatsby-plugin-manifest` has dependency `sharp@0.27.0`, But sharp supports Apple M1 since `@0.29.0`

### 🖼️ Screenshot

![image](https://user-images.githubusercontent.com/17964556/133740882-da15dad1-904c-4a5e-87e8-9a012a0dba58.png)

