### PR TITLE
fix: 🐛 getEndRows return all items when theres no frozen row

### DIFF
--- a/packages/s2-core/src/data-set/table-data-set.ts
+++ b/packages/s2-core/src/data-set/table-data-set.ts
@@ -35,8 +35,9 @@ export class TableDataSet extends BaseDataSet {
   protected getEndRows() {
     const { frozenTrailingRowCount } = this.spreadsheet.options || {};
     // 没有冻结行时返回空数组
-    if (isEmpty(frozenTrailingRowCount)) return [];
+    if (!frozenTrailingRowCount) return [];
     const { displayData } = this;
+
     return displayData.slice(-frozenTrailingRowCount);
   }
 


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

筛选和排序时若无底部冻结行 返回结果异常