### PR TITLE
fix(table): table col resize issue

### DIFF
--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -154,10 +154,9 @@ export class ColCell extends HeaderCell {
       })) as Group;
   }
 
-  // 绘制热区
-  private drawResizeArea() {
+  protected drawHorizontalResizeArea() {
     const { viewportWidth, scrollX } = this.headerConfig;
-    const { label, width: cellWidth, height: cellHeight, parent } = this.meta;
+    const { height: cellHeight } = this.meta;
     const resizeStyle = this.getStyle('resizeArea');
     const resizeArea = this.getColResizeArea();
     const resizeAreaName = `${HORIZONTAL_RESIZE_AREA_KEY_PRE}${this.meta.key}`;
@@ -192,6 +191,13 @@ export class ColCell extends HeaderCell {
         },
       });
     }
+  }
+
+  protected drawVerticalResizeArea() {
+    const { label, width: cellWidth, height: cellHeight, parent } = this.meta;
+    const resizerOffset = this.getColResizeAreaOffset();
+    const resizeStyle = this.getStyle('resizeArea');
+    const resizeArea = this.getColResizeArea();
     if (this.meta.isLeaf) {
       // 列宽调整热区
       // 基准线是根据container坐标来的，因此把热区画在container
@@ -218,6 +224,12 @@ export class ColCell extends HeaderCell {
         },
       });
     }
+  }
+
+  // 绘制热区
+  private drawResizeArea() {
+    this.drawHorizontalResizeArea();
+    this.drawVerticalResizeArea();
   }
 
   private drawRightBorder() {

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -2,12 +2,21 @@ import { get, isEmpty } from 'lodash';
 import { isFrozenCol, isFrozenTrailingCol } from 'src/facet/utils';
 import { Group } from '@antv/g-canvas';
 import { isLastColumnAfterHidden } from '@/utils/hide-columns';
-import { S2Event } from '@/common/constant';
+import {
+  S2Event,
+  TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY,
+  KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA,
+} from '@/common/constant';
 import { renderDetailTypeSortIcon } from '@/utils/layout/add-detail-type-sort-icon';
 import { getEllipsisText, getTextPosition } from '@/utils/text';
 import { renderIcon, renderLine, renderText } from '@/utils/g-renders';
 import { ColCell } from '@/cell/col-cell';
-import { CellBoxCfg, DefaultCellTheme, IconTheme } from '@/common/interface';
+import {
+  CellBoxCfg,
+  DefaultCellTheme,
+  IconTheme,
+  ResizeInfo,
+} from '@/common/interface';
 import { KEY_GROUP_FROZEN_COL_RESIZE_AREA } from '@/common/constant';
 
 export class TableColCell extends ColCell {
@@ -215,5 +224,54 @@ export class TableColCell extends ColCell {
 
   private isLastColumn() {
     return isLastColumnAfterHidden(this.spreadsheet, this.meta.field);
+  }
+
+  private getHorizontalResizeArea() {
+    const prevResizeArea = this.spreadsheet.foregroundGroup.findById(
+      KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA,
+    );
+    return (prevResizeArea ||
+      this.spreadsheet.foregroundGroup.addGroup({
+        id: KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA,
+      })) as Group;
+  }
+
+  protected drawHorizontalResizeArea() {
+    const { viewportWidth } = this.headerConfig;
+    const { height: cellHeight } = this.meta;
+    const resizeStyle = this.getStyle('resizeArea');
+    const resizeArea = this.getHorizontalResizeArea();
+
+    const prevHorizontalResizeArea = resizeArea.find(
+      (element) => element.attrs.name === TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY,
+    );
+
+    // 如果已经绘制当前列高调整热区热区，则不再绘制
+    if (!prevHorizontalResizeArea) {
+      // 列高调整热区
+      resizeArea.addShape('rect', {
+        attrs: {
+          name: TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY,
+          x: 0,
+          y: cellHeight - resizeStyle.size,
+          width: viewportWidth,
+          height: resizeStyle.size,
+          fill: resizeStyle.background,
+          fillOpacity: resizeStyle.backgroundOpacity,
+          cursor: 'row-resize',
+          appendInfo: {
+            isResizeArea: true,
+            class: 'resize-trigger',
+            type: 'row',
+            id: this.getColResizeAreaKey(),
+            affect: 'field',
+            offsetX: 0,
+            offsetY: 0,
+            width: viewportWidth,
+            height: cellHeight,
+          } as ResizeInfo,
+        },
+      });
+    }
   }
 }

--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -35,6 +35,8 @@ export const KEY_GROUP_ROW_INDEX_RESIZE_AREA = 'rowIndexResizeAreaGroup';
 export const KEY_GROUP_CORNER_RESIZE_AREA = 'cornerResizeAreaGroup';
 export const KEY_GROUP_COL_RESIZE_AREA = 'colResizeAreaGroup';
 export const KEY_GROUP_FROZEN_COL_RESIZE_AREA = 'colFrozenResizeAreaGroup';
+export const KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA =
+  'colHorizontalResizeAreaGroup';
 export const KEY_GROUP_COL_SCROLL = 'colScrollGroup';
 export const KEY_GROUP_COL_FROZEN = 'colFrozenGroup';
 export const KEY_GROUP_COL_FROZEN_TRAILING = 'colFrozenTrailingGroup';
@@ -43,6 +45,8 @@ export const KEY_GROUP_COL_FROZEN_TRAILING = 'colFrozenTrailingGroup';
 export const KEY_SERIES_NUMBER_NODE = 'series-number-node';
 
 export const HORIZONTAL_RESIZE_AREA_KEY_PRE = 'horizontal-resize-area-';
+export const TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY =
+  'table-col-horizontal-resize-area';
 
 export const KEY_COL_REAL_WIDTH_INFO = 'col-real-width-info';
 

--- a/packages/s2-core/src/facet/header/table-col.ts
+++ b/packages/s2-core/src/facet/header/table-col.ts
@@ -123,8 +123,7 @@ export class TableColHeader extends ColHeader {
       frozenTrailingColWidth += colLeafNodes[colLeafNodes.length - 1 - i].width;
     }
 
-    const frozenClipWidth =
-      width + scrollX - frozenColWidth - frozenTrailingColWidth;
+    const frozenClipWidth = width - frozenColWidth - frozenTrailingColWidth;
 
     this.scrollGroup.setClip({
       type: 'rect',

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -264,8 +264,9 @@ export class TableFacet extends BaseFacet {
 
   private getColNodeHeight(col: Node) {
     const { colCfg } = this.cfg;
-    const userDragWidth = get(colCfg, `heightByField.${col.key}`);
-    return userDragWidth || colCfg.height;
+    // 明细表所有列节点高度保持一致
+    const userDragHeight = Object.values(get(colCfg, `heightByField`))[0];
+    return userDragHeight || colCfg.height;
   }
 
   private calculateColNodesCoordinate(


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

目前明细表列头高度的 resize 存在问题，这个 PR 修复了。

明细表只需要绘制一条水平 resize 区域即可。因此在 table-col-cell 里面做水平 resize 区域逻辑做了 override。