### PR TITLE
fix(facet): adjustXY in pagination

### DIFF
--- a/packages/s2-core/src/components/sheets/table-sheet/index.tsx
+++ b/packages/s2-core/src/components/sheets/table-sheet/index.tsx
@@ -223,6 +223,11 @@ export const TableSheet: React.FC<BaseSheetProps> = memo((props) => {
     ownSpreadsheet?.hideColumns(options.interaction?.hiddenColumnFields);
   }, [ownSpreadsheet, options.interaction?.hiddenColumnFields]);
 
+  useEffect(() => {
+    setCurrent(options?.pagination?.current || 1);
+    setPageSize(options?.pagination?.pageSize || 10);
+  }, [options?.pagination]);
+
   return (
     <StrictMode>
       <Spin spinning={isLoading === undefined ? loading : isLoading}>

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -467,6 +467,14 @@ export abstract class BaseFacet {
     this.dynamicRenderCell();
   };
 
+  getRendererHeight = () => {
+    const { start, end } = this.getCellRange();
+    return (
+      this.viewCellHeights.getCellOffsetY(end + 1) -
+      this.viewCellHeights.getCellOffsetY(start)
+    );
+  };
+
   adjustXAndY = (x: number, y: number): Point => {
     let newX = x;
     let newY = y;
@@ -475,11 +483,10 @@ export abstract class BaseFacet {
         newX = this.layoutResult.colsHierarchy.width - this.panelBBox.width;
       }
     }
-
-    const totalHeight = this.viewCellHeights.getTotalHeight();
+    const rendererHeight = this.getRendererHeight();
     if (y !== undefined) {
-      if (y + this.panelBBox.height >= totalHeight) {
-        newY = totalHeight - this.panelBBox.height;
+      if (y + this.panelBBox.height >= rendererHeight) {
+        newY = rendererHeight - this.panelBBox.height;
       }
     }
     return {


### PR DESCRIPTION
### 👀 PR includes

### 📝 Description

调整 Scroll Offset 的时候，在分页的时候，应该用分页之后实际渲染的高度作为调整 Scroll Offset 的边界

不然在不分页的时候滚动到底部，然后开启分页，就会越界导致渲染异常。