### PR TITLE
fix: :bug: prevent the cell click event when clicking the HeaderActionIcon and close #409 #452

### DIFF
--- a/packages/s2-core/__tests__/unit/dataset/pivot-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/dataset/pivot-dataset-spec.ts
@@ -11,8 +11,14 @@ import { PivotSheet } from '@/sheet-type';
 import { PivotDataSet } from '@/data-set/pivot-data-set';
 import { Store } from '@/common/store';
 import { Node } from '@/facet/layout/node';
+import { RootInteraction } from '@/interaction/root';
 
 jest.mock('@/sheet-type');
+
+jest.mock('@/interaction/root');
+
+const MockRootInteraction =
+  RootInteraction as unknown as jest.Mock<RootInteraction>;
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 
@@ -27,6 +33,7 @@ describe('Pivot Dataset Test', () => {
     MockPivotSheet.mockClear();
     const mockSheet = new MockPivotSheet();
     mockSheet.store = new Store();
+    mockSheet.interaction = new MockRootInteraction(mockSheet);
     dataSet = new PivotDataSet(mockSheet);
     dataSet.setDataCfg(dataCfg);
   });

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -124,6 +124,7 @@ export abstract class HeaderCell extends BaseCell<Node> {
         fill: text.fill,
       });
       sortIcon.on('click', (event) => {
+        this.spreadsheet.emit(S2Event.GLOBAL_ACTION_ICON_CLICK, event);
         this.spreadsheet.handleGroupSort(event, this.meta);
       });
       this.add(sortIcon);

--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -63,3 +63,5 @@ export const MIN_CELL_HEIGHT = 16;
 export const PRECISION = 16;
 
 export const ROOT_BEGINNING_REGEX = /^root\[&\]*/;
+
+export const IMAGE = 'image';

--- a/packages/s2-core/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-core/src/components/sheets/base-sheet/index.tsx
@@ -1,10 +1,9 @@
 import { Event as GEvent } from '@antv/g-canvas';
-import { Pagination, Spin } from 'antd';
-import { forIn, get, isEmpty, isFunction, merge } from 'lodash';
+import { Spin } from 'antd';
+import { forIn, isEmpty, isFunction, merge } from 'lodash';
 import React, { memo, StrictMode, useEffect, useRef, useState } from 'react';
 import { S2Event } from '@/common/constant';
 import { S2_PREFIX_CLS } from '@/common/constant/classnames';
-import { i18n } from '@/common/i18n';
 import {
   CellScrollPosition,
   LayoutCol,

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -219,6 +219,8 @@ export class PivotDataSet extends BaseDataSet {
       this.spreadsheet.store.set('drillDownFieldInLevel', []);
     }
 
+    // 重置当前交互
+    this.spreadsheet.interaction.reset();
     store.set('drillDownIdPathMap', idPathMap);
   }
 

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -59,7 +59,6 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
 
   private handleRowColClick = (event: CanvasEvent, isTreeRowClick = false) => {
     event.stopPropagation();
-
     const { interaction } = this.spreadsheet;
     const lastState = interaction.getState();
     const cell = this.spreadsheet.getCell(event.target);

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -311,6 +311,7 @@ export class EventController {
 
     this.spreadsheet.on(S2Event.GLOBAL_ACTION_ICON_CLICK, () => {
       this.spreadsheet.interaction.addIntercepts([InterceptType.HOVER]);
+      this.spreadsheet.interaction.clearState();
     });
     const cell = this.spreadsheet.getCell(event.target);
     if (cell) {
@@ -322,12 +323,22 @@ export class EventController {
             this.spreadsheet.emit(S2Event.DATA_CELL_CLICK, event);
             break;
           case CellTypes.ROW_CELL:
+            // 屏蔽 actionIcons的点击，只有HeaderCells 需要， DataCell 有状态类 icon， 不需要屏蔽
+            if (this.target.cfg?.type === 'image') {
+              break;
+            }
             this.spreadsheet.emit(S2Event.ROW_CELL_CLICK, event);
             break;
           case CellTypes.COL_CELL:
+            if (this.target.cfg?.type === 'image') {
+              break;
+            }
             this.spreadsheet.emit(S2Event.COL_CELL_CLICK, event);
             break;
           case CellTypes.CORNER_CELL:
+            if (this.target.cfg?.type === 'image') {
+              break;
+            }
             this.spreadsheet.emit(S2Event.CORNER_CELL_CLICK, event);
             break;
           case CellTypes.MERGED_CELLS:

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -7,6 +7,7 @@ import {
 import { each, get, isEmpty } from 'lodash';
 import {
   CellTypes,
+  IMAGE,
   InteractionKeyboardKey,
   InterceptType,
   OriginEventType,
@@ -88,6 +89,10 @@ export class EventController {
         this.spreadsheet.emit(S2Event.GLOBAL_MOUSE_UP, event);
       },
     );
+  }
+
+  private getTargetType() {
+    return get(this, 'target.cfg.type');
   }
 
   private onKeyboardCopy(event: KeyboardEvent) {
@@ -324,19 +329,19 @@ export class EventController {
             break;
           case CellTypes.ROW_CELL:
             // 屏蔽 actionIcons的点击，只有HeaderCells 需要， DataCell 有状态类 icon， 不需要屏蔽
-            if (this.target.cfg?.type === 'image') {
+            if (this.getTargetType() === IMAGE) {
               break;
             }
             this.spreadsheet.emit(S2Event.ROW_CELL_CLICK, event);
             break;
           case CellTypes.COL_CELL:
-            if (this.target.cfg?.type === 'image') {
+            if (this.getTargetType() === IMAGE) {
               break;
             }
             this.spreadsheet.emit(S2Event.COL_CELL_CLICK, event);
             break;
           case CellTypes.CORNER_CELL:
-            if (this.target.cfg?.type === 'image') {
+            if (this.getTargetType() === IMAGE) {
               break;
             }
             this.spreadsheet.emit(S2Event.CORNER_CELL_CLICK, event);

--- a/packages/s2-core/src/utils/drill-down.ts
+++ b/packages/s2-core/src/utils/drill-down.ts
@@ -175,6 +175,8 @@ export const HandleDrillDown = (params: DrillDownParams) => {
       spreadsheet.store.set('drillDownDataCache', newDrillDownDataCache);
     }
 
+    // 重置当前交互
+    spreadsheet.interaction.reset();
     spreadsheet.render(false);
   });
 };


### PR DESCRIPTION
…nIcon

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #409 #452 

### 📝 Description

- Reset the interaction after drill-down or clear the drill-down which is needed to hide the tooltip.
- Clear the interaction state after clicking the HeaderActionIcon.
- Prevent the cell click event when clicking the HeaderActionIcon.

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| ![image](https://user-images.githubusercontent.com/10885578/137826218-af045583-5c02-47c9-9a6d-8846ec3e78d3.png)| ![image](https://user-images.githubusercontent.com/10885578/137826235-44095357-72c4-4ca0-9039-4cf532651c1d.png)|

