### PR TITLE
refactor: optimize sortedDimensionValues's structure by change map to object for saving repeat value and modify test

### DIFF
--- a/packages/s2-core/__tests__/unit/dataset/pivot-dataset-row-value-spec.ts
+++ b/packages/s2-core/__tests__/unit/dataset/pivot-dataset-row-value-spec.ts
@@ -1,7 +1,7 @@
 /**
  * pivot mode data-set test when value in row.
  */
-import { get } from 'lodash';
+import { get, keys } from 'lodash';
 import { assembleDataCfg } from '../../util/sheet-entry';
 import { EXTRA_FIELD, VALUE_FIELD } from '@/common/constant';
 import { S2DataConfig } from '@/common/interface';
@@ -122,18 +122,15 @@ describe('Pivot Mode Test When Value In Row', () => {
 
     test('should get correct sorted dimension value', () => {
       const sortedDimensionValues = dataSet.sortedDimensionValues;
-      expect([...sortedDimensionValues.keys()]).toEqual([
+      expect([...keys(sortedDimensionValues)]).toEqual([
         'province',
         'city',
         EXTRA_FIELD,
         'type',
         'sub_type',
       ]);
-      expect([...sortedDimensionValues.get('province')]).toEqual([
-        '浙江省',
-        '四川省',
-      ]);
-      expect([...sortedDimensionValues.get('city')]).toEqual([
+      expect([...sortedDimensionValues.province]).toEqual(['浙江省', '四川省']);
+      expect([...sortedDimensionValues.city]).toEqual([
         '杭州市',
         '绍兴市',
         '宁波市',
@@ -143,17 +140,14 @@ describe('Pivot Mode Test When Value In Row', () => {
         '南充市',
         '乐山市',
       ]);
-      expect([...sortedDimensionValues.get('type')]).toEqual([
-        '家具',
-        '办公用品',
-      ]);
-      expect([...sortedDimensionValues.get('sub_type')]).toEqual([
+      expect([...sortedDimensionValues.type]).toEqual(['家具', '办公用品']);
+      expect([...sortedDimensionValues.sub_type]).toEqual([
         '桌子',
         '沙发',
         '笔',
         '纸张',
       ]);
-      expect([...sortedDimensionValues.get(EXTRA_FIELD)]).toEqual(['number']);
+      expect([...sortedDimensionValues[EXTRA_FIELD]]).toEqual(['number']);
     });
   });
 

--- a/packages/s2-core/__tests__/unit/dataset/pivot-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/dataset/pivot-dataset-spec.ts
@@ -1,7 +1,7 @@
 /**
  * pivot mode base data-set test.
  */
-import { get } from 'lodash';
+import { get, keys } from 'lodash';
 import { assembleDataCfg } from '../../util/sheet-entry';
 import { data as drillDownData } from '../../data/mock-drill-down-dataset.json';
 import { ViewMeta } from '@/common/interface';
@@ -123,18 +123,15 @@ describe('Pivot Dataset Test', () => {
 
     test('should get correct sorted dimension value', () => {
       const sortedDimensionValues = dataSet.sortedDimensionValues;
-      expect([...sortedDimensionValues.keys()]).toEqual([
+      expect([...keys(sortedDimensionValues)]).toEqual([
         'province',
         'city',
         'type',
         'sub_type',
         EXTRA_FIELD,
       ]);
-      expect([...sortedDimensionValues.get('province')]).toEqual([
-        '浙江省',
-        '四川省',
-      ]);
-      expect([...sortedDimensionValues.get('city')]).toEqual([
+      expect([...sortedDimensionValues.province]).toEqual(['浙江省', '四川省']);
+      expect([...sortedDimensionValues.city]).toEqual([
         '杭州市',
         '绍兴市',
         '宁波市',
@@ -144,17 +141,14 @@ describe('Pivot Dataset Test', () => {
         '南充市',
         '乐山市',
       ]);
-      expect([...sortedDimensionValues.get('type')]).toEqual([
-        '家具',
-        '办公用品',
-      ]);
-      expect([...sortedDimensionValues.get('sub_type')]).toEqual([
+      expect([...sortedDimensionValues.type]).toEqual(['家具', '办公用品']);
+      expect([...sortedDimensionValues.sub_type]).toEqual([
         '桌子',
         '沙发',
         '笔',
         '纸张',
       ]);
-      expect([...sortedDimensionValues.get(EXTRA_FIELD)]).toEqual(['number']);
+      expect([...sortedDimensionValues[EXTRA_FIELD]]).toEqual(['number']);
     });
   });
 

--- a/packages/s2-core/__tests__/unit/dataset/pivot-dataset-total-spec.ts
+++ b/packages/s2-core/__tests__/unit/dataset/pivot-dataset-total-spec.ts
@@ -1,7 +1,7 @@
 /**
  * pivot mode base data-set test.
  */
-import { get } from 'lodash';
+import { get, keys } from 'lodash';
 import { assembleDataCfg } from '../../util/sheet-entry';
 import { EXTRA_FIELD, VALUE_FIELD } from '@/common/constant';
 import { S2DataConfig } from '@/common/interface';
@@ -107,19 +107,19 @@ describe('Pivot Dataset Total Test', () => {
 
     test('should get correct sorted dimension value', () => {
       const sortedDimensionValues = dataSet.sortedDimensionValues;
-      expect([...sortedDimensionValues.keys()]).toEqual([
+      expect([...keys(sortedDimensionValues)]).toEqual([
         'province',
         'city',
         'type',
         'sub_type',
         EXTRA_FIELD,
       ]);
-      expect([...sortedDimensionValues.get('province')]).toEqual([
+      expect([...sortedDimensionValues.province]).toEqual([
         '浙江省',
         '四川省',
         undefined,
       ]);
-      expect([...sortedDimensionValues.get('city')]).toEqual([
+      expect([...sortedDimensionValues.city]).toEqual([
         '杭州市',
         '绍兴市',
         '宁波市',
@@ -129,20 +129,24 @@ describe('Pivot Dataset Total Test', () => {
         '南充市',
         '乐山市',
         undefined,
+        undefined,
+        undefined,
       ]);
-      expect([...sortedDimensionValues.get('type')]).toEqual([
+      expect([...sortedDimensionValues.type]).toEqual([
         '家具',
         '办公用品',
         undefined,
       ]);
-      expect([...sortedDimensionValues.get('sub_type')]).toEqual([
+      expect([...sortedDimensionValues.sub_type]).toEqual([
         '桌子',
         '沙发',
         '笔',
         '纸张',
         undefined,
+        undefined,
+        undefined,
       ]);
-      expect([...sortedDimensionValues.get(EXTRA_FIELD)]).toEqual(['number']);
+      expect([...sortedDimensionValues[EXTRA_FIELD]]).toEqual(['number']);
     });
   });
 

--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -70,7 +70,7 @@ jest.mock('src/data-set/pivot-data-set', () => {
         rowPivotMeta,
         colPivotMeta,
         indexesData,
-        sortedDimensionValues: sortedDimensionValues,
+        sortedDimensionValues,
         moreThanOneValue: jest.fn(),
         getFieldFormatter: actualDataSet.prototype.getFieldFormatter,
         getFieldMeta: (field: string, meta: ViewMeta) =>

--- a/packages/s2-core/__tests__/unit/facet/util.ts
+++ b/packages/s2-core/__tests__/unit/facet/util.ts
@@ -5,7 +5,7 @@ import { transformIndexesData } from '@/utils/dataset/pivot-data-set';
  * 获取 Mock 数据
  */
 export function getMockPivotMeta() {
-  const sortedDimensionValues = new Map();
+  const sortedDimensionValues = {};
   const rawRowPivotMeta = new Map();
   const rawColPivotMeta = new Map();
   const rawIndexesData = [];

--- a/packages/s2-core/__tests__/unit/utils/data-set-operate-spec.tsx
+++ b/packages/s2-core/__tests__/unit/utils/data-set-operate-spec.tsx
@@ -2,6 +2,7 @@ import { set, keys } from 'lodash';
 import {
   flattenDeep as customFlattenDeep,
   flatten as customFlatten,
+  getListBySorted,
 } from '@/utils/data-set-operate';
 
 describe('Data Set Operate Test', () => {
@@ -49,6 +50,29 @@ describe('Data Set Operate Test', () => {
 
     it('test custom flatten', () => {
       expect(keys(customFlatten(data))).toBeArrayOfSize(6);
+    });
+  });
+
+  describe('Dataset Operate Test GetListBySorted', () => {
+    let list = [];
+    beforeEach(() => {
+      list = ['浙江省', '四川省'];
+    });
+
+    it('should get correct list by complete sorted', () => {
+      expect(getListBySorted(list, ['四川省', '浙江省'])).toEqual([
+        '四川省',
+        '浙江省',
+      ]);
+      expect(getListBySorted(list, ['浙江省', '四川省'])).toEqual([
+        '浙江省',
+        '四川省',
+      ]);
+    });
+
+    it('should get correct list by sub sorted list', () => {
+      expect(getListBySorted(list, ['四川省'])).toEqual(['四川省', '浙江省']);
+      expect(getListBySorted(list, ['浙江省'])).toEqual(['浙江省', '四川省']);
     });
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/dataset/pivot-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/dataset/pivot-dataset-spec.ts
@@ -59,9 +59,7 @@ describe('PivotDataSet util test', () => {
     });
     expect(result.colPivotMeta.has('家具')).toBeTrue();
     expect(result.rowPivotMeta.has('浙江省')).toBeTrue();
-    expect(result.sortedDimensionValues.province).toEqual(
-      new Set(['浙江省', '四川省']),
-    );
+    expect(result.sortedDimensionValues.province).toEqual(['浙江省', '四川省']);
   });
 
   test('for transformDimensionsValues function', () => {

--- a/packages/s2-core/__tests__/unit/utils/dataset/pivot-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/dataset/pivot-dataset-spec.ts
@@ -35,7 +35,7 @@ describe('PivotDataSet util test', () => {
 
   test('for transformIndexesData function', () => {
     const { rows, columns } = dataCfg.fields;
-    const sortedDimensionValues = new Map();
+    const sortedDimensionValues = {};
     const rowPivotMeta = new Map();
     const colPivotMeta = new Map();
     const result = transformIndexesData({
@@ -44,7 +44,7 @@ describe('PivotDataSet util test', () => {
       originData: dataCfg.data,
       totalData: [],
       indexesData: [],
-      sortedDimensionValues: sortedDimensionValues,
+      sortedDimensionValues,
       rowPivotMeta: rowPivotMeta,
       colPivotMeta: colPivotMeta,
     });
@@ -59,14 +59,14 @@ describe('PivotDataSet util test', () => {
     });
     expect(result.colPivotMeta.has('家具')).toBeTrue();
     expect(result.rowPivotMeta.has('浙江省')).toBeTrue();
-    expect(result.sortedDimensionValues.get('province')).toEqual(
+    expect(result.sortedDimensionValues.province).toEqual(
       new Set(['浙江省', '四川省']),
     );
   });
 
   test('for transformDimensionsValues function', () => {
     const rows = ['province', 'city'];
-    const sortedDimensionValues = new Map();
+    const sortedDimensionValues = {};
     const data = {
       city: '杭州市',
       number: 7789,
@@ -74,7 +74,12 @@ describe('PivotDataSet util test', () => {
       sub_type: '桌子',
       type: '家具',
     };
-    const result = transformDimensionsValues(data, rows, sortedDimensionValues);
+    const result = transformDimensionsValues(
+      data,
+      rows,
+      sortedDimensionValues,
+      {},
+    );
     expect(result).toEqual(['浙江省', '杭州市']);
   });
 

--- a/packages/s2-core/src/data-set/interface.ts
+++ b/packages/s2-core/src/data-set/interface.ts
@@ -14,6 +14,8 @@ export type PivotMetaValue = {
 
 export type PivotMeta = Map<string, PivotMetaValue>;
 
+export type SortedDimensionValues = Record<string, string[]>;
+
 export type DataPathParams = {
   rowDimensionValues: string[];
   colDimensionValues: string[];

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -10,7 +10,6 @@ import {
   keys,
   uniq,
   values,
-  map,
   cloneDeep,
   filter,
   forEach,
@@ -22,7 +21,7 @@ import {
   flatten as customFlatten,
   flattenDeep as customFlattenDeep,
   getFieldKeysByDimensionValues,
-  getIntersections,
+  getListBySorted,
   isEveryUndefined,
   splitTotal,
   isTotalData,
@@ -38,7 +37,12 @@ import {
   ViewMeta,
 } from '@/common/interface';
 import { BaseDataSet } from '@/data-set/base-data-set';
-import { CellDataParams, DataType, PivotMeta } from '@/data-set/interface';
+import {
+  CellDataParams,
+  DataType,
+  PivotMeta,
+  SortedDimensionValues,
+} from '@/data-set/interface';
 import { handleSortAction } from '@/utils/sort-action';
 import {
   transformIndexesData,
@@ -59,7 +63,7 @@ export class PivotDataSet extends BaseDataSet {
   public colPivotMeta: PivotMeta;
 
   // sorted dimension values
-  public sortedDimensionValues: Map<string, Set<string>>;
+  public sortedDimensionValues: SortedDimensionValues;
 
   // each path items max index
   protected pathIndexMax = [];
@@ -73,7 +77,7 @@ export class PivotDataSet extends BaseDataSet {
    */
   public setDataCfg(dataCfg: S2DataConfig) {
     super.setDataCfg(dataCfg);
-    this.sortedDimensionValues = new Map();
+    this.sortedDimensionValues = {};
     this.rowPivotMeta = new Map();
     this.colPivotMeta = new Map();
     // total data in raw data scene.
@@ -229,19 +233,16 @@ export class PivotDataSet extends BaseDataSet {
       const { sortFieldId, sortByMeasure } = item;
       // 万物排序的前提
       if (!sortFieldId) return;
-      const originValues = [
-        ...(this.sortedDimensionValues.get(sortFieldId)?.keys?.() || []),
-      ];
+      const originValues = [...(this.sortedDimensionValues[sortFieldId] || [])];
       const result = handleSortAction({
         dataSet: this,
         sortParam: item,
         originValues,
         isSortByMeasure: !isEmpty(sortByMeasure),
       });
-      this.sortedDimensionValues.set(
-        sortFieldId,
-        new Set([...result, ...originValues]), // 这里是控制顺序的，优先result
-      );
+      this.sortedDimensionValues[sortFieldId] = [
+        ...getListBySorted(originValues, [...(new Set(result) || [])]),
+      ];
     });
   };
 
@@ -323,16 +324,24 @@ export class PivotDataSet extends BaseDataSet {
         if (meta.has(value) && !isUndefined(value)) {
           const childField = meta.get(value)?.childField;
           meta = meta.get(value).children;
-          if (this.sortedDimensionValues.has(childField)) {
-            sortedMeta = [...this.sortedDimensionValues.get(childField)];
+          if (
+            find(this.sortParams, (item) => item.sortFieldId === childField) &&
+            this.sortedDimensionValues[childField]
+          ) {
+            sortedMeta = [...this.sortedDimensionValues[childField]];
+          } else {
+            sortedMeta = [...meta.keys()];
           }
         }
       }
-      return filterUndefined(getIntersections([...meta.keys()], sortedMeta));
+      if (isEmpty(sortedMeta)) {
+        return [];
+      }
+      return filterUndefined(getListBySorted([...meta.keys()], sortedMeta));
     }
 
-    if (this.sortedDimensionValues.has(field)) {
-      return filterUndefined([...this.sortedDimensionValues.get(field)]);
+    if (this.sortedDimensionValues[field]) {
+      return filterUndefined([...this.sortedDimensionValues[field]]);
     }
 
     return filterUndefined([...meta.keys()]);

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -6,7 +6,7 @@ import { i18n } from '@/common/i18n';
 import { Node } from '@/facet/layout/node';
 import { generateId } from '@/utils/layout/generate-id';
 import { SpreadSheet } from '@/sheet-type';
-import { getIntersections, filterUndefined } from '@/utils/data-set-operate';
+import { getListBySorted, filterUndefined } from '@/utils/data-set-operate';
 import { PivotDataSet } from '@/data-set';
 
 const addTotals = (
@@ -37,10 +37,10 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
   const query = parentNode.query;
   const isDrillDownItem = spreadsheet.dataCfg.fields.rows?.length <= level;
   const sortedDimensionValues =
-    (dataSet as PivotDataSet)?.sortedDimensionValues?.get(currentField) || [];
+    (dataSet as PivotDataSet)?.sortedDimensionValues?.[currentField] || [];
 
   const dimValues = filterUndefined(
-    getIntersections([...sortedDimensionValues], [...(pivotMeta.keys() || [])]),
+    getListBySorted([...(pivotMeta.keys() || [])], [...sortedDimensionValues]),
   );
 
   let fieldValues: FieldValue[] = layoutArrange(

--- a/packages/s2-core/src/utils/data-set-operate.ts
+++ b/packages/s2-core/src/utils/data-set-operate.ts
@@ -2,12 +2,21 @@ import { filter, isUndefined, keys, get, reduce, every } from 'lodash';
 import { Data } from '@/common/interface/s2DataConfig';
 import { Fields } from '@/common/interface/index';
 
-/**
- * get intersections between two arrs
- *
- */
-export const getIntersections = (arr1: string[], arr2: string[]) => {
-  return arr1.filter((item) => arr2.includes(item));
+export const getListBySorted = (list: string[], sorted: string[]) => {
+  return list.sort((a, b) => {
+    const ia = sorted.indexOf(a);
+    const ib = sorted.indexOf(b);
+    if (ia === -1 && ib === -1) {
+      return 0;
+    }
+    if (ia === -1) {
+      return 1;
+    }
+    if (ib === -1) {
+      return -1;
+    }
+    return ia - ib;
+  });
 };
 
 export const filterUndefined = (values: string[]) => {

--- a/packages/s2-core/src/utils/dataset/pivot-data-set.ts
+++ b/packages/s2-core/src/utils/dataset/pivot-data-set.ts
@@ -38,24 +38,24 @@ export function transformDimensionsValues(
   sortedDimensionValues: SortedDimensionValues,
   dimensionCache: Record<string, number>,
 ): string[] {
-  const dimensionLink = [];
+  const dimensionValuePath: string[] = [];
   return map(dimensions, (dimension) => {
     const dimensionValue = record[dimension];
-    dimensionLink.push(`${dimension}${ID_SEPARATOR}${dimensionValue}`);
+    dimensionValuePath.push(`${dimension}${ID_SEPARATOR}${dimensionValue}`);
 
     if (!sortedDimensionValues[dimension]) {
       sortedDimensionValues[dimension] = [
         isUndefined(dimensionValue) ? String(dimensionValue) : dimensionValue,
       ];
     } else if (
-      !dimensionCache[dimensionLink.join(ID_SEPARATOR)] &&
+      !dimensionCache[dimensionValuePath.join(ID_SEPARATOR)] &&
       dimension !== EXTRA_FIELD
     ) {
       sortedDimensionValues[dimension].push(dimensionValue);
     }
 
-    if (!dimensionCache[dimensionLink.join(ID_SEPARATOR)]) {
-      dimensionCache[dimensionLink.join(ID_SEPARATOR)] = 1;
+    if (!dimensionCache[dimensionValuePath.join(ID_SEPARATOR)]) {
+      dimensionCache[dimensionValuePath.join(ID_SEPARATOR)] = 1;
     }
 
     return dimensionValue;


### PR DESCRIPTION
… object for saving repeat value

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [ ] Code style optimization
- [x] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
refactor: optimize sortedDimensionValues's structure by change map to object for saving repeat value and modify test
### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |
![image](https://user-images.githubusercontent.com/19166133/140893935-8a988f3a-a8ae-451c-8679-ba95edb22f17.png)|![image](https://user-images.githubusercontent.com/19166133/140893770-f02589f4-3098-4410-a943-5550d908f72e.png)
