### PR TITLE
fix: fix merged cells can't be sorted and dragged

### DIFF
--- a/packages/s2-core/__tests__/util/sheet-entry.tsx
+++ b/packages/s2-core/__tests__/util/sheet-entry.tsx
@@ -77,7 +77,7 @@ export const SheetEntry = forwardRef(
 
     const initDataCfg = props.forceUpdateDataCfg
       ? props.dataCfg
-      : assembleOptions(props.dataCfg);
+      : assembleDataCfg(props.dataCfg);
     const [options, setOptions] = useState(() => initOptions);
     const [dataCfg, setDataCfg] = useState(() => initDataCfg);
 

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -885,7 +885,7 @@ export abstract class BaseFacet {
     hRowScroll: number,
   ) {
     translateGroup(
-      this.spreadsheet.panelGroup,
+      this.spreadsheet.panelScrollGroup,
       this.cornerBBox.width - scrollX,
       this.cornerBBox.height - scrollY,
     );

--- a/packages/s2-core/src/utils/interaction/merge-cells.ts
+++ b/packages/s2-core/src/utils/interaction/merge-cells.ts
@@ -159,7 +159,7 @@ export const mergeCells = (
       merge(sheet.options, { mergedCellsInfo: mergedCellsInfo }),
     );
     const value = hideData ? '' : viewMeta;
-    sheet.facet.panelGroup.add(new MergedCells(value, sheet, cells));
+    sheet.panelScrollGroup.add(new MergedCells(value, sheet, cells));
   }
 };
 
@@ -186,14 +186,13 @@ const removeMergedCells = (cells: S2CellType[], mergedCells: MergedCells) => {
 /**
  * upddate the merge
  * @param sheet the base sheet instance
- * @param curSelectedState
  */
 export const updateMergedCells = (sheet: SpreadSheet) => {
   const mergedCellsInfo = sheet.options?.mergedCellsInfo;
   if (isEmpty(mergedCellsInfo)) return;
 
   const allCells = filter(
-    sheet.panelGroup.getChildren(),
+    sheet.panelScrollGroup.getChildren(),
     (child) => !(child instanceof MergedCells),
   ) as unknown as S2CellType[];
   if (isEmpty(allCells)) return;
@@ -204,7 +203,7 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
   });
 
   const oldMergedCells = filter(
-    sheet.panelGroup.getChildren(),
+    sheet.panelScrollGroup.getChildren(),
     (child) => child instanceof MergedCells,
   ) as unknown as MergedCells;
 
@@ -217,14 +216,14 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
     } else if (commonCells.length > 0 && commonCells.length < cells.length) {
       // 合并的单元格部分在当前可视区域内
       removeMergedCells(mergedCell, oldMergedCells);
-      sheet.facet.panelGroup.add(new MergedCells(viewMeta, sheet, cells));
+      sheet.panelScrollGroup.add(new MergedCells(viewMeta, sheet, cells));
     } else {
       const findOne = find(oldMergedCells, (item: MergedCells) =>
         isEqual(mergedCell, item.cells),
       ) as MergedCells;
       // 如果合并单元格完全在可视区域内，且之前没有添加道panelGroup中，需要重新添加
       if (!findOne)
-        sheet.facet.panelGroup.add(new MergedCells(viewMeta, sheet, cells));
+        sheet.panelScrollGroup.add(new MergedCells(viewMeta, sheet, cells));
     }
   });
 };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve performance.
- [ ] Type optimization

🐛 Bugfix

- [X] Bug fix merged cells can't be sorted and dragged

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release
- [ ] Other (<!-- what? -->)

### 📝 Description
1. 修复合并单元格，排序后失效问题。
2. 修复合并单元格，修改行列宽度后失效问题。
3. 修复对明细表冻结功能的影响。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| ![合并单元格无法保存](https://user-images.githubusercontent.com/20497176/137659830-df4ed6ca-7ca9-4dc4-9217-feb4cca98aa3.gif) | ![合并单元格修复2](https://user-images.githubusercontent.com/20497176/137659843-2ef7fe8e-f318-488d-b64f-ed544ca7cca2.gif) |

### 🔗 Related issue link
<!-- close #0 -->
