### PR TITLE
fix: return filtered dataset on range_filtered event

### DIFF
--- a/packages/s2-core/src/common/interface/emitter.ts
+++ b/packages/s2-core/src/common/interface/emitter.ts
@@ -39,7 +39,6 @@ type MouseEventHandler = (event: MouseEvent) => void;
 type EventHandler = (event: Event) => void;
 type ResizeHandler = (data: { info: ResizeInfo; style: Style }) => void;
 type SelectedHandler = (cells: S2CellType[]) => void;
-type FilterHandler = (info: FilterParam) => void;
 
 export interface EmitterType {
   /** ================ Global ================  */
@@ -59,11 +58,11 @@ export interface EmitterType {
 
   /** ================ Sort ================  */
   [S2Event.RANGE_SORT]: (info: SortParams) => void;
-  [S2Event.RANGE_SORTED]: (rangeData: Data[]) => void;
+  [S2Event.RANGE_SORTED]: (rangeData: Data[]) => any;
 
   /** ================ Filter ================  */
-  [S2Event.RANGE_FILTER]: FilterHandler;
-  [S2Event.RANGE_FILTERED]: FilterHandler;
+  [S2Event.RANGE_FILTER]: (info: FilterParam) => void;
+  [S2Event.RANGE_FILTERED]: (data: Data[]) => any;
 
   /** ================ Cell ================  */
   [S2Event.GLOBAL_LINK_FIELD_JUMP]: (data: {

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -78,7 +78,10 @@ export class TableFacet extends BaseFacet {
       set(s2.dataCfg, 'filterParams', oldConfig);
 
       s2.render(true);
-      s2.emit(S2Event.RANGE_FILTERED, params);
+      s2.emit(
+        S2Event.RANGE_FILTERED,
+        (s2.dataSet as TableDataSet).getDisplayDataSet(),
+      );
     });
   }
 


### PR DESCRIPTION

🐛 Bugfix

- [x] Solve the issue and close #0




Filtered事件返回被过滤以后的dataset