### PR TITLE
fix(povit-table): resolve scroll shake issue close #374 #361

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -376,28 +376,34 @@ export abstract class BaseFacet {
   calculateCornerBBox = () => {
     const { rowsHierarchy, colsHierarchy } = this.layoutResult;
 
-    const leftWidth = rowsHierarchy.width + this.getSeriesNumberWidth();
-    const height = colsHierarchy.height;
-
-    this.cornerWidth = leftWidth;
-    let renderWidth = leftWidth;
-    if (!this.cfg.spreadsheet.isScrollContainsRowHeader()) {
-      renderWidth = this.getCornerWidth(leftWidth, colsHierarchy);
-    }
-    if (!this.cfg.spreadsheet.isPivotMode()) {
-      renderWidth = 0;
-    }
+    const originalCornerWidth = Math.floor(
+      rowsHierarchy.width + this.getSeriesNumberWidth(),
+    );
+    const height = Math.floor(colsHierarchy.height);
+    const width = this.getCornerBBoxWidth(originalCornerWidth);
 
     this.cornerBBox = {
       x: 0,
       y: 0,
-      width: renderWidth,
+      width,
       height,
-      maxX: renderWidth,
+      maxX: width,
       maxY: height,
       minX: 0,
       minY: 0,
     };
+    this.cornerWidth = originalCornerWidth;
+  };
+
+  getCornerBBoxWidth = (cornerWidth: number): number => {
+    const { colsHierarchy } = this.layoutResult;
+    if (!this.cfg.spreadsheet.isScrollContainsRowHeader()) {
+      return this.getCornerWidth(cornerWidth, colsHierarchy);
+    }
+    if (!this.cfg.spreadsheet.isPivotMode()) {
+      return 0;
+    }
+    return cornerWidth;
   };
 
   getCornerWidth = (leftWidth: number, colsHierarchy: Hierarchy): number => {
@@ -427,7 +433,7 @@ export abstract class BaseFacet {
       // tree mode
       renderWidth = leftWidth;
     }
-    return renderWidth;
+    return Math.floor(renderWidth);
   };
 
   calculatePanelBBox = () => {
@@ -722,7 +728,9 @@ export abstract class BaseFacet {
   };
 
   updateHScrollBarThumbOffset = (deltaX: number) => {
-    this.hScrollBar.updateThumbOffset(this.hScrollBar.thumbOffset + deltaX / 8);
+    this.hScrollBar?.updateThumbOffset(
+      this.hScrollBar.thumbOffset + deltaX / 8,
+    );
   };
 
   updateHRowScrollBarThumbOffset = (deltaX: number) => {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Bug fix issue #374 

### 📝 Description

1.修复透视表行头有滚动条时, 在数值单元格区域无法滚动的问题
2.修复透视表行头滚动抖动

### 🔗 Related issue link

close #374 #361
