### PR TITLE
fix(components): switcher support receive antd popover props for resolve scroling with the page

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/switcher-spec.tsx
+++ b/packages/s2-core/__tests__/spreadsheet/switcher-spec.tsx
@@ -57,13 +57,24 @@ function MainLayout() {
     },
   };
   return (
-    <div>
-      <div style={{ margin: '10px' }}>
+    <div style={{ overflow: 'scroll', height: 600 }}>
+      <div
+        style={{
+          padding: 10,
+          height: 1000,
+          background: '#eee',
+          position: 'relative',
+        }}
+      >
+        <h2>测试滚动跟随</h2>
         <Switcher
           {...fields}
           onSubmit={(result) => {
             // eslint-disable-next-line no-console
             console.log('result: ', result);
+          }}
+          popover={{
+            getPopupContainer: (trigger) => trigger.parentElement,
           }}
         />
       </div>

--- a/packages/s2-core/__tests__/unit/ui/hd-adapter/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/hd-adapter/index-spec.ts
@@ -102,7 +102,6 @@ describe('HD Adapter Tests', () => {
     });
     visualViewport.dispatchEvent(new Event('resize'));
 
-    await expectContainerSize();
     expect(s2.render).not.toHaveBeenCalled();
   });
 

--- a/packages/s2-core/__tests__/unit/ui/hd-adapter/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/hd-adapter/index-spec.ts
@@ -15,7 +15,7 @@ describe('HD Adapter Tests', () => {
   let expectContainerSize: (
     size?: [number, number],
     updatedSize?: [number, number],
-  ) => Promise<void>;
+  ) => void;
 
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -30,14 +30,13 @@ describe('HD Adapter Tests', () => {
     hdAdapter = new HdAdapter(s2);
     hdAdapter.init();
 
-    expectContainerSize = async (
+    expectContainerSize = (
       [width, height] = [s2.options.width, s2.options.height],
       [updatedWidth, updatedHeight] = [
         s2.options.width * DPR,
         s2.options.height * DPR,
       ],
     ) => {
-      await sleep(1000);
       const canvas: HTMLCanvasElement = s2.container.get('el');
       expect(canvas.style.width).toEqual(`${width}px`);
       expect(canvas.style.height).toEqual(`${height}px`);
@@ -62,7 +61,9 @@ describe('HD Adapter Tests', () => {
 
   test('should not be update container size when zoom scale changed, but scale less than current DPR', async () => {
     visualViewport.dispatchEvent(new Event('resize'));
-    await expectContainerSize();
+    await sleep(500);
+
+    expectContainerSize();
     expect(s2.render).not.toHaveBeenCalled();
   });
 
@@ -73,10 +74,11 @@ describe('HD Adapter Tests', () => {
       configurable: true,
     });
     visualViewport.dispatchEvent(new Event('resize'));
+    await sleep(500);
 
     // update container width/height, not update container stylesheet width/height
     // eg: <canvas width="1000" height="500" style="width:500px; height: 250px;" />
-    await expectContainerSize(
+    expectContainerSize(
       [s2.options.width, s2.options.height],
       [s2.options.width * scale, s2.options.height * scale],
     );
@@ -90,7 +92,7 @@ describe('HD Adapter Tests', () => {
     });
     visualViewport.dispatchEvent(new Event('resize'));
 
-    await expectContainerSize();
+    await sleep(500);
     expect(s2.render).not.toHaveBeenCalled();
   });
 
@@ -102,6 +104,7 @@ describe('HD Adapter Tests', () => {
     });
     visualViewport.dispatchEvent(new Event('resize'));
 
+    await sleep(500);
     expect(s2.render).not.toHaveBeenCalled();
   });
 
@@ -114,7 +117,9 @@ describe('HD Adapter Tests', () => {
     hdAdapter.init();
     visualViewport.dispatchEvent(new Event('resize'));
 
-    await expectContainerSize();
+    await sleep(500);
+
+    expectContainerSize();
     expect(s2.render).not.toHaveBeenCalled();
   });
 });

--- a/packages/s2-core/src/components/switcher/index.tsx
+++ b/packages/s2-core/src/components/switcher/index.tsx
@@ -1,23 +1,22 @@
-import { Button, Popover } from 'antd';
+import { Button, Popover, PopoverProps } from 'antd';
 import React, { FC, ReactNode, useState } from 'react';
 import { SwitcherIcon } from '../icons';
 import { SwitcherContent, SwitcherContentProps } from './content';
-import './index.less';
 import { getSwitcherClassName } from './util';
 import { i18n } from '@/common/i18n';
+import './index.less';
 
 export interface SwitcherProps
   extends Omit<SwitcherContentProps, 'onToggleVisible'> {
   title?: ReactNode;
-  triggerClassName?: string;
-  overlayClassName?: string;
+  // ref: https://ant.design/components/popover-cn/#API
+  popover?: PopoverProps;
 }
 
 export const Switcher: FC<SwitcherProps> = ({
   title,
-  triggerClassName,
-  overlayClassName,
-  ...props
+  popover,
+  ...otherProps
 }) => {
   const [visible, setVisible] = useState(false);
 
@@ -27,14 +26,15 @@ export const Switcher: FC<SwitcherProps> = ({
 
   return (
     <Popover
-      className={triggerClassName}
-      overlayClassName={overlayClassName}
-      placement="bottomLeft"
-      trigger="click"
       visible={visible}
-      destroyTooltipOnHide={true}
-      content={<SwitcherContent {...props} onToggleVisible={onToggleVisible} />}
+      content={
+        <SwitcherContent {...otherProps} onToggleVisible={onToggleVisible} />
+      }
       onVisibleChange={onToggleVisible}
+      trigger="click"
+      placement="bottomLeft"
+      destroyTooltipOnHide
+      {...popover}
     >
       {title || (
         <Button

--- a/s2-site/docs/api/components/switcher.zh.md
+++ b/s2-site/docs/api/components/switcher.zh.md
@@ -17,6 +17,7 @@ order: 3
 | overlayClassName      | `string`                                                |      |          | 弹出框样式名                           |
 | innerContentClassName | `string`                                                |      |          | 弹出框内容样式名                       |
 | onSubmit              | `(result:` [SwitcherResult](#switcherresult)`) => void` |      |          | 关闭弹窗后，处理行列切换结果的回调函数 |
+| popover              | [PopoverProps](https://ant.design/components/popover-cn/#API) |      |          | 弹窗配置, 透传给 `antd` 的 `Popover` 组件 |
 
 ## SwitcherField
 

--- a/s2-site/docs/manual/basic/analysis/switcher.zh.md
+++ b/s2-site/docs/manual/basic/analysis/switcher.zh.md
@@ -6,7 +6,7 @@ order: 10
 内部不维护状态
 自定义 title
 
-S2 自带维度切换组件 Switcher 。借助它，你可以非常方便的实现交互式行列切换，以及维度隐藏的功能。
+S2 自带维度切换组件 `Switcher` 。借助它，你可以非常方便的实现交互式行列切换，以及维度隐藏的功能。
 
 ![preview](https://gw.alipayobjects.com/zos/antfincdn/fyf455mio/2021-09-29%25252015.08.03.gif)
 
@@ -48,51 +48,49 @@ ReactDOM.render(
 
 ```
 
-<playground path='analysis/switcher/demo/pure-switcher.tsx' rid='container'></playground>
+<playground path='react-component/switcher/demo/pure-switcher.tsx' rid='container'></playground>
 
 ## 配置解释
 
 ### 维度配置
 
-Switcher 可接收三种类型的维度配置，分别是`rows`，`columns`和`values`。它们的类型皆为 [SwitcherField](/zh/docs/api/components/switcher#switcherfield)。
+`Switcher` 可接收三种类型的维度配置，分别是 `rows`，`columns` 和 `values`。它们的类型皆为 [SwitcherField](/zh/docs/api/components/switcher#switcherfield)。
 
 > 其中`rows`和`columns`两个维度可以相互拖拽到彼此的配置框中，而`values`只能在自己的配置框中更改字段顺序。
 
-通过传入不同维度配置，Switcher 的展示形态也会有所不同：
-<table
-        style="width: 100%; outline: none; border-collapse: collapse;"
-      >
-        <colgroup>
-          <col width="33%"/>
-          <col width="33%" />
-        </colgroup>
-        <tbody>
-        <tr>
-            <td style="text-align: center;">
-            三种维度
-            </td>
-              <td style="text-align: center;">
-            两种维度
-            </td>
-              <td style="text-align: center;">
-            一种维度
-            </td>
-        </tr>
-         <tr style="vertical-align: top;">
-          <td>
-             <img alt="three-dimensions" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/yp0RwxxNa/93e973ba-38d1-41b5-b6c7-374dbb003850.png">
-            </td>
-            <td>
-             <img alt="two-dimensions" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/tAUVwe9CP/93feeb52-1490-430f-98a3-fdba64750f31.png">
-            </td>
-              <td>
-            <img alt="one-dimension" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/fuvYDKebN/75b333ef-56f4-4c2c-ba15-12c4fd03113c.png">
-            </td>
-        </tr>
-        </tbody>
-  </table>
+通过传入不同维度配置，`Switcher` 的展示形态也会有所不同：
+<table style="width: 100%; outline: none; border-collapse: collapse;">
+  <colgroup>
+    <col width="33%"/>
+    <col width="33%" />
+  </colgroup>
+  <tbody>
+  <tr>
+    <td style="text-align: center;">
+    三种维度
+    </td>
+      <td style="text-align: center;">
+    两种维度
+    </td>
+      <td style="text-align: center;">
+    一种维度
+    </td>
+  </tr>
+  <tr style="vertical-align: top;">
+    <td>
+      <img alt="three-dimensions" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/yp0RwxxNa/93e973ba-38d1-41b5-b6c7-374dbb003850.png">
+    </td>
+    <td>
+      <img alt="two-dimensions" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/tAUVwe9CP/93feeb52-1490-430f-98a3-fdba64750f31.png">
+    </td>
+      <td>
+    <img alt="one-dimension" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/fuvYDKebN/75b333ef-56f4-4c2c-ba15-12c4fd03113c.png">
+    </td>
+  </tr>
+  </tbody>
+</table>
 
-* 每个维度默认只能进行拖拽排序。如果你希望能控制其字段的显隐，可以设置其`selectable`属性用于开启字段的 checkbox：
+* 每个维度默认只能进行拖拽排序。如果你希望能控制其字段的显隐，可以设置其 `selectable` 属性用于开启字段的 `checkbox`：
 
 ```js
 const field = {
@@ -103,7 +101,7 @@ const field = {
 };
 ```
 
-* 如果维度中的每一个字段项还存在关系子项，可以设置其`expandable`属性用于开发展开子项的 checkbox，也可以进一步设置`expandText`定制展开 checkbox 的提示文字：
+* 如果维度中的每一个字段项还存在关系子项，可以设置其 `expandable` 属性用于开发展开子项的 `checkbox`，也可以进一步设置 `expandText` 定制展开 `checkbox` 的提示文字：
 
 ```js
 const field = {
@@ -115,71 +113,72 @@ const field = {
 };
 ```
 
-<table
-        style="width: 100%; outline: none; border-collapse: collapse;"
-      >
-        <colgroup>
-          <col width="50%"/>
-          <col width="50%" />
-        </colgroup>
-        <tbody>
-        <tr>
-            <td style="text-align: center;">
-            控制显隐
-            </td>
-              <td style="text-align: center;">
-            展开子项
-            </td>
-        </tr>
-         <tr style="vertical-align: top;">
-          <td>
-             <img alt="selectable" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/hqNGSM13B/a202c136-d403-4510-9271-733687504110.png">
-            </td>
-            <td>
-             <img alt="expandable" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/5VbNE%26p2X/53dd765c-a72f-4e7a-a4ce-3904c8e7acfc.png">
-            </td>
-        </tr>
-        </tbody>
-  </table>
+<table style="width: 100%; outline: none; border-collapse: collapse;">
+  <colgroup>
+    <col width="50%"/>
+    <col width="50%" />
+  </colgroup>
+  <tbody>
+  <tr>
+    <td style="text-align: center;">
+    控制显隐
+    </td>
+      <td style="text-align: center;">
+    展开子项
+    </td>
+  </tr>
+  <tr style="vertical-align: top;">
+    <td>
+      <img alt="selectable" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/hqNGSM13B/a202c136-d403-4510-9271-733687504110.png">
+    </td>
+    <td>
+      <img alt="expandable" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/5VbNE%26p2X/53dd765c-a72f-4e7a-a4ce-3904c8e7acfc.png">
+    </td>
+  </tr>
+  </tbody>
+</table>
 
 ### 提交修改
 
-Switcher 组件会在弹窗关闭后触发 `onSubmit` 回调，且此回调会接收一个 [SwitcherResult](/zh/docs/api/components/switcher#switcherresult) 类型的参数，你可以通过该回调拿到排序的结果。
+ `Switcher` 组件会在弹窗关闭后触发 `onSubmit` 回调，且此回调会接收一个 [SwitcherResult](/zh/docs/api/components/switcher#switcherresult) 类型的参数，你可以通过该回调拿到排序的结果。
 
 所有结果会**按维度**分组，并且每一组字段会**扁平化后**按按顺序排序。
 
 你可以通过以下示例查看详细的结果数据类型：
+
 <playground path='analysis/switcher/demo/pivot.tsx' rid='result'></playground>
 
 ❗️注意：出于减少内部状态过时的考虑，Switcher 组件内部并不会持久化操作后状态。也就是说在每次弹窗关闭后，Switcher 内部状态会清空，再次打开时任然以 Props 中的各个维度配置为准。
 
 ### 定制化
 
-* 如果 Switcher 组件内置的触发按钮不满足你的需求，可通过`title`定制化触发按钮
-* Switcher 组件也提供了`resetText`属性用于定义重置按钮的问题
+* 如果 `Switcher` 组件内置的触发按钮不满足你的需求，可通过 `title` 定制化触发按钮
+* `Switcher` 组件也提供了 `resetText` 属性用于定义重置按钮的问题
 
 ![customize](https://gw.alipayobjects.com/zos/antfincdn/N2fNJBRwz/ef4ffb16-505b-41ed-9a72-c6804c66827a.png)
 
-🎨 Switcher 组件详细的配置参考 [Switcher Props](/zh/docs/api/components/switcher) 文档。
+* `Switcher` 组件的弹出层基于 `Antd Design` 的 [Popover](https://ant.design/components/popover-cn/) 开发，支持透传 `Popover` [配置项](https://ant.design/components/popover-cn/#API), 进行弹出层的自定义，比如 `触发方式`, `箭头指向`, `卡片弹出方向` 等
+
+```tsx
+<Switcher popover={{ arrowPointAtCenter: true }} />
+```
+
+🎨 `Switcher` 组件详细的配置参考 [Switcher Props](/zh/docs/api/components/switcher) 文档。
 
 ## 示例
 
-### 交叉表
-
-交叉表联合 Switcher 组件使用：
+### 结合交叉表使用
 
 * 行列值可以相互移动
 * 指标值可以控制显隐
 
-<playground path='analysis/switcher/demo/pivot-with-children.tsx' rid='pivot'></playground>
+<playground path='react-component/switcher/demo/pivot-with-children.tsx' rid='pivot'></playground>
 
-​
-
-### 明细表
+### 结合明细表使用
 
 * 列头可以控制显隐
 * 表格列头对应出现展开图标
 
-<playground path='analysis/switcher/demo/table.tsx' rid='table'></playground>
+<playground path='react-component/switcher/demo/table.tsx' rid='table'></playground>
 
 ​📊 查看更多 [维度切换示例](/zh/examples/analysis/switcher#pure-switcher)。

--- a/s2-site/examples/react-component/switcher/demo/table.tsx
+++ b/s2-site/examples/react-component/switcher/demo/table.tsx
@@ -69,7 +69,7 @@ fetch(
             sheetType={'table'}
             adaptive={false}
             dataCfg={{ data, fields }}
-            options={{ ...s2options, hiddenColumnFields }}
+            options={{ ...s2options, interaction: { hiddenColumnFields } }}
           />
         </div>
       );


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复 `<Switcher/>` 滚动不跟随的问题
2. 支持透传 antd `popover` 配置, 满足更多自定义需求
3. 修复维度切换组件 文档示例不生效

默认还是挂载在 `body` 下, 如解决滚动不跟随问题, 使用者自行透传 getPopupContainer 即可

```tsx
  <Switcher
    popover={{
      getPopupContainer: (trigger) => trigger.parentElement,
    }}
  />
```

ref: 
https://ant.design/docs/react/faq-cn#Select-Dropdown-DatePicker-TimePicker-Popover-Popconfirm-%E4%BC%9A%E8%B7%9F%E9%9A%8F%E6%BB%9A%E5%8A%A8%E6%9D%A1%E4%B8%8A%E4%B8%8B%E7%A7%BB%E5%8A%A8%EF%BC%9F

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ![Kapture 2021-11-16 at 15 29 35](https://user-images.githubusercontent.com/21015895/141940482-f3b917e8-6fb8-4a29-9009-dae229106ca4.gif) |          
![Kapture 2021-11-16 at 15 31 53](https://user-images.githubusercontent.com/21015895/141940638-cdafbef9-e9f4-447a-9a4f-341bd8e62aa0.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
