### PR TITLE
chore: unfix peerDep versions

### DIFF
--- a/packages/s2-core/package.json
+++ b/packages/s2-core/package.json
@@ -50,8 +50,8 @@
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "peerDependencies": {
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0"
+    "react": ">=16.14.0",
+    "react-dom": ">=16.14.0"
   },
   "dependencies": {
     "@antv/event-emitter": "~0.1.2",


### PR DESCRIPTION
### 👀 PR includes

Unfix react versions that other projects react that version > 16 can run 'npm i' successfully.

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [x] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
