### PR TITLE
feat: 🎸 修复interactionState的borderWidth和borderColor不生效问题

### DIFF
--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -36,6 +36,7 @@ export const SHAPE_STYLE_MAP = {
   backgroundColor: 'fill',
   borderOpacity: 'strokeOpacity',
   borderColor: 'stroke',
+  borderWidth: 'lineWidth',
   opacity: 'opacity',
 };
 
@@ -44,7 +45,7 @@ export const SHAPE_ATTRS_MAP = {
   textShape: ['textOpacity'],
   linkFieldShape: ['opacity'],
   interactiveBgShape: ['backgroundColor', 'backgroundOpacity'],
-  interactiveBorderShape: ['borderColor', 'borderOpacity'],
+  interactiveBorderShape: ['borderColor', 'borderOpacity', 'borderWidth'],
 };
 
 export const INTERACTION_STATE_INFO_KEY = 'interactionStateInfo';

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -40,7 +40,7 @@ export interface InteractionStateTheme {
   borderColor?: string;
   /* 边线宽度 */
   borderWidth?: number;
-  /* 边明度 */
+  /* 边线透明度 */
   borderOpacity?: number;
   /* 透明度 */
   opacity?: number;

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -40,6 +40,8 @@ export interface InteractionStateTheme {
   borderColor?: string;
   /* 边线宽度 */
   borderWidth?: number;
+  /* 边明度 */
+  borderOpacity?: number;
   /* 透明度 */
   opacity?: number;
 }


### PR DESCRIPTION

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

```js 
// theme 
{
  dataCell: {
    cell: {
      padding: {},
      interactionState: {
        selected: {
          backgroundColor: '#2a83fa',
          borderColor: '#2a83fa',
          backgroundOpacity: 0.1,
          borderWidth: 2,
          borderOpacity: 1,
        },
      },
    },
  },
};

```



### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌       ![image](https://user-images.githubusercontent.com/9219215/141071073-ce30650f-0992-432b-bfd6-5c80ebbc9eb0.png) | ✅                  ![image](https://user-images.githubusercontent.com/9219215/141070572-859a445a-72bc-44d6-8659-3b1393124cdd.png)           |




### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge
- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
