### PR TITLE
fix: 🐛 totals caculate width's err when data is empty but options have totals and close #507

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/facet-spec.ts
@@ -1,0 +1,21 @@
+import { getSubTotalNodeWidthOrHeightByLevel } from '@/utils/facet';
+
+describe('getSubTotalNodeWidthOrHeightByLevel Test', () => {
+  test('should get correct width of subTotal node', () => {
+    const sampleNodesForAllLevels = [
+      {
+        id: 'root[&]测试',
+        value: '测试',
+        isSubTotals: true,
+        width: 20,
+        level: 0,
+      },
+    ];
+    expect(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      getSubTotalNodeWidthOrHeightByLevel(sampleNodesForAllLevels, -1, 'width'),
+    ).toEqual(20);
+    expect(getSubTotalNodeWidthOrHeightByLevel([], -1, 'width')).toEqual(0);
+  });
+});

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -24,6 +24,7 @@ import {
 import { Node } from '@/facet/layout/node';
 import { handleDataItem } from '@/utils/cell/data-cell';
 import { measureTextWidth, measureTextWidthRoughly } from '@/utils/text';
+import { getSubTotalNodeWidthOrHeightByLevel } from '@/utils/facet';
 
 export class PivotFacet extends BaseFacet {
   protected doLayout(): LayoutResult {
@@ -243,7 +244,7 @@ export class PivotFacet extends BaseFacet {
         // parent's width = all children's width
         parent.width = parent.children
           .map((value: Node) => value.width)
-          .reduce((sum, current) => sum + current);
+          .reduce((sum, current) => sum + current, 0);
         prevColParent = parent;
       }
     }
@@ -384,7 +385,7 @@ export class PivotFacet extends BaseFacet {
         // parent's height = all children's height
         parent.height = parent.children
           .map((value) => value.height)
-          .reduce((sum, current) => sum + current);
+          .reduce((sum, current) => sum + current, 0);
         prevRowParent = parent;
       }
     }
@@ -447,10 +448,11 @@ export class PivotFacet extends BaseFacet {
       const subTotalNodeChildren = subTotalNode.children;
       if (isRowHeader) {
         // 填充行总单元格宽度
-        subTotalNode.width = hierarchy.sampleNodesForAllLevels
-          .filter((node: Node) => node.level >= subTotalNode.level)
-          .map((value) => value.width)
-          .reduce((sum, current) => sum + current);
+        subTotalNode.width = getSubTotalNodeWidthOrHeightByLevel(
+          hierarchy.sampleNodesForAllLevels,
+          subTotalNode.level,
+          'width',
+        );
 
         // 调整其叶子结点位置
         forEach(subTotalNodeChildren, (node: Node) => {
@@ -458,10 +460,11 @@ export class PivotFacet extends BaseFacet {
         });
       } else {
         // 填充列总单元格高度
-        subTotalNode.height = hierarchy.sampleNodesForAllLevels
-          .filter((node: Node) => node.level >= subTotalNode.level)
-          .map((value) => value.height)
-          .reduce((sum, current) => sum + current);
+        subTotalNode.height = getSubTotalNodeWidthOrHeightByLevel(
+          hierarchy.sampleNodesForAllLevels,
+          subTotalNode.level,
+          'height',
+        );
         // 调整其叶子结点位置
         forEach(subTotalNodeChildren, (node: Node) => {
           node.y = hierarchy.getNodes(maxLevel)[0].y;

--- a/packages/s2-core/src/utils/facet.ts
+++ b/packages/s2-core/src/utils/facet.ts
@@ -1,0 +1,12 @@
+import { Node } from '@/facet/layout/node';
+
+export const getSubTotalNodeWidthOrHeightByLevel = (
+  sampleNodesForAllLevels: Node[],
+  level: number,
+  key: 'width' | 'height',
+) => {
+  return sampleNodesForAllLevels
+    .filter((node: Node) => node.level >= level)
+    .map((value) => value[key])
+    .reduce((sum, current) => sum + current, 0);
+};


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #507 

### 📝 Description
1. fix totals caculate width's err when data is empty but options have totals
2. add test

<!-- close #507 -->
