### PR TITLE
fix(interaction): cancel data cell hover focus timer when row or col mousemove

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
@@ -23,6 +23,15 @@ describe('Interaction Hover Tests', () => {
   };
   const mockCellMeta = omit(mockCell, 'update');
   const mockCellUpdate = jest.fn();
+  const mockTooltipParams = [
+    [{ value: undefined, valueField: undefined }],
+    {
+      enterable: true,
+      hideSummary: true,
+      isTotals: undefined,
+      showSingleTips: true,
+    },
+  ];
 
   beforeEach(() => {
     s2 = createFakeSpreadSheet();
@@ -91,7 +100,7 @@ describe('Interaction Hover Tests', () => {
     expect(s2.showTooltipWithInfo).toHaveBeenCalled();
   });
 
-  test('should clear hover focus timer when cell clicked', async () => {
+  test('should clear data cell hover focus timer when cell clicked', async () => {
     s2.emit(S2Event.DATA_CELL_HOVER, { target: {} } as GEvent);
 
     // click date cell before will trigger hover focus
@@ -107,6 +116,52 @@ describe('Interaction Hover Tests', () => {
 
     expect(s2.interaction.getCurrentStateName()).not.toEqual(
       InteractionStateName.HOVER_FOCUS,
+    );
+  });
+
+  test('should clear data cell hover focus timer when row cell hover', async () => {
+    const dataCellEvent = {
+      target: {
+        id: 'data-cell',
+      },
+    };
+
+    const rowCellEvent = {
+      target: {
+        id: 'row-cell',
+      },
+    };
+    s2.emit(S2Event.DATA_CELL_HOVER, dataCellEvent as unknown as GEvent);
+    s2.emit(S2Event.ROW_CELL_HOVER, rowCellEvent as unknown as GEvent);
+
+    await sleep(HOVER_FOCUS_TIME + 200);
+
+    expect(s2.showTooltipWithInfo).toHaveBeenLastCalledWith(
+      rowCellEvent,
+      ...mockTooltipParams,
+    );
+  });
+
+  test('should clear data cell hover focus timer when col cell hover', async () => {
+    const dataCellEvent = {
+      target: {
+        id: 'data-cell',
+      },
+    };
+
+    const colCellEvent = {
+      target: {
+        id: 'col-cell',
+      },
+    };
+    s2.emit(S2Event.DATA_CELL_HOVER, dataCellEvent as unknown as GEvent);
+    s2.emit(S2Event.COL_CELL_HOVER, colCellEvent as unknown as GEvent);
+
+    await sleep(HOVER_FOCUS_TIME + 200);
+
+    expect(s2.showTooltipWithInfo).toHaveBeenLastCalledWith(
+      colCellEvent,
+      ...mockTooltipParams,
     );
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -86,6 +86,7 @@ describe('Interaction Row Column Resize Tests', () => {
     rowColumnResizeInstance.getHeaderGroup = () => new Group('');
     s2.render = jest.fn();
     s2.tooltip.container = document.createElement('div');
+    s2.hideTooltip = jest.fn();
   });
 
   test('should register events', () => {
@@ -354,7 +355,7 @@ describe('Interaction Row Column Resize Tests', () => {
     expect(rowColumnResizeInstance.resizeStartPosition).toEqual({});
   });
 
-  test('should disable tooltip point event when mouse down', () => {
+  test('should hidden tooltip when resize start', () => {
     const resizeInfo: ResizeInfo = {
       type: 'row',
       offsetX: 2,
@@ -375,6 +376,6 @@ describe('Interaction Row Column Resize Tests', () => {
       },
       resizeInfo,
     );
-    expect(s2.tooltip.container.style.pointerEvents).not.toEqual('all');
+    expect(s2.hideTooltip).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -363,13 +363,14 @@ describe('Interaction Row Column Resize Tests', () => {
 
   test('should hidden tooltip when resize start', () => {
     const resizeInfo: ResizeInfo = {
-      type: 'row',
+      theme: {},
+      type: ResizeAreaType.Row,
       offsetX: 2,
       offsetY: 2,
       width: 5,
       height: 2,
       isResizeArea: true,
-      affect: 'cell',
+      effect: ResizeAreaEffect.Cell,
       caption: 'filedB',
       id: '',
     };

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -85,6 +85,7 @@ describe('Interaction Row Column Resize Tests', () => {
     rowColumnResizeInstance = new RowColumnResize(s2);
     rowColumnResizeInstance.getHeaderGroup = () => new Group('');
     s2.render = jest.fn();
+    s2.tooltip.container = document.createElement('div');
   });
 
   test('should register events', () => {
@@ -351,5 +352,29 @@ describe('Interaction Row Column Resize Tests', () => {
 
     // reset resize position
     expect(rowColumnResizeInstance.resizeStartPosition).toEqual({});
+  });
+
+  test('should disable tooltip point event when mouse down', () => {
+    const resizeInfo: ResizeInfo = {
+      type: 'row',
+      offsetX: 2,
+      offsetY: 2,
+      width: 5,
+      height: 2,
+      isResizeArea: true,
+      affect: 'cell',
+      caption: 'filedB',
+      id: '',
+    };
+
+    emitResizeEvent(
+      S2Event.LAYOUT_RESIZE_MOUSE_DOWN,
+      {
+        offsetX: 10,
+        offsetY: 20,
+      },
+      resizeInfo,
+    );
+    expect(s2.tooltip.container.style.pointerEvents).not.toEqual('all');
   });
 });

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -62,6 +62,7 @@ export const createFakeSpreadSheet = () => {
   s2.getCellType = jest.fn();
   s2.render = jest.fn();
   s2.hideTooltip = jest.fn();
+  s2.showTooltip = jest.fn();
   s2.showTooltipWithInfo = jest.fn();
 
   const interaction = new RootInteraction(s2 as unknown as SpreadSheet);

--- a/packages/s2-core/__tests__/util/sheet-entry.tsx
+++ b/packages/s2-core/__tests__/util/sheet-entry.tsx
@@ -78,6 +78,7 @@ export const SheetEntry = forwardRef(
       ? props.dataCfg
       : assembleDataCfg(props.dataCfg);
     const [adaptive, setAdaptive] = useState(false);
+    const [showResizeArea, setShowResizeArea] = useState(true);
     const [options, setOptions] = useState<S2Options>(() => initOptions);
     const [dataCfg, setDataCfg] = useState<Partial<S2DataConfig>>(
       () => initDataCfg,
@@ -189,11 +190,19 @@ export const SheetEntry = forwardRef(
             onChange={onFreezeRowHeaderChange}
           />
           <Switch
-            checkedChildren="容器自适应开"
-            unCheckedChildren="容器自适应关"
+            checkedChildren="容器宽高自适应开"
+            unCheckedChildren="容器宽高自适应关"
             defaultChecked={adaptive}
             onChange={(checked) => {
               setAdaptive(checked);
+            }}
+          />
+          <Switch
+            checkedChildren="resize热区开"
+            unCheckedChildren="resize热区关"
+            defaultChecked={showResizeArea}
+            onChange={(checked) => {
+              setShowResizeArea(checked);
             }}
           />
           <Space>
@@ -254,7 +263,14 @@ export const SheetEntry = forwardRef(
               ref.current = instance;
             }
           }}
-          themeCfg={props.themeCfg}
+          themeCfg={{
+            ...props.themeCfg,
+            theme: merge({}, props.themeCfg.theme, {
+              resizeArea: {
+                backgroundOpacity: showResizeArea ? 1 : 0,
+              },
+            }),
+          }}
           onColCellClick={props.onColCellClick}
         />
       </div>

--- a/packages/s2-core/__tests__/util/sheet-entry.tsx
+++ b/packages/s2-core/__tests__/util/sheet-entry.tsx
@@ -59,6 +59,7 @@ interface SheetEntryProps {
 // eslint-disable-next-line react/display-name
 export const SheetEntry = forwardRef(
   (props: SheetEntryProps, ref: MutableRefObject<SpreadSheet>) => {
+    const { themeCfg = {} } = props;
     const [mode, setMode] = useState('grid');
     const [valueInCols, setValueInCols] = useState(true);
     const initOptions = assembleOptions(props.options);
@@ -252,8 +253,8 @@ export const SheetEntry = forwardRef(
             }
           }}
           themeCfg={{
-            ...props.themeCfg,
-            theme: merge({}, props.themeCfg.theme, {
+            ...themeCfg,
+            theme: merge({}, themeCfg.theme, {
               resizeArea: {
                 backgroundOpacity: showResizeArea ? 1 : 0,
               },

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -93,6 +93,8 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
     }
     const { interaction } = this.spreadsheet;
     const activeCells = interaction.getActiveCells();
+    interaction.clearHoverTimer();
+
     // 避免在统一单元格内鼠标移动造成的多次渲染
     if (isEqual(activeCells?.[0], cell)) {
       return;

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -148,6 +148,8 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
         return;
       }
 
+      // 防止在拖拽过程中 鼠标在 tooltip 上面 导致拖拽失效
+      this.spreadsheet.tooltip.disablePointerEvent();
       this.spreadsheet.interaction.addIntercepts([InterceptType.RESIZE]);
       this.setResizeArea(shape);
       this.showResizeGroup();
@@ -312,8 +314,6 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
 
   private resizeMouseMove = (event: CanvasEvent) => {
     if (!this.resizeGroup?.get('visible')) {
-      // 鼠标在 resize 热区 时, 将 tooltip 关闭, 避免造成干扰
-      this.spreadsheet.hideTooltip();
       return;
     }
     event.preventDefault();

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -148,8 +148,8 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
         return;
       }
 
-      // 防止在拖拽过程中 鼠标在 tooltip 上面 导致拖拽失效
-      this.spreadsheet.tooltip.disablePointerEvent();
+      // 鼠标在 resize 热区 按下时, 将 tooltip 关闭, 避免造成干扰
+      this.spreadsheet.hideTooltip();
       this.spreadsheet.interaction.addIntercepts([InterceptType.RESIZE]);
       this.setResizeArea(shape);
       this.showResizeGroup();

--- a/packages/s2-core/src/ui/tooltip/index.tsx
+++ b/packages/s2-core/src/ui/tooltip/index.tsx
@@ -27,10 +27,7 @@ import { Interpretation } from '@/ui/tooltip/components/interpretation';
 import { TooltipOperator } from '@/ui/tooltip/components/operator';
 import { SimpleTips } from '@/ui/tooltip/components/simple-tips';
 import { TooltipSummary } from '@/ui/tooltip/components/summary';
-import {
-  TOOLTIP_CONTAINER_CLS,
-  TOOLTIP_PREFIX_CLS,
-} from '@/common/constant/tooltip';
+import { TOOLTIP_CONTAINER_CLS } from '@/common/constant/tooltip';
 
 import './index.less';
 
@@ -115,9 +112,14 @@ export class BaseTooltip {
   }
 
   public disablePointerEvent() {
+    if (!this.container) {
+      return;
+    }
+
     if (this.container.style.pointerEvents === 'none') {
       return;
     }
+
     setContainerStyle(this.container, {
       style: {
         pointerEvents: 'none',


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and closes #601 #602

### 📝 Description

1. 修复 data cell timer 未取消, 导致鼠标在 行/列头 时, 任然显示 data cell 的 tooltip
> 鼠标悬停在 数值单元格时 => 然后鼠标移动到 行/列 头

2. 修复 tooltip 打开后, 鼠标移动到 resize 热区 tooltip 会关闭的问题

> 之前关闭tooltip 是为了防止tooltip 对拖拽造成干扰, 现在还是改为 拖拽时 让 tooltip 光标失效 (避免拖拽过程中鼠标在tooltip上无法继续拖动)

### 🖼️ Screenshot

![Kapture 2021-11-02 at 12 59 25](https://user-images.githubusercontent.com/21015895/139789201-5184e934-51dd-44ec-9439-c8873a5d0eaa.gif)



### 🔗 Related issue link

close #601 
close #602

<!-- close #0 -->
