### PR TITLE
fix(cell): cell padding issue

### DIFF
--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -134,7 +134,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
 
   // get content area that exclude padding
   protected getContentArea() {
-    const { padding } = this.getStyle().cell;
+    const { padding } = this.getStyle()?.cell || this.theme.dataCell.cell;
     return getContentArea(this.getCellArea(), padding);
   }
 


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

base-cell 里面 getContentArea 写死了获取 dataCell 的 padding，会导致其他 cell 的 theme cell padding 设置失效。