### PR TITLE
chore(ci): support prerelease notify

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -52,6 +52,7 @@ jobs:
           notify_title: '🎉 {release_tag} 发布 🎉'
           notify_body: '### { title }<hr /> ![preview](https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png) <hr /> { body } <hr />'
           at_all: false
+          enable_prerelease: ${{ github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha' }}
 
       # 金牌服务群
       - name: Release success ding talk dev group notify
@@ -62,6 +63,7 @@ jobs:
           notify_title: '🎉 {release_tag} 发布 🎉'
           notify_body: '### { title }<hr /> ![preview](https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png) <hr /> { body } <hr />'
           at_all: false
+          enable_prerelease: ${{ github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha' }}
 
       # 发布失败推送通知内部开发群
       - name: Release failed ding talk dev group notify

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -80,3 +80,15 @@ jobs:
             你好 @${{ github.event.issue.user.login }}，Issue 板块是用于 bug 反馈与需求讨论的地方。你可以试着在 [antv s2 discussions](https://github.com/antvis/S2/discussions) 新开一个 discussion，选择 `🙏Q&A` 类别进行提问, 我们会及时进行解答, 感谢你的理解。
 
             Hello, @${{ github.event.issue.user.login }}. The Issue section is used for bug feedback and requirement discussion. You can try to open a new discussion in [antv s2 discussions](https://github.com/antvis/S2/discussions), choose the `🙏Q&A` category to ask questions, we will answer in time. Thank you so much for being so understanding.
+
+      - name: Accepted
+        if: github.event.label.name == '✅ accepted'
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            你好 @${{ github.event.issue.user.login }}，经过我们的反复讨论, 你的需求现已被采纳, 我们会排期开发, 请关注后续发布日志.
+
+            Hello, @${{ github.event.issue.user.login }}, After our repeated discussion, your feature request have been accepted, we will schedule the development, please pay attention to the subsequent release log


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🔧 Chore

- [x] CI / workflow

### 📝 Description

支持 预发布版本 的 钉钉通知

1. 给 dingtalk-release-notify 提了一个 [PR](https://github.com/visiky/dingtalk-release-notify/pull/5), 经过测试, 暂无问题

 - beta 和 alpha 分支 发布 pre release npm 包 采用 pre release  通知
 - master 分支 发布 正式版 npm 包  使用 正式的 release 通知
![image](https://user-images.githubusercontent.com/21015895/139840033-7d158acc-5797-4de1-b094-13d39652a038.png)

![image](https://user-images.githubusercontent.com/21015895/139840118-6fe35b30-3854-4c98-8c59-ad758e81f204.png)

2. 增加需求被采纳的 label

