### PR TITLE
fix(interaction): optimize reset state logic

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -11,7 +11,6 @@ import {
 import { SpreadSheet } from '@/sheet-type';
 import { InteractionStateName, S2Event } from '@/common/constant';
 import { Node } from '@/facet/layout/node';
-import { RootInteraction } from '@/interaction/root';
 
 jest.mock('@/interaction/event-controller');
 

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import { dsvFormat } from 'd3-dsv';
 import EE from '@antv/event-emitter';
 import { Canvas } from '@antv/g-canvas';
-import { RootInteraction } from '../../src/interaction/root';
-import { Store } from '../../src/common/store';
-import { SpreadSheet } from '../../src/sheet-type';
+import { RootInteraction } from '@/interaction/root';
+import { Store } from '@/common/store';
+import { SpreadSheet } from '@/sheet-type';
+import { BaseTooltip } from '@/ui/tooltip';
 
 export const parseCSV = (csv: string, header?: string[]) => {
   const DELIMITER = ',';
@@ -39,6 +40,9 @@ export const createFakeSpreadSheet = () => {
   const interaction = new RootInteraction(s2 as unknown as SpreadSheet);
   s2.store = new Store();
   s2.interaction = interaction;
+  s2.tooltip = {
+    container: {} as HTMLElement,
+  } as BaseTooltip;
   s2.container = {
     draw: jest.fn(),
   } as unknown as Canvas;

--- a/packages/s2-core/src/components/index.tsx
+++ b/packages/s2-core/src/components/index.tsx
@@ -11,14 +11,17 @@ export { DrillDown, DrillDownProps } from './drill-down';
 export { Switcher, SwitcherProps } from './switcher';
 export { AdvancedSort, AdvancedSortProps } from './advanced-sort';
 
-export const SheetComponent = debounceRender((props: SpreadsheetProps) => {
-  const { sheetType } = props;
-  switch (sheetType) {
-    case 'table':
-      return <TableSheet {...props} />;
-    case 'tabular':
-      return <TabularSheet {...props} />;
-    default:
-      return <BaseSheet {...props} />;
-  }
-}, 100);
+export const SheetComponent: React.FC<SpreadsheetProps> = debounceRender(
+  (props: SpreadsheetProps) => {
+    const { sheetType } = props;
+    switch (sheetType) {
+      case 'table':
+        return <TableSheet {...props} />;
+      case 'tabular':
+        return <TabularSheet {...props} />;
+      default:
+        return <BaseSheet {...props} />;
+    }
+  },
+  100,
+);

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -136,7 +136,7 @@ export class EventController {
       // 这里不能使用 bounding rect 的 width 和 height, 高清适配后 canvas 实际宽高会变
       // 比如实际 400 * 300 => hd (800 * 600)
       // 从视觉来看, 虽然点击了空白处, 但其实还是处于 放大后的 canvas 区域, 所以还需要额外判断一下坐标
-      const { width, height } = this.spreadsheet.options;
+      const { width, height } = this.getContainerRect();
       return (
         canvas.contains(event.target as HTMLElement) &&
         event.clientX <= x + width &&
@@ -144,6 +144,15 @@ export class EventController {
       );
     }
     return false;
+  }
+
+  private getContainerRect() {
+    const { maxX, maxY } = this.spreadsheet.facet.panelBBox;
+    const { width, height } = this.spreadsheet.options;
+    return {
+      width: Math.min(width, maxX),
+      height: Math.min(height, maxY),
+    };
   }
 
   private isMouseOnTheTooltip(event: Event) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Bug fix issue #0

### 📝 Description

**1. 优化点击空白处重置交互的处理逻辑**: 对于数据量很小的表格, 虽然看起来是空白处, 但其实还处于 canvas 区域, 这时候点击 **[空白处]** 并不能达到用户的预期, 可能会对用户产生迷惑性

### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/21015895/136946858-47a40fd4-1ca1-4acd-a533-36a73dbc3312.png)

|  Before  |  After  |
|----|----|
|  ![Kapture 2021-10-12 at 19 24 30](https://user-images.githubusercontent.com/21015895/136947286-f66b7cc6-c146-4e8f-ab01-24ba10e9c6d2.gif) |  ![Kapture 2021-10-12 at 19 18 41](https://user-images.githubusercontent.com/21015895/136946707-9945bb29-e63f-444d-95f4-ab45fc5bec55.gif) |
