### PR TITLE
fix(table): fix expand column icon cover text and sort icon

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-609-spec.tsx
+++ b/packages/s2-core/__tests__/bugs/issue-609-spec.tsx
@@ -22,6 +22,7 @@ interface Props {
 const s2Options: S2Options = {
   width: 200,
   height: 200,
+  hdAdapter: false,
 };
 
 let s2: SpreadSheet;

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.tsx
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.tsx
@@ -101,7 +101,7 @@ function MainLayout({ callback }) {
   const options: S2Options = {
     width: 800,
     height: 600,
-    showSeriesNumber: true,
+    // showSeriesNumber: true,
     placeholder: '',
     style: {
       colCfg: {
@@ -120,24 +120,24 @@ function MainLayout({ callback }) {
       enableCopy: true,
       hoverHighlight: false,
       linkFields: ['order_id', 'customer_name'],
+      hiddenColumnFields,
     },
-    frozenRowCount: 2,
-    frozenColCount: 1,
-    frozenTrailingColCount: 1,
-    frozenTrailingRowCount: 1,
+    // frozenRowCount: 2,
+    // frozenColCount: 1,
+    // frozenTrailingColCount: 1,
+    // frozenTrailingRowCount: 1,
     tooltip: {
       showTooltip: true,
       operation: {
         hiddenColumns: hiddenColumnsOperator,
       },
     },
-    hiddenColumnFields,
-  } as S2Options;
+  };
 
   const s2Ref = React.useRef<SpreadSheet>(null);
 
   const logData = (...d: unknown[]) => {
-    console.info(...d);
+    console.log(...d);
   };
 
   useEffect(() => {

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.tsx
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.tsx
@@ -101,7 +101,7 @@ function MainLayout({ callback }) {
   const options: S2Options = {
     width: 800,
     height: 600,
-    // showSeriesNumber: true,
+    showSeriesNumber: true,
     placeholder: '',
     style: {
       colCfg: {
@@ -122,10 +122,10 @@ function MainLayout({ callback }) {
       linkFields: ['order_id', 'customer_name'],
       hiddenColumnFields,
     },
-    // frozenRowCount: 2,
-    // frozenColCount: 1,
-    // frozenTrailingColCount: 1,
-    // frozenTrailingRowCount: 1,
+    frozenRowCount: 2,
+    frozenColCount: 1,
+    frozenTrailingColCount: 1,
+    frozenTrailingRowCount: 1,
     tooltip: {
       showTooltip: true,
       operation: {

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -110,7 +110,7 @@ describe('Interaction Data Cell Click Tests', () => {
 
     const defaultColumnsDetail: HiddenColumnsInfo[] = [
       {
-        displaySiblingNode: mockNode as Node,
+        displaySiblingNode: { prev: null, next: mockNode as Node },
         hideColumnNodes: [mockNode] as Node[],
       },
     ];
@@ -148,13 +148,13 @@ describe('Interaction Data Cell Click Tests', () => {
     expect(columnsHidden).toHaveBeenCalledWith(
       // current hidden column infos
       {
-        displaySiblingNode: { colIndex: 2, field: '2' },
+        displaySiblingNode: { prev: null, next: { colIndex: 2, field: '2' } },
         hideColumnNodes: [{ colIndex: 1, field: mockField }],
       },
       // hidden columns detail
       [
         {
-          displaySiblingNode: { colIndex: 2, field: '2' },
+          displaySiblingNode: { prev: null, next: { colIndex: 2, field: '2' } },
           hideColumnNodes: [{ colIndex: 1, field: mockField }],
         },
       ],

--- a/packages/s2-core/__tests__/unit/utils/hide-columns.spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/hide-columns.spec.ts
@@ -65,28 +65,54 @@ describe('hide-columns test', () => {
   test('should get next sibling node when hidden node is not at the last', () => {
     // hide single column
     expect(getHiddenColumnDisplaySiblingNode(sheet, ['3'])).toEqual({
-      field: '4',
-      colIndex: 4,
+      prev: {
+        field: '2',
+        colIndex: 2,
+      },
+      next: {
+        field: '4',
+        colIndex: 4,
+      },
     });
 
     // hide a continuous column list
     expect(getHiddenColumnDisplaySiblingNode(sheet, ['3', '4'])).toEqual({
-      field: '5',
-      colIndex: 5,
+      prev: {
+        field: '2',
+        colIndex: 2,
+      },
+      next: {
+        field: '5',
+        colIndex: 5,
+      },
     });
   });
 
   test('should get pre sibling node when hidden node is at the last', () => {
     // hide single column
     expect(getHiddenColumnDisplaySiblingNode(sheet, ['5'])).toEqual({
-      field: '4',
-      colIndex: 4,
+      prev: {
+        field: '4',
+        colIndex: 4,
+      },
+      next: null,
+    });
+
+    expect(getHiddenColumnDisplaySiblingNode(sheet, ['1'])).toEqual({
+      prev: null,
+      next: {
+        field: '2',
+        colIndex: 2,
+      },
     });
 
     // hide a continuous column list
     expect(getHiddenColumnDisplaySiblingNode(sheet, ['3', '4', '5'])).toEqual({
-      field: '2',
-      colIndex: 2,
+      prev: {
+        field: '2',
+        colIndex: 2,
+      },
+      next: null,
     });
   });
 
@@ -138,7 +164,10 @@ describe('hide-columns test', () => {
     // save hidden meta
     expect(mockSpreadSheetInstance.store.get('hiddenColumnsDetail')).toEqual([
       {
-        displaySiblingNode: { field: '4', colIndex: 4 },
+        displaySiblingNode: {
+          prev: { field: '2', colIndex: 2 },
+          next: { field: '4', colIndex: 4 },
+        },
         hideColumnNodes: [{ field: '3', colIndex: 3 }],
       },
     ]);
@@ -153,7 +182,7 @@ describe('hide-columns test', () => {
 
     expect(mockSpreadSheetInstance.store.get('hiddenColumnsDetail')).toEqual([
       {
-        displaySiblingNode: { field: '4', colIndex: 4 },
+        displaySiblingNode: { next: null, prev: { field: '4', colIndex: 4 } },
         hideColumnNodes: [{ field: '5', colIndex: 5 }],
       },
     ]);
@@ -169,13 +198,13 @@ describe('hide-columns test', () => {
     expect(columnsHidden).toHaveBeenCalledWith(
       // current hidden column infos
       {
-        displaySiblingNode: { colIndex: 4, field: '4' },
+        displaySiblingNode: { next: null, prev: { colIndex: 4, field: '4' } },
         hideColumnNodes: [{ colIndex: 5, field: '5' }],
       },
       // hidden columns detail
       [
         {
-          displaySiblingNode: { colIndex: 4, field: '4' },
+          displaySiblingNode: { next: null, prev: { colIndex: 4, field: '4' } },
           hideColumnNodes: [{ colIndex: 5, field: '5' }],
         },
       ],
@@ -195,7 +224,10 @@ describe('hide-columns test', () => {
 
     expect(mockSpreadSheetInstance.store.get('hiddenColumnsDetail')).toEqual([
       {
-        displaySiblingNode: { field: '4', colIndex: 4 },
+        displaySiblingNode: {
+          prev: { field: '1', colIndex: 1 },
+          next: { field: '4', colIndex: 4 },
+        },
         hideColumnNodes: [
           { field: '2', colIndex: 2 },
           { field: '3', colIndex: 3 },
@@ -209,11 +241,17 @@ describe('hide-columns test', () => {
 
     expect(mockSpreadSheetInstance.store.get('hiddenColumnsDetail')).toEqual([
       {
-        displaySiblingNode: { field: '2', colIndex: 2 },
+        displaySiblingNode: {
+          prev: null,
+          next: { field: '2', colIndex: 2 },
+        },
         hideColumnNodes: [{ field: '1', colIndex: 1 }],
       },
       {
-        displaySiblingNode: { field: '4', colIndex: 4 },
+        displaySiblingNode: {
+          prev: { field: '2', colIndex: 2 },
+          next: { field: '4', colIndex: 4 },
+        },
         hideColumnNodes: [{ field: '3', colIndex: 3 }],
       },
     ]);

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -7,6 +7,7 @@ import {
   SHAPE_STYLE_MAP,
 } from '@/common/constant';
 import {
+  CellThemes,
   FormatResult,
   ResizeArea,
   S2CellType,
@@ -131,7 +132,9 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
   /*                common functions that will be used in subtype               */
   /* -------------------------------------------------------------------------- */
 
-  public getStyle(name?: keyof S2Theme): S2Theme[keyof S2Theme] {
+  public getStyle<K extends keyof S2Theme = keyof CellThemes>(
+    name?: K,
+  ): S2Theme[K] {
     return this.theme[name || this.cellType];
   }
 

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -131,7 +131,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
   /*                common functions that will be used in subtype               */
   /* -------------------------------------------------------------------------- */
 
-  public getStyle(name?: keyof S2Theme) {
+  public getStyle(name?: keyof S2Theme): S2Theme[keyof S2Theme] {
     return this.theme[name || this.cellType];
   }
 

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -175,7 +175,7 @@ export class RowCell extends HeaderCell {
     const {
       horizontalBorderColor,
       horizontalBorderWidth,
-      horizontalBorderOpacity,
+      horizontalBorderColorOpacity,
       verticalBorderColor,
       verticalBorderWidth,
       verticalBorderColorOpacity,
@@ -194,7 +194,7 @@ export class RowCell extends HeaderCell {
       {
         stroke: horizontalBorderColor,
         lineWidth: horizontalBorderWidth,
-        opacity: horizontalBorderOpacity,
+        opacity: horizontalBorderColorOpacity,
       },
     );
 

--- a/packages/s2-core/src/common/interface/store.ts
+++ b/packages/s2-core/src/common/interface/store.ts
@@ -28,7 +28,10 @@ export interface HiddenColumnsInfo {
   // 当前显示的兄弟节点之前所隐藏的节点
   hideColumnNodes: Node[];
   // 当前隐藏列所对应展示展开按钮的兄弟节点
-  displaySiblingNode: Node;
+  displaySiblingNode: {
+    prev: Node;
+    next: Node;
+  };
 }
 
 /**

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -180,11 +180,9 @@ export interface DefaultCellTheme {
   icon?: IconTheme;
   /* 序号列宽 */
   seriesNumberWidth?: number;
-  /* 额外属性字段 */
-  [key: string]: any;
 }
 
-type CellThemes = {
+export type CellThemes = {
   [K in CellTypes]?: DefaultCellTheme;
 };
 
@@ -199,8 +197,6 @@ export interface S2Theme extends CellThemes {
   prepareSelectMask?: InteractionStateTheme;
   /* 画布背景底色 */
   background?: Background;
-  /* 额外属性字段 */
-  [key: string]: any;
 }
 
 export type ThemeName = 'default' | 'colorful' | 'gray';

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -169,7 +169,7 @@ export interface SplitLine {
     right: string;
   };
 }
-export interface DefaultCellTheme {
+export interface DefaultCellTheme extends GridAnalysisCellTheme {
   /* 粗体文本样式 */
   bolderText?: TextTheme;
   /* 文本样式 */
@@ -180,6 +180,18 @@ export interface DefaultCellTheme {
   icon?: IconTheme;
   /* 序号列宽 */
   seriesNumberWidth?: number;
+}
+
+export interface GridAnalysisCellTheme {
+  // 次级文本，如副指标
+  minorText?: TextTheme;
+  // 衍生指标
+  derivedMeasureText?: {
+    mainUp: string;
+    mainDown: string;
+    minorUp: string;
+    minorDown: string;
+  };
 }
 
 export type CellThemes = {

--- a/packages/s2-core/src/components/sheets/grid-analysis-sheet/grid-analysis-theme.ts
+++ b/packages/s2-core/src/components/sheets/grid-analysis-sheet/grid-analysis-theme.ts
@@ -1,5 +1,5 @@
 import { FONT_FAMILY } from '@/common/constant/theme';
-import { DefaultCellTheme } from '@/common/interface/theme';
+import { S2Theme } from '@/common/interface/theme';
 
 import { isWindows } from '@/utils/is-mobile';
 
@@ -7,7 +7,7 @@ export const FONT_SIZE = 12;
 export const FONT_SIZE_MINOR = 11;
 
 /* 交叉表的样式 */
-export const GridAnalysisTheme = {
+export const GridAnalysisTheme: S2Theme = {
   // 表头
   dataCell: {
     text: {
@@ -27,7 +27,6 @@ export const GridAnalysisTheme = {
       textBaseline: 'middle',
       textAlign: 'left',
     },
-
     // 衍生指标
     derivedMeasureText: {
       mainUp: '#F46649',
@@ -39,9 +38,9 @@ export const GridAnalysisTheme = {
       fontSize: FONT_SIZE,
       fontFamily: FONT_FAMILY,
       fill: 'rgba(0, 0, 0, 1)',
-      fontWeight: isWindows() ? 'bold' : '520',
+      fontWeight: isWindows() ? 'bold' : 520,
       textBaseline: 'middle',
       textAlign: 'left',
     },
   },
-} as DefaultCellTheme;
+};

--- a/packages/s2-core/src/components/sheets/grid-analysis-sheet/index.tsx
+++ b/packages/s2-core/src/components/sheets/grid-analysis-sheet/index.tsx
@@ -10,7 +10,7 @@ import { GridAnalysisDataCell } from './grid-analysis-data-cell';
 import { GridAnalysisTheme } from './grid-analysis-theme';
 import { S2Event } from '@/common/constant';
 import { getBaseCellData } from '@/utils/interaction/formatter';
-import { S2Options } from '@/common/interface';
+import { S2Options, ThemeCfg } from '@/common/interface';
 import { getSafetyDataConfig, getSafetyOptions } from '@/utils/merge';
 import { SpreadSheet, PivotSheet } from '@/sheet-type';
 import { useResizeEffect } from '@/components/sheets/hooks';

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -187,7 +187,8 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     );
     const { hideColumnNodes = [] } =
       hiddenColumnsDetail.find(
-        ({ displaySiblingNode }) => displaySiblingNode?.field === node.field,
+        ({ displaySiblingNode }) =>
+          displaySiblingNode?.next?.field === node.field,
       ) || {};
     const willDisplayColumnFields = hideColumnNodes.map(({ field }) => field);
     this.spreadsheet.setOptions({
@@ -201,7 +202,8 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     this.spreadsheet.store.set(
       'hiddenColumnsDetail',
       hiddenColumnsDetail.filter(
-        ({ displaySiblingNode }) => displaySiblingNode?.field !== node.field,
+        ({ displaySiblingNode }) =>
+          displaySiblingNode?.next?.field !== node.field,
       ),
     );
     this.spreadsheet.interaction.reset();

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -177,7 +177,7 @@ export class EventController {
     }
 
     const { x, y, width, height } =
-      this.spreadsheet.tooltip?.container?.getBoundingClientRect() || {};
+      this.spreadsheet.tooltip?.container?.getBoundingClientRect?.() || {};
 
     if (event instanceof MouseEvent) {
       return (

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -21,7 +21,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : '500',
+        fontWeight: isWindows() ? 'bold' : 500,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'center',
@@ -69,7 +69,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : '520',
+        fontWeight: isWindows() ? 'bold' : 520,
         fill: basicColors[14],
         linkTextFill: basicColors[14],
         opacity: 1,
@@ -120,7 +120,6 @@ export const getTheme = (
           // -------------- unselected -------------------
           unselected: {
             backgroundOpacity: 0.3,
-            textOpacity: 0.3,
             opacity: 0.3,
           },
         },
@@ -139,7 +138,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : '520',
+        fontWeight: isWindows() ? 'bold' : 520,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'center',
@@ -188,7 +187,6 @@ export const getTheme = (
           // -------------- unselected -------------------
           unselected: {
             backgroundOpacity: 0.3,
-            textOpacity: 0.3,
             opacity: 0.3,
           },
         },
@@ -209,7 +207,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : '520',
+        fontWeight: isWindows() ? 'bold' : 520,
         fill: basicColors[13],
         opacity: 1,
         textAlign: 'right',
@@ -266,7 +264,6 @@ export const getTheme = (
           // -------------- unselected -------------------
           unselected: {
             backgroundOpacity: 0.3,
-            textOpacity: 0.3,
             opacity: 0.3,
           },
           // -------------- prepare select --------------
@@ -340,5 +337,5 @@ export const getTheme = (
       color: basicColors[8],
       opacity: 1,
     },
-  } as S2Theme;
+  };
 };

--- a/packages/s2-core/src/utils/hide-columns.ts
+++ b/packages/s2-core/src/utils/hide-columns.ts
@@ -29,7 +29,7 @@ export const getHiddenColumnNodes = (
 export const getHiddenColumnDisplaySiblingNode = (
   spreadsheet: SpreadSheet,
   hiddenColumnFields: string[] = [],
-): Node => {
+): HiddenColumnsInfo['displaySiblingNode'] => {
   const initColumnNodes = spreadsheet.getInitColumnNodes();
   const hiddenColumnIndexes = getHiddenColumnNodes(
     spreadsheet,
@@ -43,7 +43,10 @@ export const getHiddenColumnDisplaySiblingNode = (
   const prevSiblingNode = initColumnNodes.find(
     (node) => node.colIndex === firstHiddenColumnIndex - 1,
   );
-  return nextSiblingNode ?? prevSiblingNode;
+  return {
+    prev: prevSiblingNode || null,
+    next: nextSiblingNode || null,
+  };
 };
 
 /**

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -14,7 +14,7 @@ import { S2Options } from '@/common/interface/s2Options';
 import { DefaultCellTheme } from '@/common/interface/theme';
 import { renderText } from '@/utils/g-renders';
 import { DataCell } from '@/cell/data-cell';
-import { EMPTY_PLACEHOLDER } from '@/common/constant';
+import { CellTypes, EMPTY_PLACEHOLDER } from '@/common/constant';
 
 const canvas = document.createElement('canvas');
 const ctx = canvas.getContext('2d');
@@ -280,21 +280,23 @@ const getStyle = (
   colIndex: number,
   value: string | number,
   options: S2Options,
-  theme: DefaultCellTheme,
+  dataCellTheme: DefaultCellTheme,
 ) => {
   const cellCfg = get(options, 'style.cellCfg', {}) as Partial<CellCfg>;
   const derivedMeasureIndex = cellCfg?.firstDerivedMeasureRowIndex;
   const minorMeasureIndex = cellCfg?.minorMeasureRowIndex;
   const isMinor = rowIndex === minorMeasureIndex;
   const isDerivedMeasure = colIndex >= derivedMeasureIndex;
-  const style = isMinor ? clone(theme.minorText) : clone(theme.text);
-  const derivedMeasureText = theme.derivedMeasureText;
+  const style = isMinor
+    ? clone(dataCellTheme.minorText)
+    : clone(dataCellTheme.text);
+  const derivedMeasureText = dataCellTheme.derivedMeasureText;
   const upFill = isMinor
     ? derivedMeasureText?.minorUp
-    : derivedMeasureText?.mainUp || theme.dataCell.icon.upIconColor;
+    : derivedMeasureText?.mainUp || dataCellTheme.icon.upIconColor;
   const downFill = isMinor
     ? derivedMeasureText?.minorDown
-    : derivedMeasureText?.mainDown || theme.dataCell.icon.downIconColor;
+    : derivedMeasureText?.mainDown || dataCellTheme.icon.downIconColor;
   if (isDerivedMeasure) {
     const isUp = getDataState(value);
     return merge(style, {
@@ -311,9 +313,9 @@ const getStyle = (
 export const drawObjectText = (cell: DataCell) => {
   const { x, y, height, width } = cell.getContentArea();
   const text = cell.getMeta().fieldValue as MultiData;
-  const cellStyle = cell.getStyle('dataCell') as DefaultCellTheme;
-  const labelStyle = cellStyle.bolderText;
-  const padding = cellStyle.cell.padding;
+  const dataCellStyle = cell.getStyle(CellTypes.DATA_CELL);
+  const labelStyle = dataCellStyle.bolderText;
+  const padding = dataCellStyle.cell.padding;
 
   // 指标个数相同，任取其一即可
   const realWidth = width / (text.values[0].length + 1);
@@ -347,7 +349,7 @@ export const drawObjectText = (cell: DataCell) => {
         j,
         curText,
         cell?.getMeta().spreadsheet.options,
-        cellStyle,
+        dataCellStyle,
       );
       curWidth = j === 0 ? realWidth * 2 : realWidth;
       curX = calX(x, padding.right, totalWidth);
@@ -363,7 +365,6 @@ export const drawObjectText = (cell: DataCell) => {
           fontParam: curStyle,
         }),
         curStyle,
-        curStyle?.fill,
       );
     }
   }

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -103,7 +103,7 @@ order: 0
 | 列头宽度改变  | `S2Event.LAYOUT_RESIZE_COL_WIDTH` |   |
 | 行头宽度改变  | `S2Event.LAYOUT_RESIZE_COL_HEIGHT` |   |
 | 树状结构宽度改变  | `S2Event.LAYOUT_RESIZE_TREE_WIDTH` |  树状模式下，单元格宽度发生改变时触发 |
-| 列头展开  | `S2Event.LAYOUT_TABLE_COL_EXPANDED` |  列头展开时触犯，明细表有效  |
+| 列头展开  | `S2Event.LAYOUT_TABLE_COL_EXPANDED` |  列头展开时触发，明细表有效  |
 | 列头隐藏  | `S2Event.LAYOUT_TABLE_COL_HIDDEN` |  列头隐藏时触发，明细表有效  |
 
 ### 全局
@@ -240,7 +240,9 @@ s2.on(S2Event.GLOBAL_RESET,() => {
 
 ```ts
 const s2options = {
-  autoResetSheetStyle: false
+  interaction: {
+    autoResetSheetStyle: false
+  }
 };
 ```
 
@@ -257,4 +259,13 @@ const s2options = {
     },
   },
 };
+```
+
+## 调用交互方法
+
+`S2` 内置了一些交互相关的方法，统一挂载在 `interaction` 命名空间下，你可以在拿到 `SpreadSheet` 实例后调用它们来实现你的效果，比如 `选中所有单元格`, `获取列头单元格` 等常用方法，具体请查看 [Interaction 实例类](/zh/docs/api/basic-class/interaction)
+
+```ts
+const s2 = new PivotSheet()
+s2.interaction.selectAll()
 ```


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复 展开隐藏列图标 **遮挡**列头文本和排序图标的问题
2. 修复 明细表 列头文本 和 排序图标 **没有 margin** 的问题
3. 修改 隐藏列头的 回调, 增加 prev node
4. 修复 主题 类型定义

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ![image](https://user-images.githubusercontent.com/21015895/141268369-3e8573b7-7ca0-4995-a1d9-803f41ac21ce.png) | ![image](https://user-images.githubusercontent.com/21015895/141268048-60f15ff4-4132-40d1-88aa-9dec46e2d466.png) |
| ![image](https://user-images.githubusercontent.com/21015895/141268329-b40f5349-d6b1-4657-8a8f-83290a469708.png)  | ![image](https://user-images.githubusercontent.com/21015895/141268241-b97fb58b-5bdf-4b39-8283-495a52829c4e.png)|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
