### PR TITLE
fix(scroll): set scroll move event target to body

### DIFF
--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -43,7 +43,6 @@ export const SHAPE_STYLE_MAP = {
 export const SHAPE_ATTRS_MAP = {
   textShape: ['textOpacity'],
   linkFieldShape: ['opacity'],
-  backgroundShape: ['backgroundOpacity'],
   interactiveBgShape: ['backgroundColor', 'backgroundOpacity'],
   interactiveBorderShape: ['borderColor', 'borderOpacity'],
 };

--- a/packages/s2-core/src/ui/scrollbar/index.ts
+++ b/packages/s2-core/src/ui/scrollbar/index.ts
@@ -318,7 +318,7 @@ export class ScrollBar extends Group {
 
   private bindLaterEvent = () => {
     const canvas = this.get('canvas');
-    const containerDOM: EventTarget = canvas.get('container');
+    const containerDOM: EventTarget = document.body;
 
     let events: EventListenerReturn[] = [];
     if (this.isMobile) {


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

1. 修复选中态的一个问题，当 DataCell 选中态的背景色为透明时，因为 SHAPE_ATTRS_MAP 中存在 backgroundShape: ['backgroundOpacity'] 的多余映射，DataCell 选中时，背景色（backgroundShape）的透明度也会被改变，就会发现点击一个格子之后背景颜色就彻底变了。复现只需要设置 theme.dataCell.cell.interactionState.selected.backgroundOpacity 小于1 即可。

2. 横向滚动条，主要用鼠标的用户会比较常用，直接拖动横向滚动条。目前 mousemove 的事件绑定在 container 上，如果用户鼠标往下移动一点就出了范围，滚动就会中断，体验不太好。放到 body 上就可以解决这个问题。
