### PR TITLE
fix(table): scroll position issue when re-render 

### DIFF
--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -111,7 +111,7 @@ export class TableColCell extends ColCell {
       { cursor: 'pointer' },
     );
 
-    if (!spreadsheet.options.headerActionIcons) {
+    if (!spreadsheet.options.headerActionIcons?.length) {
       renderDetailTypeSortIcon(
         this,
         spreadsheet,

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -111,7 +111,7 @@ export class TableColCell extends ColCell {
       { cursor: 'pointer' },
     );
 
-    if (!spreadsheet.options.headerActionIcons?.length) {
+    if (!isEmpty(spreadsheet.options.headerActionIcons)) {
       renderDetailTypeSortIcon(
         this,
         spreadsheet,

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -375,26 +375,28 @@ export class TableFacet extends BaseFacet {
   }
 
   protected initFrozenGroupPosition = () => {
-    const scrollY = this.getPaginationScrollY();
+    const { scrollY, scrollX } = this.getScrollOffset();
+    const paginationScrollY = this.getPaginationScrollY();
+
     translateGroup(
       this.spreadsheet.frozenRowGroup,
-      this.cornerBBox.width,
-      this.cornerBBox.height - scrollY,
+      this.cornerBBox.width - scrollX,
+      this.cornerBBox.height - paginationScrollY,
     );
     translateGroup(
       this.spreadsheet.frozenColGroup,
       this.cornerBBox.width,
-      this.cornerBBox.height - scrollY,
+      this.cornerBBox.height - scrollY - paginationScrollY,
     );
     translateGroup(
       this.spreadsheet.frozenTrailingColGroup,
       this.cornerBBox.width,
-      this.cornerBBox.height - scrollY,
+      this.cornerBBox.height - scrollY - paginationScrollY,
     );
     translateGroup(
       this.spreadsheet.frozenTopGroup,
       this.cornerBBox.width,
-      this.cornerBBox.height - scrollY,
+      this.cornerBBox.height - paginationScrollY,
     );
   };
 

--- a/packages/s2-core/src/sheet-type/table-sheet.ts
+++ b/packages/s2-core/src/sheet-type/table-sheet.ts
@@ -124,4 +124,18 @@ export class TableSheet extends SpreadSheet {
     this.facet = new TableFacet(facetCfg);
     this.facet.render();
   }
+
+  protected clearFrozenGroups() {
+    this.frozenRowGroup.set('children', []);
+    this.frozenColGroup.set('children', []);
+    this.frozenTrailingRowGroup.set('children', []);
+    this.frozenTrailingColGroup.set('children', []);
+    this.frozenTopGroup.set('children', []);
+    this.frozenBottomGroup.set('children', []);
+  }
+
+  public destroy() {
+    super.destroy();
+    this.clearFrozenGroups();
+  }
 }


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

修复：明细表行列冻结在滚动后重新调 render 的时候，scrollY 设置不正确，导致渲染异常 的问题。

### 🖼️ Screenshot

![image](https://user-images.githubusercontent.com/10339692/137424895-f2dc341d-8266-4cba-9315-acf297a3f770.png)

