### PR TITLE
fix: :bug: correct the wrong condition to show the default headerActionIcons for the detail table

### DIFF
--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -111,7 +111,7 @@ export class TableColCell extends ColCell {
       { cursor: 'pointer' },
     );
 
-    if (!isEmpty(spreadsheet.options.headerActionIcons)) {
+    if (spreadsheet.options.showDefaultHeaderActionIcon) {
       renderDetailTypeSortIcon(
         this,
         spreadsheet,


### PR DESCRIPTION
…onIcons for detail table mode

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🐛 Bugfix

- [x] Solve the issue.


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| ![image](https://user-images.githubusercontent.com/10885578/137702950-0a8ecd4f-d890-40a0-98c5-5d21734632c3.png) |![image](https://user-images.githubusercontent.com/10885578/137703023-2970ccbf-9ef2-4316-bf0d-5de134cfb3c3.png)|


