### PR TITLE
fix(table): table mode corner width err

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -393,7 +393,7 @@ export abstract class BaseFacet {
       minX: 0,
       minY: 0,
     };
-    this.cornerWidth = 0;
+    this.cornerWidth = originalCornerWidth;
   }
 
   getCornerBBoxWidth = (cornerWidth: number): number => {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -374,7 +374,7 @@ export abstract class BaseFacet {
       : hRowScroll;
   };
 
-  calculateCornerBBox = () => {
+  protected calculateCornerBBox() {
     const { rowsHierarchy, colsHierarchy } = this.layoutResult;
 
     const originalCornerWidth = Math.floor(
@@ -393,16 +393,13 @@ export abstract class BaseFacet {
       minX: 0,
       minY: 0,
     };
-    this.cornerWidth = originalCornerWidth;
-  };
+    this.cornerWidth = 0;
+  }
 
   getCornerBBoxWidth = (cornerWidth: number): number => {
     const { colsHierarchy } = this.layoutResult;
     if (!this.cfg.spreadsheet.isScrollContainsRowHeader()) {
       return this.getCornerWidth(cornerWidth, colsHierarchy);
-    }
-    if (!this.cfg.spreadsheet.isPivotMode()) {
-      return 0;
     }
     return cornerWidth;
   };

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -55,6 +55,25 @@ export class TableFacet extends BaseFacet {
     });
   }
 
+  protected calculateCornerBBox() {
+    const { colsHierarchy } = this.layoutResult;
+
+    const height = Math.floor(colsHierarchy.height);
+    const width = 0;
+
+    this.cornerBBox = {
+      x: 0,
+      y: 0,
+      width,
+      height,
+      maxX: width,
+      maxY: height,
+      minX: 0,
+      minY: 0,
+    };
+    this.cornerWidth = 0;
+  }
+
   public destroy() {
     super.destroy();
     this.spreadsheet.off(S2Event.RANGE_SORT);


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

修复 https://github.com/antvis/S2/commit/014d683a8cc251f0f4cddb28662b45b7b96d4edb 这个 commit 引入的 table 模式渲染异常问题：

![image](https://user-images.githubusercontent.com/10339692/135422678-5376dad6-b0ec-4296-a79b-c0c49adb6ca2.png)


把 cornerBBox 的计算逻辑放到了 table-facet 子类中覆盖了原来的方法。这样后面好维护一些。

