### PR TITLE
feat(table): add shadow for frozen line

### DIFF
--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -155,8 +155,8 @@ export interface SplitLine {
   verticalBorderColorOpacity?: number;
   /* 垂直分割线宽度 */
   verticalBorderWidth?: number;
-  /* 分割线是否显示右侧外阴影 */
-  showRightShadow?: boolean;
+  /* 分割线是否显示外阴影 */
+  showShadow?: boolean;
   /* 阴影宽度 */
   shadowWidth?: number;
   /* 阴影线性渐变色 */

--- a/packages/s2-core/src/facet/header/frame.ts
+++ b/packages/s2-core/src/facet/header/frame.ts
@@ -120,7 +120,7 @@ export class Frame extends Group {
     }
     const splitLine = spreadsheet.theme?.splitLine;
     if (
-      splitLine.showRightShadow &&
+      splitLine.showShadow &&
       showViewPortRightShadow &&
       this.cfg.spreadsheet.isFreezeRowHeader()
     ) {

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -462,6 +462,11 @@ export class TableFacet extends BaseFacet {
     return totalHeight;
   };
 
+  private getShadowFill = (angle: number) => {
+    const style: SplitLine = get(this.cfg, 'spreadsheet.theme.splitLine');
+    return `l (${angle}) 0:${style.shadowColors?.left} 1:${style.shadowColors?.right}`;
+  };
+
   protected renderFrozenGroupSplitLine = () => {
     const {
       frozenRowCount,
@@ -506,6 +511,18 @@ export class TableFacet extends BaseFacet {
           ...verticalBorderStyle,
         },
       );
+
+      if (style.showShadow) {
+        this.foregroundGroup.addShape('rect', {
+          attrs: {
+            x,
+            y: this.cornerBBox.height,
+            width: style.shadowWidth,
+            height: this.panelBBox.maxY - this.cornerBBox.height,
+            fill: this.getShadowFill(0),
+          },
+        });
+      }
     }
 
     if (frozenRowCount > 0) {
@@ -524,6 +541,18 @@ export class TableFacet extends BaseFacet {
           ...horizontalBorderStyle,
         },
       );
+
+      if (style.showShadow) {
+        this.foregroundGroup.addShape('rect', {
+          attrs: {
+            x: 0,
+            y: y,
+            width: this.panelBBox.width,
+            height: style.shadowWidth,
+            fill: this.getShadowFill(90),
+          },
+        });
+      }
     }
 
     if (frozenTrailingColCount > 0) {
@@ -548,6 +577,18 @@ export class TableFacet extends BaseFacet {
           ...verticalBorderStyle,
         },
       );
+
+      if (style.showShadow) {
+        this.foregroundGroup.addShape('rect', {
+          attrs: {
+            x: x - style.shadowWidth,
+            y: this.cornerBBox.height,
+            width: style.shadowWidth,
+            height: this.panelBBox.maxY - this.cornerBBox.height,
+            fill: this.getShadowFill(180),
+          },
+        });
+      }
     }
 
     if (frozenTrailingRowCount > 0) {
@@ -569,6 +610,18 @@ export class TableFacet extends BaseFacet {
           ...horizontalBorderStyle,
         },
       );
+
+      if (style.showShadow) {
+        this.foregroundGroup.addShape('rect', {
+          attrs: {
+            x: 0,
+            y: y - style.shadowWidth,
+            width: this.panelBBox.width,
+            height: style.shadowWidth,
+            fill: this.getShadowFill(270),
+          },
+        });
+      }
     }
   };
 

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -323,7 +323,7 @@ export const getTheme = (
       verticalBorderColor: basicColors[11],
       verticalBorderColorOpacity: 1,
       verticalBorderWidth: 2,
-      showRightShadow: true,
+      showShadow: true,
       shadowWidth: 10,
       shadowColors: {
         left: 'rgba(0,0,0,0.1)',

--- a/s2-site/docs/api/general/S2Theme.zh.md
+++ b/s2-site/docs/api/general/S2Theme.zh.md
@@ -102,7 +102,7 @@ order: 2
 | verticalBorderColor | `string` | | | 垂直分割线颜色 |
 | verticalBorderColorOpacity | `number` | | 1 | 垂直分割线颜色透明度 |
 | verticalBorderWidth | `number` | | 2 | 垂直分割线宽度 |
-| showRightShadow | `boolean` | | `true` | 分割线是否显示右侧外阴影(透视表行头冻结情况下) |
+| showShadow | `boolean` | | `true` | 分割线是否显示外阴影(行列冻结情况下) |
 | shadowWidth | `number` | | 10 | 阴影宽度 |
 | shadowColors | `{left: string,` <br> `right: string}` | | `{left: 'rgba(0,0,0,0.1)',`<br>`right: 'rgba(0,0,0,0)'}` | `left` : 线性变化左侧颜色  <br> `right` : 线性变化右侧颜色 |
 


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

明细表行列冻结时添加阴影。把之前主题配置中的 showRightShadow 改为了 showShadow。统一控制交叉表和明细表的 shadow 展示。

![image](https://user-images.githubusercontent.com/10339692/140000942-847c5e23-0e10-40f4-999b-9de032cf2b15.png)

