### PR TITLE
fix(facet): adjust h scrollbar position

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -661,7 +661,7 @@ export abstract class BaseFacet {
           (this.cfg.spreadsheet.isScrollContainsRowHeader()
             ? -this.cornerBBox.width + halfScrollSize
             : halfScrollSize),
-        y: this.panelBBox.maxY - this.scrollBarSize / 2,
+        y: this.panelBBox.maxY,
       };
       const finaleRealWidth =
         realWidth +


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

微调水平滚动条的位置，去除了多余的空白

### 🖼️ Screenshot

调整前：

![image](https://user-images.githubusercontent.com/10339692/139402386-6125c9a9-2ea7-4c73-9b62-464bf9a95396.png)

位置偏移了 scrollBarSzie/2

调整后：

![image](https://user-images.githubusercontent.com/10339692/139402061-350d62f9-a754-43f6-b37b-72891cedcf0e.png)


### 🔗 Related issue link

<!-- close #0 -->
