### PR TITLE
fix(tooltip): custom tooltip keep right  position wrong calc

### DIFF
--- a/packages/s2-core/src/ui/tooltip/index.tsx
+++ b/packages/s2-core/src/ui/tooltip/index.tsx
@@ -64,7 +64,7 @@ export class BaseTooltip {
       ? ReactDOM.render(CustomComponent, container)
       : ReactDOM.render(this.renderContent(data, options), container);
 
-    const { x, y } = getPosition(position, this.container);
+    const { x, y } = getPosition(position, container);
 
     this.position = {
       x,
@@ -75,13 +75,16 @@ export class BaseTooltip {
       left: `${x}px`,
       top: `${y}px`,
       pointerEvents: enterable ? 'all' : 'none',
-      display: 'block',
+      visibility: 'visible',
     });
   }
 
   public hide() {
     const container = this.getContainer();
-    setContainerStyle(container, { pointerEvents: 'none', display: 'none' });
+    setContainerStyle(container, {
+      pointerEvents: 'none',
+      visibility: 'hidden',
+    });
     this.resetPosition();
     this.unMountComponent(container);
   }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Bug fix issue #435

### 📝 Description

1. 修复自定义tooltip 偶数次点击 tooltip 边缘算法判断失效的问题

原因: 
**单数次点击** 容器 display: block, getBoundingClientRect 判断正常, 
**偶数次点击**, 本身会隐藏自带的 tooltip, 这个时候容器 display: none, 导致 getBoundingClientRect 得到的 容器宽度为0, 导致判断错误

经过测试, display: none 的时候 getBoundingClientRect 无效, 使用 visibility: 'hidden' getBoundingClientRect 正常

### 🖼️ Screenshot

|  Before  |  After  |
|----|----|
|  ![image](https://user-images.githubusercontent.com/21015895/136895950-7b0f8c26-1ee6-4e3d-aec1-3291d6b6a5f5.png) |  ![image](https://user-images.githubusercontent.com/21015895/136895935-ffe23a0c-d4f7-4bf6-bbd0-b09941b18bf7.png)  |

### 🔗 Related issue link

close #435 
