### PR TITLE
fix(component): fix not use container width when enable adaptive and first rendered

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-609-spec.tsx
+++ b/packages/s2-core/__tests__/bugs/issue-609-spec.tsx
@@ -1,0 +1,120 @@
+/**
+ * @description spec for issue #609
+ * https://github.com/antvis/S2/issues/609
+ * Wrong table width and height when enable adaptive
+ *
+ */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { getContainer, sleep } from 'tests/util/helpers';
+import { SheetComponent } from '@/components/sheets';
+import { SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+
+interface Props {
+  containerWidth: number;
+  adaptive?: boolean;
+  containerId?: string;
+}
+
+const s2Options: S2Options = {
+  width: 200,
+  height: 200,
+};
+
+let s2: SpreadSheet;
+
+function MainLayout({ containerWidth, adaptive, containerId }: Props) {
+  return (
+    <div
+      id={containerId}
+      style={{
+        width: containerWidth,
+      }}
+    >
+      <SheetComponent
+        adaptive={adaptive}
+        sheetType="pivot"
+        dataCfg={mockDataConfig}
+        options={s2Options}
+        themeCfg={{ name: 'default' }}
+        getSpreadSheet={(instance) => {
+          s2 = instance;
+        }}
+      />
+    </div>
+  );
+}
+
+describe('SheetComponent adaptive Tests', () => {
+  beforeEach(() => {
+    s2 = null;
+  });
+  test('should use container width when table first rendered', () => {
+    act(() => {
+      ReactDOM.render(
+        <MainLayout adaptive containerWidth={400} />,
+        getContainer(),
+      );
+    });
+
+    expect(s2.options.width).toEqual(400);
+    expect(s2.container.cfg.width).toEqual(400);
+  });
+
+  test('should use container width when container width less than options width and table first rendered', () => {
+    act(() => {
+      ReactDOM.render(
+        <MainLayout adaptive containerWidth={s2Options.width - 100} />,
+        getContainer(),
+      );
+    });
+
+    expect(s2.options.width).toEqual(s2Options.width - 100);
+    expect(s2.container.cfg.width).toEqual(s2Options.width - 100);
+  });
+
+  test('should use option width when table first rendered, and disable adaptive', () => {
+    act(() => {
+      ReactDOM.render(
+        <MainLayout adaptive={false} containerWidth={1000} />,
+        getContainer(),
+      );
+    });
+
+    expect(s2.options.width).toEqual(s2Options.width);
+    expect(s2.container.cfg.width).toEqual(s2Options.width);
+  });
+
+  test('should update table width when container resize', async () => {
+    const newContainerWidth = 1000;
+
+    act(() => {
+      ReactDOM.render(
+        <MainLayout
+          adaptive
+          containerId="testContainer"
+          containerWidth={200}
+        />,
+        getContainer(),
+      );
+    });
+
+    act(() => {
+      document
+        .querySelector('#testContainer')
+        .setAttribute('style', `width: ${newContainerWidth}px`);
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    await sleep(1000);
+
+    expect(s2.options.width).toEqual(newContainerWidth);
+    expect(s2.container.cfg.width).toEqual(newContainerWidth);
+  });
+});

--- a/packages/s2-core/src/components/sheets/hooks.ts
+++ b/packages/s2-core/src/components/sheets/hooks.ts
@@ -32,9 +32,11 @@ export const useResizeEffect = (
   }, [resizeTimeStamp, container, s2, adaptive]);
 
   useEffect(() => {
-    s2?.changeSize(options.width, options.height);
-    s2?.render(false);
-  }, [s2, options.width, options.height]);
+    if (!adaptive) {
+      s2?.changeSize(options.width, options.height);
+      s2?.render(false);
+    }
+  }, [s2, options.width, options.height, adaptive]);
 
   useEffect(() => {
     if (adaptive) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #609


### 📝 Description

1. 修复 开启 `adaptive` 后, 首次渲染并没有按照容器宽度渲染

原因: 先走第一个 `useEffect` 渲染为 容器宽度, 然后又走了第二个 `useEffect` 又重置为 s2Options 配置的宽度, 实际渲染了两次


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/140313433-45abb756-8861-436b-8da0-b3d60386cecc.png) | ![image](https://user-images.githubusercontent.com/21015895/140313407-fa27712b-e4dc-4569-b802-76d9fae58c13.png) |

### 🔗 Related issue link

close #609 

<!-- close #0 -->
