### PR TITLE
fix: not sort when sortMethod is not true

### DIFF
--- a/packages/s2-core/src/data-set/table-data-set.ts
+++ b/packages/s2-core/src/data-set/table-data-set.ts
@@ -72,14 +72,14 @@ export class TableDataSet extends BaseDataSet {
     each(this.sortParams, (item) => {
       const { sortFieldId, sortBy, sortMethod } = item;
       // 万物排序的前提
-      if (!sortFieldId) return;
+      if (!sortFieldId || !sortMethod) return;
       // For frozen options
       this.displayData = [
         ...this.getStartRows(),
         ...orderBy(
           this.getMovableRows(),
           [sortBy || sortFieldId],
-          [sortMethod?.toLocaleLowerCase() as boolean | 'asc' | 'desc'],
+          [sortMethod.toLocaleLowerCase() as boolean | 'asc' | 'desc'],
         ),
         ...this.getEndRows(),
       ];


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve performance.
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

明细表内sortMethod为假值时 不应该触发排序

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->
