### PR TITLE
fix(interaction): hide tooltip and clear hover highlight if mouseleave the cell

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/merge.spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge.spec.ts
@@ -80,7 +80,7 @@ describe('merge test', () => {
       interaction: {
         linkFields: [],
         hiddenColumnFields: [],
-        selectedCellsSpotlight: true,
+        selectedCellsSpotlight: false,
         hoverHighlight: true,
         scrollSpeedRatio: {
           horizontal: 1,

--- a/packages/s2-core/__tests__/util/sheet-entry.tsx
+++ b/packages/s2-core/__tests__/util/sheet-entry.tsx
@@ -71,7 +71,7 @@ export const SheetEntry = forwardRef(
       ? props.dataCfg
       : assembleDataCfg(props.dataCfg);
     const [adaptive, setAdaptive] = useState(false);
-    const [showResizeArea, setShowResizeArea] = useState(true);
+    const [showResizeArea, setShowResizeArea] = useState(false);
     const [options, setOptions] = useState<S2Options>(() => initOptions);
     const [dataCfg, setDataCfg] = useState<Partial<S2DataConfig>>(
       () => initDataCfg,

--- a/packages/s2-core/src/common/constant/events/origin.ts
+++ b/packages/s2-core/src/common/constant/events/origin.ts
@@ -1,10 +1,12 @@
 export enum OriginEventType {
   MOUSE_DOWN = 'mousedown',
   MOUSE_MOVE = 'mousemove',
+  MOUSE_OUT = 'mouseout',
   MOUSE_UP = 'mouseup',
   KEY_DOWN = 'keydown',
   KEY_UP = 'keyup',
   CLICK = 'click',
+  HOVER = 'hover',
   DOUBLE_CLICK = 'dblclick',
   CONTEXT_MENU = 'contextmenu',
 }

--- a/packages/s2-core/src/common/constant/options.ts
+++ b/packages/s2-core/src/common/constant/options.ts
@@ -44,7 +44,7 @@ export const DEFAULT_OPTIONS: Readonly<S2Options> = {
   interaction: {
     linkFields: [],
     hiddenColumnFields: [],
-    selectedCellsSpotlight: true,
+    selectedCellsSpotlight: false,
     hoverHighlight: true,
     scrollSpeedRatio: {
       horizontal: 1,

--- a/packages/s2-core/src/common/constant/tooltip.ts
+++ b/packages/s2-core/src/common/constant/tooltip.ts
@@ -24,7 +24,7 @@ export const TOOLTIP_DEFAULT_ICON_PROPS: Partial<HtmlIconProps> = {
 };
 
 export const TOOLTIP_POSITION_OFFSET: TooltipPosition = {
-  x: 10,
+  x: 15,
   y: 10,
 };
 

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -49,11 +49,16 @@ export class EventController {
     return this.spreadsheet.container;
   }
 
+  public get isAutoResetSheetStyle() {
+    return this.spreadsheet.options.interaction.autoResetSheetStyle;
+  }
+
   public bindEvents() {
     this.clearAllEvents();
 
     this.addCanvasEvent(OriginEventType.MOUSE_DOWN, this.onCanvasMousedown);
     this.addCanvasEvent(OriginEventType.MOUSE_MOVE, this.onCanvasMousemove);
+    this.addCanvasEvent(OriginEventType.MOUSE_OUT, this.onCanvasMouseout);
     this.addCanvasEvent(OriginEventType.MOUSE_UP, this.onCanvasMouseup);
     this.addCanvasEvent(OriginEventType.DOUBLE_CLICK, this.onCanvasDoubleClick);
     this.addCanvasEvent(OriginEventType.CONTEXT_MENU, this.onCanvasContextMenu);
@@ -116,8 +121,7 @@ export class EventController {
   }
 
   private resetSheetStyle(event: Event) {
-    const { autoResetSheetStyle } = this.spreadsheet.options.interaction;
-    if (!autoResetSheetStyle) {
+    if (!this.isAutoResetSheetStyle) {
       return;
     }
 
@@ -406,6 +410,16 @@ export class EventController {
             break;
         }
       }
+    }
+  };
+
+  private onCanvasMouseout = () => {
+    if (!this.isAutoResetSheetStyle) {
+      return;
+    }
+    const { interaction } = this.spreadsheet;
+    if (!interaction.isSelectedState()) {
+      interaction.reset();
     }
   };
 

--- a/s2-site/docs/common/interaction.zh.md
+++ b/s2-site/docs/common/interaction.zh.md
@@ -9,7 +9,7 @@ order: 5
 | 参数 | 类型 | 必选  | 默认值 | 功能描述 |
 | :-- | :-- | :-: | :-- | --- |
 | linkFields | `string[]` |  |  | 标记字段为链接样式，用于外链跳转 |
-| selectedCellsSpotlight | `boolean` |   | `true` | 是否开启选中高亮聚光灯效果 |
+| selectedCellsSpotlight | `boolean` |   | `false` | 是否开启选中高亮聚光灯效果 |
 | hoverHighlight | `boolean` |   | `true` | 鼠标悬停时高亮当前单元格，以及所对应的行头，列头 |
 | hiddenColumnFields | `string[]` |  |  | 隐藏列 （明细表有效） |
 | enableCopy | `boolean` |   | `false` | 是否允许复制 |

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -169,12 +169,12 @@ const s2Options = {
 
 ![preview](https://gw.alipayobjects.com/zos/antfincdn/Z0nENy85%26/929f6638-a19f-4a6c-9ad8-a9a6ef2269c3.png)
 
-默认情况下，我们会在选中单元格后，置灰未选中的单元格，强调需要关注的数据，可配置 `selectedCellsSpotlight` 关闭：
+在选中单元格后，如果需要置灰未选中的单元格，强调需要关注的数据，可配置 `selectedCellsSpotlight` 开启：
 
 ```ts
 const s2options = {
   interaction: {
-    selectedCellsSpotlight: false,
+    selectedCellsSpotlight: true, // 默认 false
   }
 };
 ```


### PR DESCRIPTION

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复鼠标移出单元格, 或者表格区域时, `tooltip` 未关闭, 未取消单元格高亮
2. 增大 `tooltip` 和光标的距离
3. 修复移出单元格, 依然显示 tooltip 的问题
4. 选中聚光灯改为默认关闭

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2021-11-05 at 15 36 16](https://user-images.githubusercontent.com/21015895/140474800-4e31efef-a8b5-4e98-a201-ae84e200cd14.gif) | ![Kapture 2021-11-05 at 15 33 24](https://user-images.githubusercontent.com/21015895/140474422-35267e6b-2c11-4b14-8c34-13e1e6468651.gif)|

### 🔗 Related issue link

<!-- close #0 -->
