### PR TITLE
fix(export): pivot tree mode export error in total dim

### DIFF
--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -189,7 +189,7 @@ export const copyData = (
 
   // get max query property length
   const rowLength = rowLeafNodes.reduce((pre, cur) => {
-    const length = cur?.query ? Object.keys(cur.query).length : 0;
+    const length = cur.query ? Object.keys(cur.query).length : 0;
     return length > pre ? length : pre;
   }, 0);
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve performance.
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

修复导出功能
bug原因：
为了修复col列不对齐的问题 修正row的length问题 使用当前row下最长的length。
但是树形结构中的total行没有row.query字段，导致代码报错。

修复方式：
对row.query做非空判断，如果没有row.query，长度默认为0.

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->
