### PR TITLE
fix: 🐛 err when hierarchyType is tree and data is empty

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-507-spec.tsx
+++ b/packages/s2-core/__tests__/bugs/issue-507-spec.tsx
@@ -1,0 +1,40 @@
+/**
+ * @description spec for issue #507
+ * https://github.com/antvis/S2/issues/507
+ * Show err when hierarchyType is tree and data is empty
+ *
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { getContainer } from '../util/helpers';
+import * as dataCfg from '../data/data-issue-507.json';
+import { SheetComponent, S2Options } from '@/index';
+
+function MainLayout() {
+  const s2options: S2Options = {
+    width: 800,
+    height: 600,
+    hierarchyType: 'tree',
+  };
+
+  return (
+    <div>
+      <SheetComponent
+        dataCfg={dataCfg}
+        sheetType={'pivot'}
+        options={s2options}
+      />
+    </div>
+  );
+}
+
+describe('spreadsheet normal spec', () => {
+  test('demo', () => {
+    expect(1).toBe(1);
+  });
+
+  act(() => {
+    ReactDOM.render(<MainLayout />, getContainer());
+  });
+});

--- a/packages/s2-core/__tests__/data/data-issue-507.json
+++ b/packages/s2-core/__tests__/data/data-issue-507.json
@@ -1,0 +1,9 @@
+{
+  "fields": {
+    "rows": ["rows0", "row1"],
+    "columns": [],
+    "values": ["value"],
+    "valueInCols": true
+  },
+  "data": []
+}

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -36,11 +36,11 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
   const { spreadsheet, dataSet, collapsedRows, hierarchyCollapse } = facetCfg;
   const query = parentNode.query;
   const isDrillDownItem = spreadsheet.dataCfg.fields.rows?.length <= level;
+  const sortedDimensionValues =
+    (dataSet as PivotDataSet)?.sortedDimensionValues?.get(currentField) || [];
+
   const dimValues = filterUndefined(
-    getIntersections(
-      [...(dataSet as PivotDataSet)?.sortedDimensionValues?.get(currentField)],
-      [...pivotMeta.keys()],
-    ),
+    getIntersections([...sortedDimensionValues], [...(pivotMeta.keys() || [])]),
   );
 
   let fieldValues: FieldValue[] = layoutArrange(


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #507 

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
fix err when hierarchyType is tree and data is empty
### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/19166133/138391393-73a568d3-6720-424c-87e3-d6a336f5a193.png)

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->
