### PR TITLE
feat(facet): add scroll speed ratio

### DIFF
--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -412,3 +412,8 @@ export type ResizeEvent =
   | S2Event.LAYOUT_RESIZE_ROW_HEIGHT
   | S2Event.LAYOUT_RESIZE_COL_HEIGHT
   | S2Event.LAYOUT_RESIZE_TREE_WIDTH;
+
+export interface ScrollRatio {
+  horizontal?: number;
+  vertical?: number;
+}

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -5,6 +5,7 @@ import {
   FilterDataItemCallback,
   HeaderActionIcon,
   CustomSVGIcon,
+  ScrollRatio,
 } from './basic';
 import { Tooltip } from './tooltip';
 import {
@@ -83,7 +84,7 @@ export interface S2PartialOptions {
   // enable Command + C to copy spread data
   readonly enableCopy?: boolean;
   // the ratio to control scroll speed, default set to 1
-  readonly scrollSpeedRatio?: number;
+  readonly scrollSpeedRatio?: ScrollRatio;
 
   /** ***********CUSTOM CELL/HEADER HOOKS**************** */
   // custom data cell
@@ -197,7 +198,10 @@ export const defaultOptions: S2Options = {
   frozenTrailingRowCount: 0,
   frozenTrailingColCount: 0,
   hdAdapter: true,
-  scrollSpeedRatio: 1,
+  scrollSpeedRatio: {
+    horizontal: 1,
+    vertical: 1,
+  },
 } as S2Options;
 
 export const safetyOptions = (options: S2Options) =>

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -82,6 +82,8 @@ export interface S2PartialOptions {
   readonly mergedCellsInfo?: MergedCellInfo[][];
   // enable Command + C to copy spread data
   readonly enableCopy?: boolean;
+  // the ratio to control scroll speed, default set to 1
+  readonly scrollSpeedRatio?: number;
 
   /** ***********CUSTOM CELL/HEADER HOOKS**************** */
   // custom data cell
@@ -195,6 +197,7 @@ export const defaultOptions: S2Options = {
   frozenTrailingRowCount: 0,
   frozenTrailingColCount: 0,
   hdAdapter: true,
+  scrollSpeedRatio: 1,
 } as S2Options;
 
 export const safetyOptions = (options: S2Options) =>

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -807,8 +807,13 @@ export abstract class BaseFacet {
   };
 
   onWheel = (event: S2WheelEvent) => {
+    const ratio = this.cfg.scrollSpeedRatio;
     const { deltaX, deltaY, layerX, layerY } = event;
-    const [optimizedDeltaX, optimizedDeltaY] = optimizeScrollXY(deltaX, deltaY);
+    const [optimizedDeltaX, optimizedDeltaY] = optimizeScrollXY(
+      deltaX,
+      deltaY,
+      ratio,
+    );
 
     this.spreadsheet.hideTooltip();
 

--- a/packages/s2-core/src/facet/header/col.ts
+++ b/packages/s2-core/src/facet/header/col.ts
@@ -68,10 +68,12 @@ export class ColHeader extends BaseHeader<ColHeaderConfig> {
    */
   public onColScroll(scrollX: number, cornerWidth: number, type: string): void {
     // this is works in scroll-keep-text-center feature
-    this.headerConfig.offset = scrollX;
-    this.headerConfig.scrollX = scrollX;
-    this.headerConfig.cornerWidth = cornerWidth || 0;
-    this.render(type);
+    if (this.headerConfig.scrollX !== scrollX) {
+      this.headerConfig.offset = scrollX;
+      this.headerConfig.scrollX = scrollX;
+      this.headerConfig.cornerWidth = cornerWidth || 0;
+      this.render(type);
+    }
   }
 
   protected clip(): void {

--- a/packages/s2-core/src/facet/utils.ts
+++ b/packages/s2-core/src/facet/utils.ts
@@ -8,7 +8,7 @@ import {
   FrozenOpts,
   FrozenCellIndex,
 } from '@/common/constant/frozen';
-import { Pagination } from '@/common/interface';
+import { Pagination, ScrollRatio } from '@/common/interface';
 
 export const isFrozenCol = (colIndex: number, frozenCount: number) => {
   return frozenCount > 0 && colIndex < frozenCount;
@@ -101,7 +101,7 @@ export const calculateInViewIndexes = (
 export const optimizeScrollXY = (
   x: number,
   y: number,
-  ratio: number,
+  ratio: ScrollRatio,
 ): [number, number] => {
   const ANGLE = 2; // 调参工程师
   const angle = Math.abs(x / y);
@@ -110,7 +110,7 @@ export const optimizeScrollXY = (
   const deltaX = angle <= 1 / ANGLE ? 0 : x;
   const deltaY = angle > ANGLE ? 0 : y;
 
-  return [deltaX * ratio, deltaY * ratio];
+  return [deltaX * ratio.horizontal, deltaY * ratio.vertical];
 };
 
 export const translateGroup = (

--- a/packages/s2-core/src/facet/utils.ts
+++ b/packages/s2-core/src/facet/utils.ts
@@ -96,8 +96,13 @@ export const calculateInViewIndexes = (
  * 优化滚动方向，对于小角度的滚动，固定为一个方向
  * @param x
  * @param y
+ * @param ratio
  */
-export const optimizeScrollXY = (x: number, y: number): [number, number] => {
+export const optimizeScrollXY = (
+  x: number,
+  y: number,
+  ratio: number,
+): [number, number] => {
   const ANGLE = 2; // 调参工程师
   const angle = Math.abs(x / y);
 
@@ -105,7 +110,7 @@ export const optimizeScrollXY = (x: number, y: number): [number, number] => {
   const deltaX = angle <= 1 / ANGLE ? 0 : x;
   const deltaY = angle > ANGLE ? 0 : y;
 
-  return [deltaX, deltaY];
+  return [deltaX * ratio, deltaY * ratio];
 };
 
 export const translateGroup = (


### PR DESCRIPTION
### 👀 PR includes


✨ Feature

- [x] New feature

### 📝 Description

新增 scrollSpeedRatio 参数。类型如下：

```typescript
readonly scrollSpeedRatio?: ScrollRatio;

export interface ScrollRatio {
  horizontal?: number; // 水平方向滚动速度系数，默认为 1
  vertical?: number; // 垂直方向滚动速度系数，默认为 1
}
```

这个参数主要用于控制滚动的速率。可以放慢或者提升速度，来满足用户对滚动速率的需求。


### 🖼️ Screenshot

Gif 对比：

SpreadJS 的滚动：比较慢，比较跟手，适合用户看数据。

![s2-scroll-spread](https://user-images.githubusercontent.com/10339692/136908212-877f95bb-c29e-47ce-b447-d0ffd3bdd05b.gif)

S2 默认的滚动：很快，比较闪，用户看不清。

![s2-scroll-dp](https://user-images.githubusercontent.com/10339692/136908224-7f48edd6-375e-41c6-8cfb-137e37291c61.gif)

调整 scroll speed ratio 后的滚动：和 spreadJS 相似：

![s2-scroll-s2-new](https://user-images.githubusercontent.com/10339692/136908385-f66c2469-f132-40f0-8be1-87bce432a3e0.gif)


另外还新增了一个小优化，在 scrollX 没变化时，不调用 ColHeader 的 onScroll 方法，减少多余渲染。


