### PR TITLE
fix(hd-adapter): fix wrong container style when zoom scale changed

### DIFF
--- a/packages/s2-core/src/ui/hd-adapter/index.ts
+++ b/packages/s2-core/src/ui/hd-adapter/index.ts
@@ -82,17 +82,15 @@ export class HdAdapter {
       container,
       options: { width, height },
     } = this.spreadsheet;
-    const newWidth = Math.floor(width * ratio);
-    const newHeight = Math.floor(height * ratio);
 
     container.set('pixelRatio', ratio);
-    container.changeSize(newWidth, newHeight);
+    container.changeSize(width, height);
 
     this.spreadsheet.render(false);
   };
 
   private renderByZoomScale = debounce((e) => {
-    const ratio = Math.max(e.target.scale, window.devicePixelRatio);
+    const ratio = Math.ceil(e.target.scale);
     if (ratio > 1) {
       this.renderByDevicePixelRatio(ratio);
     }

--- a/packages/s2-core/src/utils/is-mobile.ts
+++ b/packages/s2-core/src/utils/is-mobile.ts
@@ -2,7 +2,7 @@
  * 判断是否是移动端。
  * 兼容场景：pc端但是使用mobile配置。
  */
-export function isMobile(device?) {
+export function isMobile(device?: string) {
   if (device === 'mobile') {
     return true;
   }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

> 高清适配应该只改变 canvas.width 和 canvas.height , 而不是 canvas.style.width canvas.style.height

1. 修复开启高清适配后 触控板放大后 图表宽度异常
   这个bug 的原始是 更新 `g` 的 DPR 后, 宽高不应该设置放大的宽高, 不然实际是 width * DPR * 2, 放大了4倍
2. 该问题还会导致列头裁剪异常 ref #561 问题1

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ![image](https://user-images.githubusercontent.com/21015895/141739569-3b21502a-d570-4595-8210-da603aad10e8.png) | ![image](https://user-images.githubusercontent.com/21015895/141739499-fb0bb498-55f2-46e7-8b7f-98612befd5a6.png)|

### 🔗 Related issue link

<!-- close #0 -->

ref #561 

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
