### PR TITLE
fix(interaction): wrong hidden action tooltip when mouse outside the cell

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -497,4 +497,11 @@ describe('Interaction Event Controller Tests', () => {
     spreadsheet.container.emit(OriginEventType.MOUSE_OUT);
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
+
+  test('should disable reset if mouse outside the cell and action tooltip is active', () => {
+    spreadsheet.interaction.addIntercepts([InterceptType.HOVER]);
+
+    spreadsheet.container.emit(OriginEventType.MOUSE_OUT);
+    expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
+  });
 });

--- a/packages/s2-core/__tests__/util/sheet-entry.tsx
+++ b/packages/s2-core/__tests__/util/sheet-entry.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   useState,
 } from 'react';
-import { Input, Select, Slider, Space, Switch } from 'antd';
+import { Input, Select, Slider, Space, Switch, Tooltip } from 'antd';
 import { merge } from 'lodash';
 import { data, totalData, meta } from '../data/mock-dataset.json';
 import {
@@ -24,7 +24,7 @@ import {
 import 'antd/dist/antd.min.css';
 import { customMerge } from '@/utils/merge';
 
-export const assembleOptions = (...options: Partial<S2Options>[]) =>
+export const assembleOptions = (...options: Partial<S2Options>[]): S2Options =>
   customMerge(
     DEFAULT_OPTIONS,
     { debug: true, width: 1000, height: 600 },
@@ -123,6 +123,16 @@ export const SheetEntry = forwardRef(
       );
     };
 
+    const onAutoResetSheetStyleChange = (checked: boolean) => {
+      setOptions(
+        merge({}, options, {
+          interaction: {
+            autoResetSheetStyle: checked,
+          },
+        }),
+      );
+    };
+
     useEffect(() => {
       setOptions(assembleOptions(options, props.options));
     }, [props.options]);
@@ -209,12 +219,23 @@ export const SheetEntry = forwardRef(
               setShowResizeArea(checked);
             }}
           />
+          <Tooltip title="开启后,点击空白处,按下ESC键, 取消高亮, 清空选中单元格, 等交互样式">
+            <Switch
+              checkedChildren="自动重置交互样式开"
+              unCheckedChildren="自动重置交互样式关"
+              defaultChecked={initOptions.interaction.autoResetSheetStyle}
+              onChange={onAutoResetSheetStyleChange}
+            />
+          </Tooltip>
           <Space>
-            tooltip 自动调整:
+            <Tooltip title="显示的tooltip超过指定区域时自动调整, 使其不遮挡">
+              tooltip 自动调整:
+            </Tooltip>
             <Select
               defaultValue={options.tooltip.autoAdjustBoundary}
               onChange={onAutoAdjustBoundary}
-              style={{ width: 200 }}
+              style={{ width: 180 }}
+              size="small"
             >
               <Select.Option value="container">
                 container (表格区域)
@@ -231,6 +252,7 @@ export const SheetEntry = forwardRef(
               onChange={onSizeChange('width')}
               defaultValue={options.width}
               suffix="px"
+              size="small"
             />
             设置高度 ：
             <Input
@@ -239,6 +261,7 @@ export const SheetEntry = forwardRef(
               onChange={onSizeChange('height')}
               defaultValue={options.height}
               suffix="px"
+              size="small"
             />
           </Space>
         </Space>

--- a/packages/s2-core/src/common/constant/events/origin.ts
+++ b/packages/s2-core/src/common/constant/events/origin.ts
@@ -2,6 +2,7 @@ export enum OriginEventType {
   MOUSE_DOWN = 'mousedown',
   MOUSE_MOVE = 'mousemove',
   MOUSE_OUT = 'mouseout',
+  MOUSE_LEAVE = 'mouseleave',
   MOUSE_UP = 'mouseup',
   KEY_DOWN = 'keydown',
   KEY_UP = 'keyup',

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -418,7 +418,11 @@ export class EventController {
       return;
     }
     const { interaction } = this.spreadsheet;
-    if (!interaction.isSelectedState()) {
+    // 两种情况不能重置 1. 选中单元格 2. 有交互功能的tooltip打开时
+    if (
+      !interaction.isSelectedState() &&
+      !interaction.hasIntercepts([InterceptType.HOVER])
+    ) {
       interaction.reset();
     }
   };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

修复组内排序tooltip 和 自定义tooltip 打开时鼠标从单元格移开 tooltip 会关闭的问题

- [x] tooltip 在表格内打开
- [x] tooltip 在表格外打开

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ![Kapture 2021-11-08 at 11 27 39](https://user-images.githubusercontent.com/21015895/140679772-7c4cfa80-8a63-4a68-a9c0-8bc7d89109dd.gif) | ![Kapture 2021-11-08 at 11 26 51](https://user-images.githubusercontent.com/21015895/140679706-99a4b013-5b90-4e4e-8113-d9ac63949eb3.gif)|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
