### PR TITLE
fix(scroll): sync row scroll offset when corner cell resized

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -173,7 +173,7 @@ function MainLayout() {
   };
 
   return (
-    <div>
+    <div style={{ paddingBottom: 50 }}>
       <Space size="middle" style={{ marginBottom: 20 }}>
         <Switch
           checkedChildren="渲染组件"


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #717 

### 📝 Description

1. 角头宽度改变后, 同步行头滚动条偏移:
> 背景: 拖拽调整宽高后, 之前是粗暴的将 行头滚动条重置为0, 如果用户滚动条不是起始位置的话, 每次拖拽都重置, 体验很不好
2. 重构坐标偏移代码

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ![Kapture 2021-11-16 at 20 15 07](https://user-images.githubusercontent.com/21015895/141983632-651bc675-b401-413e-9361-bcac58611618.gif) | 
![Kapture 2021-11-16 at 20 13 29](https://user-images.githubusercontent.com/21015895/141983417-ca7ed807-c0f2-4e65-8736-7c97d8062a79.gif) |

### 🔗 Related issue link

close #717 

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
