### PR TITLE
fix: 🐛 interactorBorder宽度自适应

### DIFF
--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -239,26 +239,8 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       `${this.cellType}.cell.interactionState.${stateName}`,
     );
 
-    // 根据borderWidth更新borderShape大小     https://github.com/antvis/S2/pull/705
     const { x, y, height, width } = this.getCellArea();
     const margin = Number(stateStyles.borderWidth || DEFAULT_BORDER_WIDTH);
-
-    const shape = this.stateShapes.get('interactiveBorderShape') || null;
-
-    if (shape && isNumber(margin)) {
-      // 默认留下0.5 pixel的buffer防止和周边cell的边框重合  (borderWidth = 1时，只有0.5px会被绘制在cell内部)
-      const marginStyle = {
-        x: x + margin / 2,
-        y: y + margin / 2,
-        width: width - margin - 0.5,
-        height: height - margin - 0.5,
-        lineWidth: margin,
-      };
-
-      each(marginStyle, (style, styleKey) => {
-        updateShapeAttr(shape, styleKey, style);
-      });
-    }
 
     each(stateStyles, (style, styleKey) => {
       const targetShapeNames = keys(
@@ -268,6 +250,24 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
         const shape = this.stateShapes.has(shapeName)
           ? this.stateShapes.get(shapeName)
           : this[shapeName];
+
+        // 根据borderWidth更新borderShape大小     https://github.com/antvis/S2/pull/705
+        if (
+          shapeName === 'interactiveBorderShape' &&
+          styleKey === 'borderWidth'
+        ) {
+          if (isNumber(margin)) {
+            const marginStyle = {
+              x: x + style / 2,
+              y: y + style / 2,
+              width: width - style,
+              height: height - style,
+            };
+            each(marginStyle, (style, styleKey) => {
+              updateShapeAttr(shape, styleKey, style);
+            });
+          }
+        }
         updateShapeAttr(shape, SHAPE_STYLE_MAP[styleKey], style);
       });
     });
@@ -278,6 +278,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       updateShapeAttr(shape, SHAPE_STYLE_MAP.backgroundOpacity, 0);
       updateShapeAttr(shape, SHAPE_STYLE_MAP.backgroundColor, 'transparent');
       updateShapeAttr(shape, SHAPE_STYLE_MAP.borderOpacity, 0);
+      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderWidth, 1);
       updateShapeAttr(shape, SHAPE_STYLE_MAP.borderColor, 'transparent');
     });
   }

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -247,10 +247,10 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     if (shape && isNumber(margin)) {
       // 默认留下1pixel的buffer防止和周边cell的边框重合
       const marginStyle = {
-        x: x + 1 + margin / 2,
-        y: y + 1 + margin / 2,
-        width: width - margin - 2,
-        height: height - margin - 2,
+        x: x + margin / 2,
+        y: y + margin / 2,
+        width: width - margin - 1,
+        height: height - margin - 1,
         lineWidth: margin,
       };
 

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -33,7 +33,6 @@ import { renderLine, renderText, updateShapeAttr } from '@/utils/g-renders';
 import { isMobile } from '@/utils/is-mobile';
 import { getEllipsisText, measureTextWidth } from '@/utils/text';
 
-const DEFAULT_BORDER_WIDTH = 1;
 export abstract class BaseCell<T extends SimpleBBox> extends Group {
   // cell's data meta info
   protected meta: T;
@@ -240,7 +239,6 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     );
 
     const { x, y, height, width } = this.getCellArea();
-    const margin = Number(stateStyles.borderWidth || DEFAULT_BORDER_WIDTH);
 
     each(stateStyles, (style, styleKey) => {
       const targetShapeNames = keys(
@@ -256,7 +254,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
           shapeName === 'interactiveBorderShape' &&
           styleKey === 'borderWidth'
         ) {
-          if (isNumber(margin)) {
+          if (isNumber(style)) {
             const marginStyle = {
               x: x + style / 2,
               y: y + style / 2,

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -33,6 +33,7 @@ import { renderLine, renderText, updateShapeAttr } from '@/utils/g-renders';
 import { isMobile } from '@/utils/is-mobile';
 import { getEllipsisText, measureTextWidth } from '@/utils/text';
 
+const DEFAULT_BORDER_WIDTH = 1;
 export abstract class BaseCell<T extends SimpleBBox> extends Group {
   // cell's data meta info
   protected meta: T;
@@ -238,19 +239,19 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       `${this.cellType}.cell.interactionState.${stateName}`,
     );
 
-    // // 根据borderWidth更新borderShape大小     https://github.com/antvis/S2/pull/705
+    // 根据borderWidth更新borderShape大小     https://github.com/antvis/S2/pull/705
     const { x, y, height, width } = this.getCellArea();
-    const margin = Number(stateStyles.borderWidth || 1);
+    const margin = Number(stateStyles.borderWidth || DEFAULT_BORDER_WIDTH);
 
     const shape = this.stateShapes.get('interactiveBorderShape') || null;
 
     if (shape && isNumber(margin)) {
-      // 默认留下1pixel的buffer防止和周边cell的边框重合
+      // 默认留下0.5 pixel的buffer防止和周边cell的边框重合  (borderWidth = 1时，只有0.5px会被绘制在cell内部)
       const marginStyle = {
         x: x + margin / 2,
         y: y + margin / 2,
-        width: width - margin - 1,
-        height: height - margin - 1,
+        width: width - margin - 0.5,
+        height: height - margin - 0.5,
         lineWidth: margin,
       };
 

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -238,13 +238,14 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       `${this.cellType}.cell.interactionState.${stateName}`,
     );
 
+    // // 根据borderWidth更新borderShape大小     https://github.com/antvis/S2/pull/705
     const { x, y, height, width } = this.getCellArea();
     const margin = Number(stateStyles.borderWidth || 1);
 
     const shape = this.stateShapes.get('interactiveBorderShape') || null;
 
     if (shape && isNumber(margin)) {
-      // 默认留下2 pixel的buffer防止和周边cell的边框重合
+      // 默认留下1pixel的buffer防止和周边cell的边框重合
       const marginStyle = {
         x: x + 1 + margin / 2,
         y: y + 1 + margin / 2,

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -254,6 +254,7 @@ export const getTheme = (
             backgroundColor: basicColors[2],
             backgroundOpacity: 0.6,
             borderColor: basicColors[14],
+            borderWidth: 1,
             borderOpacity: 1,
           },
           // -------------- selected -------------------
@@ -270,6 +271,7 @@ export const getTheme = (
           prepareSelect: {
             borderColor: basicColors[14],
             borderOpacity: 1,
+            borderWidth: 1,
           },
         },
 


### PR DESCRIPTION


🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
原有逻辑interactionBorderShape不会根据lineWidth自适应更改大小，导致border绘制到cell外并被Clip，影响视觉效果。



interactorBorder宽度自适应

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌          ![image](https://user-images.githubusercontent.com/9219215/141739520-83abe439-9c68-4524-8644-257aef94957a.png)     | ✅      ![image](https://user-images.githubusercontent.com/9219215/141739247-08e792ea-745b-441a-9457-796701570c73.png)            | 
      



### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
