### PR TITLE
fix(pivot-table): fix render apply font crash on ios15

### DIFF
--- a/packages/s2-core/src/common/constant/theme.ts
+++ b/packages/s2-core/src/common/constant/theme.ts
@@ -11,7 +11,7 @@ export const PALETTE_MAP: Record<string, Palette> = {
 };
 
 export const FONT_FAMILY =
-  'Roboto, PingFangSC, -apple-system, BlinkMacSystemFont, Microsoft YaHei, Arial, sans-serif';
+  'Roboto, PingFangSC, BlinkMacSystemFont, Microsoft YaHei, Arial, sans-serif';
 export const ICON_SIZE = 14;
 export const TEXT_INDENT = 12;
 

--- a/packages/s2-core/src/components/sheets/tabular-sheet/tabular-theme.ts
+++ b/packages/s2-core/src/components/sheets/tabular-sheet/tabular-theme.ts
@@ -2,7 +2,7 @@ import { S2Theme } from '@/index';
 import { isWindows } from '@/utils/is-mobile';
 
 const FONT_FAMILY =
-  'Roboto, PingFangSC, -apple-system, BlinkMacSystemFont, Microsoft YaHei, Arial, sans-serif';
+  'Roboto, PingFangSC, BlinkMacSystemFont, Microsoft YaHei, Arial, sans-serif';
 
 export const FONT_SIZE = 12;
 export const FONT_SIZE_MINOR = 11;

--- a/packages/s2-core/src/ui/tooltip/index.less
+++ b/packages/s2-core/src/ui/tooltip/index.less
@@ -14,7 +14,6 @@
       'Roboto',
       'PingFang SC',
       'Chinese Quote',
-      '-apple-system',
       'BlinkMacSystemFont',
       'Segoe UI',
       'Hiragino Sans GB',

--- a/s2-site/docs/api/general/S2Theme.zh.md
+++ b/s2-site/docs/api/general/S2Theme.zh.md
@@ -116,7 +116,7 @@ order: 2
 | :--- | :--- | :---: | :--- | :---| :--- |
 | textAlign | string | | | `left` <br> `center` <br> `right` | 文本内容的对齐方式 |
 | textBaseline | string | | | `top` <br> `middle` <br> `bottom` | 绘制文本时的基线 |
-| fontFamily | string | | Roboto, PingFangSC, -apple-system, BlinkMacSystemFont, Microsoft YaHei, Arial, sans-serif | | 字体 |
+| fontFamily | string | | Roboto, PingFangSC, BlinkMacSystemFont, Microsoft YaHei, Arial, sans-serif | | 字体 |
 | fontSize | number | | | | 字体大小 |
 | fontWeight | number <br> string | | 粗体文本：Mobile：520 <br> PC: `bold` <br> 普通文本：`normal` | number <br> string: `normal` <br> `bold` <br> `bolder` <br> `lighter` | 字体粗细 |
 | fill | string | | | | 字体颜色 |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Bug fix issue #0

### 📝 Description

修复在ios15上, 渲染表格文字时, 浏览器崩溃卡死

https://juejin.cn/post/7012161541378146334

### 🖼️ Screenshot

![image](https://user-images.githubusercontent.com/21015895/135379912-16591757-d00d-4495-a799-4bd01c5abfb1.png)

### 🔗 Related issue link
