### PR TITLE
fix(resize): fix corner resize blank

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -54,6 +54,9 @@ jest.mock('src/sheet-type', () => {
         emit: jest.fn(),
         isScrollContainsRowHeader: jest.fn(),
         isHierarchyTreeType: jest.fn(),
+        facet: {
+          getFreezeCornerDiffWidth: jest.fn(),
+        },
       };
     }),
   };

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -141,13 +141,14 @@ describe('Interaction Row Column Resize Tests', () => {
 
   test('should update resize guide line position when col cell mouse down', () => {
     const resizeInfo: ResizeInfo = {
+      theme: {},
       type: 'col',
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      affect: 'cell',
+      effect: 'cell',
       caption: '',
       id: '',
     };
@@ -182,13 +183,14 @@ describe('Interaction Row Column Resize Tests', () => {
     s2.on(S2Event.LAYOUT_RESIZE_COL_WIDTH, colWidthResize);
 
     const resizeInfo: ResizeInfo = {
+      theme: {},
       type: 'col',
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      affect: 'cell',
+      effect: 'cell',
       caption: 'filedA',
       id: '',
     };
@@ -206,7 +208,7 @@ describe('Interaction Row Column Resize Tests', () => {
     expect(getResizeMask().attr('cursor')).toEqual('col-resize');
 
     emitResizeEvent(
-      S2Event.LAYOUT_RESIZE_MOUSE_UP,
+      S2Event.GLOBAL_MOUSE_UP,
       {
         offsetX: 30,
         offsetY: 20,
@@ -253,13 +255,14 @@ describe('Interaction Row Column Resize Tests', () => {
 
   test('should update resize guide line position when row cell mouse down', () => {
     const resizeInfo: ResizeInfo = {
+      theme: {},
       type: 'row',
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      affect: 'cell',
+      effect: 'cell',
       caption: '',
       id: '',
     };
@@ -293,13 +296,14 @@ describe('Interaction Row Column Resize Tests', () => {
     s2.on(S2Event.LAYOUT_RESIZE_ROW_HEIGHT, rowWidthResize);
 
     const resizeInfo: ResizeInfo = {
+      theme: {},
       type: 'row',
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      affect: 'cell',
+      effect: 'cell',
       caption: 'filedB',
       id: '',
     };
@@ -317,7 +321,7 @@ describe('Interaction Row Column Resize Tests', () => {
     expect(getResizeMask().attr('cursor')).toEqual('row-resize');
 
     emitResizeEvent(
-      S2Event.LAYOUT_RESIZE_MOUSE_UP,
+      S2Event.GLOBAL_MOUSE_UP,
       {
         offsetX: 30,
         offsetY: 30,

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -3,6 +3,8 @@ import { pick } from 'lodash';
 import { RootInteraction } from '@/interaction/root';
 import {
   PivotSheet,
+  ResizeAreaEffect,
+  ResizeAreaType,
   ResizeInfo,
   RESIZE_END_GUIDE_LINE_ID,
   RESIZE_MASK_ID,
@@ -142,13 +144,13 @@ describe('Interaction Row Column Resize Tests', () => {
   test('should update resize guide line position when col cell mouse down', () => {
     const resizeInfo: ResizeInfo = {
       theme: {},
-      type: 'col',
+      type: ResizeAreaType.Col,
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      effect: 'cell',
+      effect: ResizeAreaEffect.Cell,
       caption: '',
       id: '',
     };
@@ -184,13 +186,13 @@ describe('Interaction Row Column Resize Tests', () => {
 
     const resizeInfo: ResizeInfo = {
       theme: {},
-      type: 'col',
+      type: ResizeAreaType.Col,
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      effect: 'cell',
+      effect: ResizeAreaEffect.Cell,
       caption: 'filedA',
       id: '',
     };
@@ -256,13 +258,13 @@ describe('Interaction Row Column Resize Tests', () => {
   test('should update resize guide line position when row cell mouse down', () => {
     const resizeInfo: ResizeInfo = {
       theme: {},
-      type: 'row',
+      type: ResizeAreaType.Row,
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      effect: 'cell',
+      effect: ResizeAreaEffect.Cell,
       caption: '',
       id: '',
     };
@@ -297,13 +299,13 @@ describe('Interaction Row Column Resize Tests', () => {
 
     const resizeInfo: ResizeInfo = {
       theme: {},
-      type: 'row',
+      type: ResizeAreaType.Row,
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      effect: 'cell',
+      effect: ResizeAreaEffect.Cell,
       caption: 'filedB',
       id: '',
     };

--- a/packages/s2-core/__tests__/unit/utils/interaction/resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/resize-spec.ts
@@ -1,0 +1,157 @@
+import { Group } from '@antv/g-canvas';
+import { ResizeArea, ResizeInfo } from '@/common/interface';
+import { SpreadSheet } from '@/sheet-type';
+import {
+  getResizeAreaAttrs,
+  getResizeAreaGroupById,
+} from '@/utils/interaction/resize';
+
+jest.mock('@/sheet-type');
+jest.mock('@/interaction/event-controller');
+
+const MockSpreadSheet = SpreadSheet as unknown as jest.Mock<SpreadSheet>;
+
+describe('Resize Utils Tests', () => {
+  const resizeAreaTheme: ResizeArea = {
+    background: '#000',
+    backgroundOpacity: 1,
+    size: 3,
+  };
+
+  const commonConfig = {
+    offsetX: 0,
+    offsetY: 0,
+    width: 20,
+    height: 20,
+    effect: 'cell',
+    theme: resizeAreaTheme,
+  } as ResizeInfo;
+
+  let s2: SpreadSheet;
+
+  beforeAll(() => {
+    MockSpreadSheet.mockClear();
+
+    s2 = new MockSpreadSheet();
+    s2.foregroundGroup = new Group('');
+  });
+
+  describe('#getResizeAreaAttrs()', () => {
+    test('should get resize area append attrs with col field', () => {
+      expect(
+        getResizeAreaAttrs({
+          ...commonConfig,
+          type: 'col',
+        }),
+      ).toStrictEqual({
+        fill: resizeAreaTheme.background,
+        fillOpacity: resizeAreaTheme.backgroundOpacity,
+        cursor: `col-resize`,
+        width: resizeAreaTheme.size,
+        height: null,
+        appendInfo: {
+          isResizeArea: true,
+          class: 'resize-trigger',
+          effect: 'cell',
+          type: 'col',
+          id: undefined,
+          offsetX: 0,
+          offsetY: 0,
+          width: 20,
+          height: 20,
+        },
+      });
+    });
+
+    test('should get resize area append attrs with row field', () => {
+      expect(
+        getResizeAreaAttrs({
+          ...commonConfig,
+          type: 'row',
+        }),
+      ).toStrictEqual({
+        fill: resizeAreaTheme.background,
+        fillOpacity: resizeAreaTheme.backgroundOpacity,
+        cursor: `row-resize`,
+        width: null,
+        height: resizeAreaTheme.size,
+        appendInfo: {
+          isResizeArea: true,
+          effect: 'cell',
+          class: 'resize-trigger',
+          type: 'row',
+          id: undefined,
+          offsetX: 0,
+          offsetY: 0,
+          width: 20,
+          height: 20,
+        },
+      });
+    });
+
+    test('should merge custom width and height', () => {
+      const attrs = getResizeAreaAttrs({
+        ...commonConfig,
+        type: 'row',
+        width: 100,
+        height: 200,
+      });
+      expect(attrs.appendInfo.width).toStrictEqual(100);
+      expect(attrs.appendInfo.height).toStrictEqual(200);
+    });
+
+    test('should merge custom width with row field', () => {
+      const attrs = getResizeAreaAttrs({
+        ...commonConfig,
+        type: 'row',
+        width: 100,
+      });
+      expect(attrs.appendInfo.width).toStrictEqual(100);
+      expect(attrs.height).toStrictEqual(resizeAreaTheme.size);
+    });
+
+    test('should merge custom height with col field', () => {
+      const attrs = getResizeAreaAttrs({
+        ...commonConfig,
+        type: 'col',
+        height: 100,
+      });
+      expect(attrs.width).toStrictEqual(resizeAreaTheme.size);
+      expect(attrs.appendInfo.height).toStrictEqual(100);
+    });
+
+    test('should get resize cursor with col field', () => {
+      const attrs = getResizeAreaAttrs({
+        ...commonConfig,
+        type: 'col',
+      });
+      expect(attrs.cursor).toStrictEqual('col-resize');
+    });
+
+    test('should get resize cursor with row field', () => {
+      const attrs = getResizeAreaAttrs({
+        ...commonConfig,
+        type: 'row',
+      });
+      expect(attrs.cursor).toStrictEqual('row-resize');
+    });
+  });
+
+  describe('#getResizeAreaGroupById()', () => {
+    test('should get new resize area group if prevResizeArea is empty', () => {
+      const group = getResizeAreaGroupById(s2, 'id');
+      expect(group.add).toBeDefined();
+      expect(s2.foregroundGroup.getChildren()).toHaveLength(1);
+    });
+
+    test('should get prev resize area group if prevResizeArea is exist', () => {
+      const groupId = 'id';
+
+      getResizeAreaGroupById(s2, groupId);
+      getResizeAreaGroupById(s2, groupId);
+      getResizeAreaGroupById(s2, groupId);
+
+      expect(s2.foregroundGroup.getChildren()).toHaveLength(1);
+    });
+  });
+});

--- a/packages/s2-core/__tests__/unit/utils/interaction/resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/resize-spec.ts
@@ -5,6 +5,7 @@ import {
   getResizeAreaAttrs,
   getResizeAreaGroupById,
 } from '@/utils/interaction/resize';
+import { ResizeAreaEffect, ResizeAreaType } from '@/common/constant/resize';
 
 jest.mock('@/sheet-type');
 jest.mock('@/interaction/event-controller');
@@ -41,7 +42,7 @@ describe('Resize Utils Tests', () => {
       expect(
         getResizeAreaAttrs({
           ...commonConfig,
-          type: 'col',
+          type: ResizeAreaType.Col,
         }),
       ).toStrictEqual({
         fill: resizeAreaTheme.background,
@@ -52,8 +53,8 @@ describe('Resize Utils Tests', () => {
         appendInfo: {
           isResizeArea: true,
           class: 'resize-trigger',
-          effect: 'cell',
-          type: 'col',
+          effect: ResizeAreaEffect.Cell,
+          type: ResizeAreaType.Col,
           id: undefined,
           offsetX: 0,
           offsetY: 0,
@@ -67,7 +68,7 @@ describe('Resize Utils Tests', () => {
       expect(
         getResizeAreaAttrs({
           ...commonConfig,
-          type: 'row',
+          type: ResizeAreaType.Row,
         }),
       ).toStrictEqual({
         fill: resizeAreaTheme.background,
@@ -77,9 +78,9 @@ describe('Resize Utils Tests', () => {
         height: resizeAreaTheme.size,
         appendInfo: {
           isResizeArea: true,
-          effect: 'cell',
+          effect: ResizeAreaEffect.Cell,
+          type: ResizeAreaType.Row,
           class: 'resize-trigger',
-          type: 'row',
           id: undefined,
           offsetX: 0,
           offsetY: 0,
@@ -92,7 +93,7 @@ describe('Resize Utils Tests', () => {
     test('should merge custom width and height', () => {
       const attrs = getResizeAreaAttrs({
         ...commonConfig,
-        type: 'row',
+        type: ResizeAreaType.Row,
         width: 100,
         height: 200,
       });
@@ -103,7 +104,7 @@ describe('Resize Utils Tests', () => {
     test('should merge custom width with row field', () => {
       const attrs = getResizeAreaAttrs({
         ...commonConfig,
-        type: 'row',
+        type: ResizeAreaType.Row,
         width: 100,
       });
       expect(attrs.appendInfo.width).toStrictEqual(100);
@@ -113,7 +114,7 @@ describe('Resize Utils Tests', () => {
     test('should merge custom height with col field', () => {
       const attrs = getResizeAreaAttrs({
         ...commonConfig,
-        type: 'col',
+        type: ResizeAreaType.Col,
         height: 100,
       });
       expect(attrs.width).toStrictEqual(resizeAreaTheme.size);
@@ -123,7 +124,7 @@ describe('Resize Utils Tests', () => {
     test('should get resize cursor with col field', () => {
       const attrs = getResizeAreaAttrs({
         ...commonConfig,
-        type: 'col',
+        type: ResizeAreaType.Col,
       });
       expect(attrs.cursor).toStrictEqual('col-resize');
     });
@@ -131,7 +132,7 @@ describe('Resize Utils Tests', () => {
     test('should get resize cursor with row field', () => {
       const attrs = getResizeAreaAttrs({
         ...commonConfig,
-        type: 'row',
+        type: ResizeAreaType.Row,
       });
       expect(attrs.cursor).toStrictEqual('row-resize');
     });
@@ -147,10 +148,12 @@ describe('Resize Utils Tests', () => {
     test('should get prev resize area group if prevResizeArea is exist', () => {
       const groupId = 'id';
 
+      // create multiple group
       getResizeAreaGroupById(s2, groupId);
       getResizeAreaGroupById(s2, groupId);
       getResizeAreaGroupById(s2, groupId);
 
+      // use prev created group, only one resize area group
       expect(s2.foregroundGroup.getChildren()).toHaveLength(1);
     });
   });

--- a/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
@@ -12,7 +12,7 @@ jest.mock('@/interaction/event-controller');
 
 const MockSpreadSheet = SpreadSheet as unknown as jest.Mock<SpreadSheet>;
 
-describe('State Test', () => {
+describe('State Controller Utils Tests', () => {
   const mockRowCell = {
     type: CellTypes.ROW_CELL,
     hideInteractionShape: jest.fn(),

--- a/packages/s2-core/__tests__/util/sheet-entry.tsx
+++ b/packages/s2-core/__tests__/util/sheet-entry.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { Input, Select, Slider, Space, Switch } from 'antd';
-import { isArray, merge, mergeWith } from 'lodash';
+import { merge } from 'lodash';
 import { data, totalData, meta } from '../data/mock-dataset.json';
 import {
   DEFAULT_OPTIONS,
@@ -20,23 +20,17 @@ import {
   DEFAULT_DATA_CONFIG,
 } from '@/index';
 import 'antd/dist/antd.min.css';
+import { customMerge } from '@/utils/merge';
 
 export const assembleOptions = (...options: Partial<S2Options>[]) =>
-  mergeWith(
-    {},
+  customMerge(
     DEFAULT_OPTIONS,
     { debug: true, width: 1000, height: 600 },
     ...options,
-    (origin, updated) => {
-      if (isArray(origin) && isArray(updated)) {
-        return updated;
-      }
-    },
   );
 
 export const assembleDataCfg = (...dataCfg: Partial<S2DataConfig>[]) =>
-  mergeWith(
-    {},
+  customMerge(
     DEFAULT_DATA_CONFIG,
     {
       fields: {
@@ -50,11 +44,6 @@ export const assembleDataCfg = (...dataCfg: Partial<S2DataConfig>[]) =>
       totalData,
     },
     ...dataCfg,
-    (origin, updated) => {
-      if (isArray(origin) && isArray(updated)) {
-        return updated;
-      }
-    },
   );
 
 interface SheetEntryProps {
@@ -146,7 +135,6 @@ export const SheetEntry = forwardRef(
       max: 10,
       step: 0.1,
       marks: {
-        0.2: '0.2倍',
         0.5: '0.5倍',
         1: '1 (默认)',
         2: '2倍',

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -123,8 +123,12 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
   /*                common functions that will be used in subtype               */
   /* -------------------------------------------------------------------------- */
 
-  protected getStyle(name?: string) {
+  protected getStyle(name?: keyof S2Theme) {
     return this.theme[name || this.cellType];
+  }
+
+  protected getResizeAreaStyle() {
+    return this.getStyle('resizeArea');
   }
 
   protected getCellArea() {

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -1,6 +1,10 @@
 import { Group, Point } from '@antv/g-canvas';
 import { HeaderCell } from './header-cell';
 import {
+  getResizeAreaAttrs,
+  getResizeAreaGroupById,
+} from '@/utils/interaction/resize';
+import {
   CellTypes,
   KEY_GROUP_COL_RESIZE_AREA,
   HORIZONTAL_RESIZE_AREA_KEY_PRE,
@@ -10,7 +14,6 @@ import {
   TextAlign,
   TextBaseline,
   TextTheme,
-  ResizeInfo,
 } from '@/common/interface';
 import { ColHeaderConfig } from '@/facet/header/col';
 import { getTextPosition } from '@/utils/cell/cell';
@@ -135,7 +138,7 @@ export class ColCell extends HeaderCell {
   }
 
   protected getColResizeAreaOffset() {
-    const { offset, scrollX, position } = this.headerConfig;
+    const { offset, position } = this.headerConfig;
     const { x, y } = this.meta;
 
     return {
@@ -145,19 +148,13 @@ export class ColCell extends HeaderCell {
   }
 
   protected getColResizeArea() {
-    const prevResizeArea = this.spreadsheet.foregroundGroup.findById(
-      KEY_GROUP_COL_RESIZE_AREA,
-    );
-    return (prevResizeArea ||
-      this.spreadsheet.foregroundGroup.addGroup({
-        id: KEY_GROUP_COL_RESIZE_AREA,
-      })) as Group;
+    return getResizeAreaGroupById(this.spreadsheet, KEY_GROUP_COL_RESIZE_AREA);
   }
 
   protected drawHorizontalResizeArea() {
     const { viewportWidth, scrollX } = this.headerConfig;
     const { height: cellHeight } = this.meta;
-    const resizeStyle = this.getStyle('resizeArea');
+    const resizeStyle = this.getResizeAreaStyle();
     const resizeArea = this.getColResizeArea();
     const resizeAreaName = `${HORIZONTAL_RESIZE_AREA_KEY_PRE}${this.meta.key}`;
     const prevHorizontalResizeArea = resizeArea.find(
@@ -169,25 +166,20 @@ export class ColCell extends HeaderCell {
       // 列高调整热区
       resizeArea.addShape('rect', {
         attrs: {
-          name: resizeAreaName,
-          x: resizerOffset.x,
-          y: resizerOffset.y + cellHeight - resizeStyle.size / 2,
-          width: viewportWidth + scrollX,
-          height: resizeStyle.size,
-          fill: resizeStyle.background,
-          fillOpacity: resizeStyle.backgroundOpacity,
-          cursor: 'row-resize',
-          appendInfo: {
-            isResizeArea: true,
-            class: 'resize-trigger',
+          ...getResizeAreaAttrs({
+            theme: resizeStyle,
             type: 'row',
             id: this.getColResizeAreaKey(),
-            affect: 'field',
+            effect: 'field',
             offsetX: resizerOffset.x,
             offsetY: resizerOffset.y,
             width: viewportWidth,
             height: cellHeight,
-          } as ResizeInfo,
+          }),
+          name: resizeAreaName,
+          x: resizerOffset.x,
+          y: resizerOffset.y + cellHeight - resizeStyle.size / 2,
+          width: viewportWidth + scrollX,
         },
       });
     }
@@ -196,31 +188,26 @@ export class ColCell extends HeaderCell {
   protected drawVerticalResizeArea() {
     const { label, width: cellWidth, height: cellHeight, parent } = this.meta;
     const resizerOffset = this.getColResizeAreaOffset();
-    const resizeStyle = this.getStyle('resizeArea');
+    const resizeStyle = this.getResizeAreaStyle();
     const resizeArea = this.getColResizeArea();
     if (this.meta.isLeaf) {
       // 列宽调整热区
       // 基准线是根据container坐标来的，因此把热区画在container
       resizeArea.addShape('rect', {
         attrs: {
-          x: resizerOffset.x + cellWidth - resizeStyle.size / 2,
-          y: resizerOffset.y,
-          width: resizeStyle.size,
-          height: cellHeight,
-          fill: resizeStyle.background,
-          fillOpacity: resizeStyle.backgroundOpacity,
-          cursor: 'col-resize',
-          appendInfo: {
-            isResizeArea: true,
-            class: 'resize-trigger',
+          ...getResizeAreaAttrs({
+            theme: resizeStyle,
             type: 'col',
-            affect: 'cell',
+            effect: 'cell',
             caption: parent.isTotals ? '' : label,
             offsetX: resizerOffset.x,
             offsetY: resizerOffset.y,
             width: cellWidth,
             height: cellHeight,
-          } as ResizeInfo,
+          }),
+          x: resizerOffset.x + cellWidth - resizeStyle.size / 2,
+          y: resizerOffset.y,
+          height: cellHeight,
         },
       });
     }

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -1,4 +1,4 @@
-import { Group, Point } from '@antv/g-canvas';
+import { Point } from '@antv/g-canvas';
 import { HeaderCell } from './header-cell';
 import {
   getResizeAreaAttrs,
@@ -8,6 +8,8 @@ import {
   CellTypes,
   KEY_GROUP_COL_RESIZE_AREA,
   HORIZONTAL_RESIZE_AREA_KEY_PRE,
+  ResizeAreaType,
+  ResizeAreaEffect,
 } from '@/common/constant';
 import {
   FormatResult,
@@ -168,9 +170,9 @@ export class ColCell extends HeaderCell {
         attrs: {
           ...getResizeAreaAttrs({
             theme: resizeStyle,
-            type: 'row',
+            type: ResizeAreaType.Row,
             id: this.getColResizeAreaKey(),
-            effect: 'field',
+            effect: ResizeAreaEffect.Filed,
             offsetX: resizerOffset.x,
             offsetY: resizerOffset.y,
             width: viewportWidth,
@@ -197,8 +199,8 @@ export class ColCell extends HeaderCell {
         attrs: {
           ...getResizeAreaAttrs({
             theme: resizeStyle,
-            type: 'col',
-            effect: 'cell',
+            type: ResizeAreaType.Col,
+            effect: ResizeAreaEffect.Cell,
             caption: parent.isTotals ? '' : label,
             offsetX: resizerOffset.x,
             offsetY: resizerOffset.y,

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -9,6 +9,8 @@ import {
   CellTypes,
   EXTRA_FIELD,
   KEY_GROUP_CORNER_RESIZE_AREA,
+  ResizeAreaEffect,
+  ResizeAreaType,
   S2Event,
 } from '@/common/constant';
 import { FormatResult, TextTheme } from '@/common/interface';
@@ -241,9 +243,9 @@ export class CornerCell extends HeaderCell {
       attrs: {
         ...getResizeAreaAttrs({
           theme: resizeStyle,
-          type: 'col',
+          type: ResizeAreaType.Col,
           id: field,
-          effect: 'field',
+          effect: ResizeAreaEffect.Filed,
           offsetX,
           offsetY,
           width: cellWidth,

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -4,6 +4,8 @@ import { HeaderCell } from './header-cell';
 import {
   CellTypes,
   KEY_GROUP_ROW_RESIZE_AREA,
+  ResizeAreaEffect,
+  ResizeAreaType,
   S2Event,
 } from '@/common/constant';
 import { FormatResult, TextTheme } from '@/common/interface';
@@ -246,8 +248,8 @@ export class RowCell extends HeaderCell {
         attrs: {
           ...getResizeAreaAttrs({
             theme: resizeStyle,
-            type: 'row',
-            effect: 'cell',
+            type: ResizeAreaType.Row,
+            effect: ResizeAreaEffect.Cell,
             caption: parent.isTotals ? '' : label,
             offsetX: position.x + x + seriesNumberWidth,
             offsetY: position.y + y - offset,

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -1,6 +1,5 @@
 import { get, isEmpty } from 'lodash';
 import { isFrozenCol, isFrozenTrailingCol } from 'src/facet/utils';
-import { Group } from '@antv/g-canvas';
 import { isLastColumnAfterHidden } from '@/utils/hide-columns';
 import {
   S2Event,
@@ -11,13 +10,12 @@ import { renderDetailTypeSortIcon } from '@/utils/layout/add-detail-type-sort-ic
 import { getEllipsisText, getTextPosition } from '@/utils/text';
 import { renderIcon, renderLine, renderText } from '@/utils/g-renders';
 import { ColCell } from '@/cell/col-cell';
-import {
-  CellBoxCfg,
-  DefaultCellTheme,
-  IconTheme,
-  ResizeInfo,
-} from '@/common/interface';
+import { CellBoxCfg, DefaultCellTheme, IconTheme } from '@/common/interface';
 import { KEY_GROUP_FROZEN_COL_RESIZE_AREA } from '@/common/constant';
+import {
+  getResizeAreaAttrs,
+  getResizeAreaGroupById,
+} from '@/utils/interaction/resize';
 
 export class TableColCell extends ColCell {
   protected isFrozenCell() {
@@ -37,13 +35,10 @@ export class TableColCell extends ColCell {
     if (!isFrozenCell) {
       return super.getColResizeArea();
     }
-    const prevResizeArea = this.spreadsheet.foregroundGroup.findById(
+    return getResizeAreaGroupById(
+      this.spreadsheet,
       KEY_GROUP_FROZEN_COL_RESIZE_AREA,
     );
-    return (prevResizeArea ||
-      this.spreadsheet.foregroundGroup.addGroup({
-        id: KEY_GROUP_FROZEN_COL_RESIZE_AREA,
-      })) as Group;
   }
 
   protected getColResizeAreaOffset() {
@@ -227,19 +222,16 @@ export class TableColCell extends ColCell {
   }
 
   private getHorizontalResizeArea() {
-    const prevResizeArea = this.spreadsheet.foregroundGroup.findById(
+    return getResizeAreaGroupById(
+      this.spreadsheet,
       KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA,
     );
-    return (prevResizeArea ||
-      this.spreadsheet.foregroundGroup.addGroup({
-        id: KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA,
-      })) as Group;
   }
 
   protected drawHorizontalResizeArea() {
     const { viewportWidth } = this.headerConfig;
     const { height: cellHeight } = this.meta;
-    const resizeStyle = this.getStyle('resizeArea');
+    const resizeStyle = this.getResizeAreaStyle();
     const resizeArea = this.getHorizontalResizeArea();
 
     const prevHorizontalResizeArea = resizeArea.find(
@@ -251,25 +243,20 @@ export class TableColCell extends ColCell {
       // 列高调整热区
       resizeArea.addShape('rect', {
         attrs: {
-          name: TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY,
-          x: 0,
-          y: cellHeight - resizeStyle.size,
-          width: viewportWidth,
-          height: resizeStyle.size,
-          fill: resizeStyle.background,
-          fillOpacity: resizeStyle.backgroundOpacity,
-          cursor: 'row-resize',
-          appendInfo: {
-            isResizeArea: true,
-            class: 'resize-trigger',
+          ...getResizeAreaAttrs({
+            theme: resizeStyle,
             type: 'row',
             id: this.getColResizeAreaKey(),
-            affect: 'field',
+            effect: 'field',
             offsetX: 0,
             offsetY: 0,
             width: viewportWidth,
             height: cellHeight,
-          } as ResizeInfo,
+          }),
+          name: TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY,
+          x: 0,
+          y: cellHeight - resizeStyle.size,
+          width: viewportWidth,
         },
       });
     }

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -1,10 +1,13 @@
 import { get, isEmpty } from 'lodash';
 import { isFrozenCol, isFrozenTrailingCol } from 'src/facet/utils';
+import { Group } from '@antv/g-canvas';
 import { isLastColumnAfterHidden } from '@/utils/hide-columns';
 import {
   S2Event,
   TABLE_COL_HORIZONTAL_RESIZE_AREA_KEY,
   KEY_GROUP_COL_HORIZONTAL_RESIZE_AREA,
+  ResizeAreaType,
+  ResizeAreaEffect,
 } from '@/common/constant';
 import { renderDetailTypeSortIcon } from '@/utils/layout/add-detail-type-sort-icon';
 import { getEllipsisText, getTextPosition } from '@/utils/text';
@@ -38,7 +41,7 @@ export class TableColCell extends ColCell {
     return getResizeAreaGroupById(
       this.spreadsheet,
       KEY_GROUP_FROZEN_COL_RESIZE_AREA,
-    );
+    ) as Group;
   }
 
   protected getColResizeAreaOffset() {
@@ -245,9 +248,9 @@ export class TableColCell extends ColCell {
         attrs: {
           ...getResizeAreaAttrs({
             theme: resizeStyle,
-            type: 'row',
+            type: ResizeAreaType.Row,
             id: this.getColResizeAreaKey(),
-            effect: 'field',
+            effect: ResizeAreaEffect.Filed,
             offsetX: 0,
             offsetY: 0,
             width: viewportWidth,

--- a/packages/s2-core/src/common/constant/resize.ts
+++ b/packages/s2-core/src/common/constant/resize.ts
@@ -1,3 +1,14 @@
 export const RESIZE_START_GUIDE_LINE_ID = 'RESIZE_START_GUIDE_LINE';
 export const RESIZE_END_GUIDE_LINE_ID = 'RESIZE_END_GUIDE_LINE';
 export const RESIZE_MASK_ID = 'RESIZE_MASK';
+
+export enum ResizeAreaType {
+  Row = 'row',
+  Col = 'col',
+}
+
+export enum ResizeAreaEffect {
+  Filed = 'field',
+  Cell = 'cell',
+  Tree = 'tree',
+}

--- a/packages/s2-core/src/common/interface/resize.ts
+++ b/packages/s2-core/src/common/interface/resize.ts
@@ -1,6 +1,7 @@
 import { Style } from './basic';
 import { ResizeArea } from './theme';
 import { S2Event } from '@/common/constant/events/basic';
+import { ResizeAreaEffect, ResizeAreaType } from '@/common/constant/resize';
 
 export type ResizeGuideLinePath = ['M' | 'L', number, number];
 
@@ -40,9 +41,9 @@ export interface ResizeInfo {
    * col是改变列配置，即改变宽度
    * row是改变行配置，即改变高度
    */
-  type: 'row' | 'col';
-  /** 改动区域 */
-  effect: 'field' | 'cell' | 'tree';
+  type: ResizeAreaType;
+  /** 改动影响区域 */
+  effect: ResizeAreaEffect;
   /** 字段id */
   id?: string;
   /** 维值，用于指定该维值对应的配置 */

--- a/packages/s2-core/src/common/interface/resize.ts
+++ b/packages/s2-core/src/common/interface/resize.ts
@@ -1,4 +1,5 @@
 import { Style } from './basic';
+import { ResizeArea } from './theme';
 import { S2Event } from '@/common/constant/events/basic';
 
 export type ResizeGuideLinePath = ['M' | 'L', number, number];
@@ -33,19 +34,19 @@ export interface ResizeDetail {
 }
 
 export interface ResizeInfo {
-  isResizeArea: boolean;
-  class?: string;
+  theme: ResizeArea;
+  isResizeArea?: boolean;
   /**
    * col是改变列配置，即改变宽度
    * row是改变行配置，即改变高度
    */
   type: 'row' | 'col';
   /** 改动区域 */
-  affect: 'field' | 'cell' | 'tree';
+  effect: 'field' | 'cell' | 'tree';
   /** 字段id */
-  id: string;
+  id?: string;
   /** 维值，用于指定该维值对应的配置 */
-  caption: string;
+  caption?: string;
   offsetX: number;
   offsetY: number;
   width: number;

--- a/packages/s2-core/src/common/interface/store.ts
+++ b/packages/s2-core/src/common/interface/store.ts
@@ -77,6 +77,8 @@ export interface StoreKey {
 
   // hover 显示的 icon 缓存
   visibleActionIcons: GuiIcon[];
+  // 冻结行头时 真实 和 实际渲染的角头宽度差值
+  freezeCornerDiffWidth: number;
 
   [key: string]: unknown;
 }

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -118,9 +118,9 @@ export interface ResizeArea {
   /* 热区背景色 */
   background?: string;
   /* 参考线颜色 */
-  guidLineColor?: string;
+  guideLineColor?: string;
   /* 参考线间隔 */
-  guidLineDash?: number;
+  guideLineDash?: number;
   /* 热区背景色透明度 */
   backgroundOpacity?: number;
   /* 交互态 */

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -230,7 +230,7 @@ export class PivotDataSet extends BaseDataSet {
       // 万物排序的前提
       if (!sortFieldId) return;
       const originValues = [
-        ...this.sortedDimensionValues.get(sortFieldId)?.keys(),
+        ...(this.sortedDimensionValues.get(sortFieldId)?.keys?.() || []),
       ];
       const result = handleSortAction({
         dataSet: this,

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -97,7 +97,7 @@ export abstract class BaseFacet {
 
   protected hScrollBar: ScrollBar;
 
-  public hRowScrollBar: ScrollBar;
+  protected hRowScrollBar: ScrollBar;
 
   protected vScrollBar: ScrollBar;
 

--- a/packages/s2-core/src/facet/header/corner.ts
+++ b/packages/s2-core/src/facet/header/corner.ts
@@ -1,8 +1,12 @@
 import { Group, Point, SimpleBBox } from '@antv/g-canvas';
-import { get, includes, isEmpty, last, max, min } from 'lodash';
-import { translateGroup } from '../utils';
+import { get, includes, isEmpty, last } from 'lodash';
 import { BaseHeader, BaseHeaderConfig } from './base';
 import { CornerData } from './interface';
+import { translateGroup } from '@/facet/utils';
+import {
+  getResizeAreaAttrs,
+  getResizeAreaGroupById,
+} from '@/utils/interaction/resize';
 import { CornerCell } from '@/cell/corner-cell';
 import {
   KEY_GROUP_CORNER_RESIZE_AREA,
@@ -14,7 +18,6 @@ import {
   S2CellType,
   S2Options,
   SpreadSheetFacetCfg,
-  ResizeInfo,
 } from '@/common/interface';
 import { BaseDataSet } from '@/data-set';
 import { Hierarchy } from '@/facet/layout/hierarchy';
@@ -175,6 +178,7 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
     colsHierarchy.sampleNodesForAllLevels.forEach((colNode) => {
       // 列头最后一个层级的位置为行头 label 标识，需要过滤
       if (colNode.level < colsHierarchy.maxLevel) {
+        const freezeCornerDiffWidth = s2.facet.getFreezeCornerDiffWidth();
         const field = columns[colNode.level];
         const cNode: Node = new Node({
           key: field,
@@ -183,7 +187,7 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
         });
         cNode.x = columOffsetX;
         cNode.y = colNode.y;
-        cNode.width = width - columOffsetX;
+        cNode.width = width - columOffsetX + freezeCornerDiffWidth;
         cNode.height = colNode.height;
         cNode.field = field;
         cNode.isPivotMode = true;
@@ -288,62 +292,52 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
   }
 
   private handleHotsSpotArea() {
-    const { data, position, width, height, seriesNumberWidth } =
+    const { data, position, width, height, seriesNumberWidth, spreadsheet } =
       this.headerConfig;
-    const resizeStyle = this.headerConfig.spreadsheet.theme.resizeArea;
-    const prevResizeArea =
-      this.headerConfig.spreadsheet.foregroundGroup.findById(
-        KEY_GROUP_CORNER_RESIZE_AREA,
-      );
-    const resizeArea = (prevResizeArea ||
-      this.headerConfig.spreadsheet.foregroundGroup.addGroup({
-        id: KEY_GROUP_CORNER_RESIZE_AREA,
-      })) as Group;
-    const treeType = this.headerConfig.spreadsheet.isHierarchyTreeType();
+    const resizeStyle = spreadsheet.theme.resizeArea;
+    const resizeArea = getResizeAreaGroupById(
+      spreadsheet,
+      KEY_GROUP_CORNER_RESIZE_AREA,
+    );
+
+    const treeType = spreadsheet.isHierarchyTreeType();
     if (treeType) {
       resizeArea.addShape('rect', {
         attrs: {
-          x: position.x + width - resizeStyle.size / 2,
-          y: position.y,
-          width: resizeStyle.size,
-          height: this.get('viewportHeight') + height,
-          fill: resizeStyle.background,
-          fillOpacity: resizeStyle.backgroundOpacity,
-          cursor: 'col-resize',
-          appendInfo: {
-            isResizeArea: true,
-            class: 'resize-trigger',
+          ...getResizeAreaAttrs({
+            theme: resizeStyle,
             type: 'col',
-            affect: 'tree',
+            effect: 'tree',
             offsetX: position.x + seriesNumberWidth,
             offsetY: position.y,
             width: width - seriesNumberWidth,
             height,
-          } as ResizeInfo,
+          }),
+          x: position.x + width - resizeStyle.size / 2,
+          y: position.y,
+          height: this.get('viewportHeight') + height,
         },
       });
     }
     const cell: CornerData = get(data, '0', {});
+    const offsetX = position.x;
+    const offsetY = position.y;
+
     resizeArea.addShape('rect', {
       attrs: {
-        x: position.x,
-        y: position.y + cell.y + cell.height - resizeStyle.size / 2,
-        width,
-        height: resizeStyle.size,
-        fill: resizeStyle.background,
-        fillOpacity: resizeStyle.backgroundOpacity,
-        cursor: 'row-resize',
-        appendInfo: {
-          isResizeArea: true,
-          class: 'resize-trigger',
+        ...getResizeAreaAttrs({
+          theme: resizeStyle,
           type: 'row',
-          affect: 'field',
+          effect: 'field',
           id: last(this.get('columns')),
-          offsetX: position.x,
-          offsetY: position.y + cell.y,
+          offsetX,
+          offsetY,
           width: cell.width,
           height: cell.height,
-        } as ResizeInfo,
+        }),
+        x: offsetX,
+        y: offsetY + cell.y + cell.height - resizeStyle.size / 2,
+        width,
       },
     });
   }

--- a/packages/s2-core/src/facet/header/corner.ts
+++ b/packages/s2-core/src/facet/header/corner.ts
@@ -11,6 +11,8 @@ import { CornerCell } from '@/cell/corner-cell';
 import {
   KEY_GROUP_CORNER_RESIZE_AREA,
   KEY_SERIES_NUMBER_NODE,
+  ResizeAreaEffect,
+  ResizeAreaType,
 } from '@/common/constant';
 import { i18n } from '@/common/i18n';
 import {
@@ -217,11 +219,11 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
   }
 
   protected layout() {
-    this.startRender();
-    this.handleHotsSpotArea();
+    this.renderCells();
+    this.renderResizeAreas();
   }
 
-  protected startRender() {
+  protected renderCells() {
     const { data, spreadsheet } = this.headerConfig;
     const cornerHeader = spreadsheet?.facet?.cfg?.cornerHeader;
     const cornerCell = spreadsheet?.facet?.cfg?.cornerCell;
@@ -233,7 +235,6 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
       );
       return;
     }
-    // 背景
     this.addBgRect();
     data.forEach((item: Node) => {
       let cell: Group;
@@ -291,7 +292,7 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
     });
   }
 
-  private handleHotsSpotArea() {
+  private renderResizeAreas() {
     const { data, position, width, height, seriesNumberWidth, spreadsheet } =
       this.headerConfig;
     const resizeStyle = spreadsheet.theme.resizeArea;
@@ -300,14 +301,13 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
       KEY_GROUP_CORNER_RESIZE_AREA,
     );
 
-    const treeType = spreadsheet.isHierarchyTreeType();
-    if (treeType) {
+    if (spreadsheet.isHierarchyTreeType()) {
       resizeArea.addShape('rect', {
         attrs: {
           ...getResizeAreaAttrs({
             theme: resizeStyle,
-            type: 'col',
-            effect: 'tree',
+            type: ResizeAreaType.Col,
+            effect: ResizeAreaEffect.Tree,
             offsetX: position.x + seriesNumberWidth,
             offsetY: position.y,
             width: width - seriesNumberWidth,
@@ -327,8 +327,8 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
       attrs: {
         ...getResizeAreaAttrs({
           theme: resizeStyle,
-          type: 'row',
-          effect: 'field',
+          type: ResizeAreaType.Row,
+          effect: ResizeAreaEffect.Filed,
           id: last(this.get('columns')),
           offsetX,
           offsetY,

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -23,6 +23,8 @@ import {
   RESIZE_END_GUIDE_LINE_ID,
   S2Event,
   CORNER_MAX_WIDTH_RATIO,
+  ResizeAreaType,
+  ResizeAreaEffect,
 } from '@/common/constant';
 
 export class RowColumnResize extends BaseEvent implements BaseEventImplement {
@@ -113,7 +115,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
 
     resizeMask.attr('cursor', `${cellType}-resize`);
 
-    if (cellType === 'col') {
+    if (cellType === ResizeAreaType.Col) {
       startResizeGuideLineShape.attr('path', [
         ['M', offsetX, offsetY],
         ['L', offsetX, guideLineMaxHeight],
@@ -194,7 +196,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     const resizeInfo = this.getResizeInfo();
 
     switch (resizeInfo.effect) {
-      case 'field':
+      case ResizeAreaEffect.Filed:
         return {
           eventType: S2Event.LAYOUT_RESIZE_ROW_WIDTH,
           style: {
@@ -205,7 +207,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
             },
           },
         };
-      case 'tree':
+      case ResizeAreaEffect.Tree:
         return {
           eventType: S2Event.LAYOUT_RESIZE_TREE_WIDTH,
           style: {
@@ -214,7 +216,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
             },
           },
         };
-      case 'cell':
+      case ResizeAreaEffect.Cell:
         return {
           eventType: S2Event.LAYOUT_RESIZE_COL_WIDTH,
           style: {
@@ -238,7 +240,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     const resizeInfo = this.getResizeInfo();
 
     switch (resizeInfo.effect) {
-      case 'field':
+      case ResizeAreaEffect.Filed:
         return {
           eventType: S2Event.LAYOUT_RESIZE_COL_HEIGHT,
           style: {
@@ -249,8 +251,8 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
             },
           },
         };
-      case 'cell':
-      case 'tree':
+      case ResizeAreaEffect.Cell:
+      case ResizeAreaEffect.Tree:
         return {
           eventType: S2Event.LAYOUT_RESIZE_ROW_HEIGHT,
           style: {
@@ -267,7 +269,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
   private getCellResizeDetail() {
     const resizeInfo = this.getResizeInfo();
 
-    if (resizeInfo.type === 'col') {
+    if (resizeInfo.type === ResizeAreaType.Col) {
       return this.getColCellResizeDetail();
     }
     return this.getRowCellResizeDetail();
@@ -299,7 +301,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
   private isResizeMoreThanMaxCornerWidthLimit(offsetX: number) {
     const resizeInfo = this.getResizeInfo();
     const isResizeFreezeRowHeader =
-      resizeInfo.effect === 'field' &&
+      resizeInfo.effect === ResizeAreaEffect.Filed &&
       this.spreadsheet.isFreezeRowHeader() &&
       !this.spreadsheet.isHierarchyTreeType();
 
@@ -331,7 +333,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     );
 
     // 下面的神仙代码我改不动了
-    if (resizeInfo.type === 'col') {
+    if (resizeInfo.type === ResizeAreaType.Col) {
       if (this.isResizeMoreThanMaxCornerWidthLimit(originalEvent.offsetX)) {
         return;
       }

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -193,7 +193,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     const width = Math.floor(end.x - start.x);
     const resizeInfo = this.getResizeInfo();
 
-    switch (resizeInfo.affect) {
+    switch (resizeInfo.effect) {
       case 'field':
         return {
           eventType: S2Event.LAYOUT_RESIZE_ROW_WIDTH,
@@ -237,7 +237,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     const height = baseHeight - rowCellPadding.top - rowCellPadding.bottom;
     const resizeInfo = this.getResizeInfo();
 
-    switch (resizeInfo.affect) {
+    switch (resizeInfo.effect) {
       case 'field':
         return {
           eventType: S2Event.LAYOUT_RESIZE_COL_HEIGHT,
@@ -283,7 +283,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
   }
 
   private bindMouseUp() {
-    this.spreadsheet.on(S2Event.LAYOUT_RESIZE_MOUSE_UP, () => {
+    this.spreadsheet.on(S2Event.GLOBAL_MOUSE_UP, () => {
       if (!this.resizeGroup) {
         return;
       }
@@ -299,7 +299,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
   private isResizeMoreThanMaxCornerWidthLimit(offsetX: number) {
     const resizeInfo = this.getResizeInfo();
     const isResizeFreezeRowHeader =
-      resizeInfo.affect === 'field' &&
+      resizeInfo.effect === 'field' &&
       this.spreadsheet.isFreezeRowHeader() &&
       !this.spreadsheet.isHierarchyTreeType();
 

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -45,11 +45,11 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     this.resizeGroup = this.spreadsheet.foregroundGroup.addGroup();
 
     const { width, height } = this.spreadsheet.options;
-    const { guidLineColor, guidLineDash, size } = this.getResizeAreaTheme();
+    const { guideLineColor, guideLineDash, size } = this.getResizeAreaTheme();
     const attrs: ShapeAttrs = {
       path: '',
-      lineDash: [guidLineDash, guidLineDash],
-      stroke: guidLineColor,
+      lineDash: [guideLineDash, guideLineDash],
+      stroke: guideLineColor,
       strokeWidth: size,
     };
     // 起始参考线

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -295,9 +295,9 @@ export const getTheme = (
     resizeArea: {
       size: 3,
       background: basicColors[7],
-      guidLineColor: basicColors[7],
-      guidLineDash: 3,
-      backgroundOpacity: 1,
+      guideLineColor: basicColors[7],
+      guideLineDash: 3,
+      backgroundOpacity: 0,
       /* ---------- interaction state ----------- */
       interactionState: {
         hover: {

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -297,7 +297,7 @@ export const getTheme = (
       background: basicColors[7],
       guidLineColor: basicColors[7],
       guidLineDash: 3,
-      backgroundOpacity: 0,
+      backgroundOpacity: 1,
       /* ---------- interaction state ----------- */
       interactionState: {
         hover: {

--- a/packages/s2-core/src/utils/interaction/resize.ts
+++ b/packages/s2-core/src/utils/interaction/resize.ts
@@ -1,0 +1,51 @@
+import { IGroup, ShapeAttrs } from '@antv/g-canvas';
+import { ResizeInfo } from '@/common/interface/resize';
+import { SpreadSheet } from '@/sheet-type/spread-sheet';
+
+export const getResizeAreaAttrs = (options: ResizeInfo): ShapeAttrs => {
+  const {
+    type,
+    id,
+    theme,
+    width: resizeAreaWidth,
+    height: resizeAreaHeight,
+    ...otherOptions
+  } = options;
+  const width = type === 'col' ? theme.size : null;
+  const height = type === 'row' ? theme.size : null;
+
+  return {
+    fill: theme.background,
+    fillOpacity: theme.backgroundOpacity,
+    cursor: `${type}-resize`,
+    width,
+    height,
+    appendInfo: {
+      ...otherOptions,
+      isResizeArea: true,
+      class: 'resize-trigger',
+      type,
+      id,
+      width: resizeAreaWidth,
+      height: resizeAreaHeight,
+    } as Omit<ResizeInfo, 'theme'>,
+  };
+};
+
+export const getResizeAreaGroupById = (
+  spreadsheet: SpreadSheet,
+  id: string,
+): IGroup => {
+  if (!spreadsheet.foregroundGroup) {
+    return;
+  }
+
+  const prevResizeArea = spreadsheet.foregroundGroup.findById(id) as IGroup;
+
+  return (
+    prevResizeArea ||
+    spreadsheet.foregroundGroup.addGroup({
+      id,
+    })
+  );
+};

--- a/s2-site/docs/api/general/S2Theme.zh.md
+++ b/s2-site/docs/api/general/S2Theme.zh.md
@@ -70,7 +70,7 @@ order: 2
 | size | `number` |  | 3 | 热区尺寸 |
 | background | `string` | |  | 热区背景色 |
 | backgroundOpacity | `number` |  | | 热区背景色透明度 |
-| guidLineColor | `string` |  | | 参考线颜色 |
+| guideLineColor | `string` |  | | 参考线颜色 |
 | interactionState | [InteractionState](#interactionstate) | |  | 热区交互态样式 |
 
 #### ScrollBarTheme
@@ -106,7 +106,7 @@ order: 2
 | shadowWidth | `number` | | 10 | 阴影宽度 |
 | shadowColors | `{left: string,` <br> `right: string}` | | `{left: 'rgba(0,0,0,0.1)',`<br>`right: 'rgba(0,0,0,0)'}` | `left` : 线性变化左侧颜色  <br> `right` : 线性变化右侧颜色 |
 
-#### TextTheme  
+#### TextTheme
 
 <description> **optional**  _object_ </description>
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [x] Test case

### 📝 Description

修复 **冻结行头** 行头有滚动条场景下一些 resize bugs

1. 修复 resize 热区渲染错误
2. 修复 角头文字 未居中
3. 修复 实际渲染的宽度 与 resize 提示线的距离 不符
4. 优化 resize appendInfo 的添加方式
5. 统一 foregroundGroup 添加 热区的方式
6. 修复 鼠标移出 图表区域 resize 事件无法结束

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2021-11-01 at 19 40 45](https://user-images.githubusercontent.com/21015895/139666154-93452926-50e2-45bc-9e5e-a8e0ada72127.gif) | ![Kapture 2021-11-01 at 19 42 18](https://user-images.githubusercontent.com/21015895/139666401-e3d63b10-ad83-406d-8740-568dee46a0e1.gif) |

### 🔗 Related issue link

close #578 

<!-- close #0 -->
