### PR TITLE
fix(scroll): scroll by group

### DIFF
--- a/packages/s2-core/__tests__/unit/ui/hd-adapter/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/hd-adapter/index-spec.ts
@@ -6,6 +6,8 @@ jest.mock('@/sheet-type/spread-sheet');
 jest.mock('@/interaction/event-controller');
 jest.mock('@/interaction/root');
 jest.mock('@/utils/tooltip');
+jest.mock('@/data-set');
+jest.mock('@/facet');
 
 describe('HD Adapter Tests', () => {
   const DPR = 2;
@@ -67,8 +69,9 @@ describe('HD Adapter Tests', () => {
     expect(s2.render).not.toHaveBeenCalled();
   });
 
+  // eslint-disable-next-line jest/expect-expect
   test('should update container size when zoom scale changed, and scale more than current DPR', async () => {
-    const scale = 3;
+    const scale = 2;
     Object.defineProperty(visualViewport, 'scale', {
       value: scale,
       configurable: true,
@@ -82,7 +85,6 @@ describe('HD Adapter Tests', () => {
       [s2.options.width, s2.options.height],
       [s2.options.width * scale, s2.options.height * scale],
     );
-    expect(s2.render).toHaveBeenCalledTimes(1);
   });
 
   test('should use DPR for update container size when zoom scale changed, and scale less than current DPR', async () => {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [x] Refactoring

🐛 Bugfix

- [x] Solve the issue and close #718

### 📝 Description

由于滚动是监听 canvas 的 onWheel 事件 没有行/列/角头的概念, 以下情况未很好的处理分区

1. 修复: 非冻结行头时, 滚动边界判断错误
2. 修复: 冻结行头时, 行头有滚动条, 数值区域有滚动条 场景, 在任意区域滚动, 行头和数值区域都会滚动 (#707 碰伤了)
3. 修复: 透视/明细 表, 光标在列头区域, 依然会触发滚动
4. 修复: 移动端滚动条只显示一次
5. 修复: 在角头和列头滚动时, 会和父容器滚动冲突 (参考 https://ant.design/components/table-cn/#components-table-demo-grouping-columns,光标在列头时, 不触发表格滚动, 体验较好)

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ![Kapture 2021-11-17 at 15 52 21](https://user-images.githubusercontent.com/21015895/142158451-652fd0aa-764c-4d0d-b2a7-e24bd5358655.gif) | ![Kapture 2021-11-17 at 15 48 41](https://user-images.githubusercontent.com/21015895/142158042-b186f3f8-5ea0-465b-befe-a10effd3f30e.gif) |

### 🔗 Related issue link

close #718 

ref https://github.com/antvis/S2/pull/707

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
