### PR TITLE
fix(facet): render v scrollbar close #681

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -596,7 +596,7 @@ export abstract class BaseFacet {
         thumbLen: thumbHeight,
         thumbOffset: (scrollY * this.panelBBox.height) / realHeight,
         position: {
-          x: this.panelBBox.maxX,
+          x: this.panelBBox.maxX - this.scrollBarSize,
           y: this.panelBBox.minY,
         },
         theme: this.scrollBarTheme,


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

之前右边的垂直滚动条没渲染出来

   
Before

![image](https://user-images.githubusercontent.com/10339692/141296975-07801861-65b0-4121-9941-fed61e24c435.png)

After 

![image](https://user-images.githubusercontent.com/10339692/141297037-eb37b15a-e70f-4633-ba33-a5bf35a84cf6.png)



