### PR TITLE
fix: difficult to select the tooltip after click then merged cell

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -169,7 +169,7 @@ describe('Interaction Event Controller Tests', () => {
       eventNames: [S2Event.CORNER_CELL_MOUSE_DOWN],
     },
     {
-      type: CellTypes.MERGED_CELLS,
+      type: CellTypes.MERGED_CELL,
       eventNames: [S2Event.MERGED_CELLS_MOUSE_DOWN],
     },
   ])('should emit mouse down for %o', expectEvents(OriginEventType.MOUSE_DOWN));
@@ -208,7 +208,7 @@ describe('Interaction Event Controller Tests', () => {
       ],
     },
     {
-      type: CellTypes.MERGED_CELLS,
+      type: CellTypes.MERGED_CELL,
       eventNames: [
         S2Event.MERGED_CELLS_MOUSE_MOVE,
         S2Event.MERGED_CELLS_HOVER,
@@ -238,7 +238,7 @@ describe('Interaction Event Controller Tests', () => {
       eventNames: [S2Event.CORNER_CELL_MOUSE_UP],
     },
     {
-      type: CellTypes.MERGED_CELLS,
+      type: CellTypes.MERGED_CELL,
       eventNames: [S2Event.MERGED_CELLS_MOUSE_UP],
     },
   ])(
@@ -264,7 +264,7 @@ describe('Interaction Event Controller Tests', () => {
       eventNames: [S2Event.CORNER_CELL_DOUBLE_CLICK],
     },
     {
-      type: CellTypes.MERGED_CELLS,
+      type: CellTypes.MERGED_CELL,
       eventNames: [S2Event.MERGED_CELLS_DOUBLE_CLICK],
     },
   ])(

--- a/packages/s2-core/src/cell/merged-cell.ts
+++ b/packages/s2-core/src/cell/merged-cell.ts
@@ -28,7 +28,7 @@ export class MergedCell extends DataCell {
   }
 
   public get cellType() {
-    return CellTypes.MERGED_CELLS;
+    return CellTypes.MERGED_CELL;
   }
 
   public update() {}

--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -24,7 +24,7 @@ export enum CellTypes {
   ROW_CELL = 'rowCell',
   COL_CELL = 'colCell',
   CORNER_CELL = 'cornerCell',
-  MERGED_CELLS = 'mergedCells',
+  MERGED_CELL = 'mergedCell',
 }
 
 export const HOVER_FOCUS_TIME = 800;

--- a/packages/s2-core/src/interaction/base-interaction/click/merged-cells-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/merged-cells-click.ts
@@ -1,6 +1,6 @@
 import { Event } from '@antv/g-canvas';
 import { BaseEvent, BaseEventImplement } from '../../base-event';
-import { S2Event } from '@/common/constant';
+import { InterceptType, S2Event } from '@/common/constant';
 
 export class MergedCellsClick extends BaseEvent implements BaseEventImplement {
   public bindEvents() {
@@ -10,6 +10,11 @@ export class MergedCellsClick extends BaseEvent implements BaseEventImplement {
   private bindDataCellClick() {
     this.spreadsheet.on(S2Event.MERGED_CELLS_CLICK, (event: Event) => {
       event.stopPropagation();
+      const { interaction } = this.spreadsheet;
+      if (interaction.hasIntercepts([InterceptType.CLICK])) {
+        return;
+      }
+      interaction.addIntercepts([InterceptType.HOVER]);
     });
   }
 }

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -242,7 +242,7 @@ export class EventController {
       case CellTypes.CORNER_CELL:
         this.spreadsheet.emit(S2Event.CORNER_CELL_MOUSE_DOWN, event);
         break;
-      case CellTypes.MERGED_CELLS:
+      case CellTypes.MERGED_CELL:
         this.spreadsheet.emit(S2Event.MERGED_CELLS_MOUSE_DOWN, event);
         break;
       default:
@@ -274,7 +274,7 @@ export class EventController {
         case CellTypes.CORNER_CELL:
           this.spreadsheet.emit(S2Event.CORNER_CELL_MOUSE_MOVE, event);
           break;
-        case CellTypes.MERGED_CELLS:
+        case CellTypes.MERGED_CELL:
           this.spreadsheet.emit(S2Event.MERGED_CELLS_MOUSE_MOVE, event);
           break;
         default:
@@ -301,7 +301,7 @@ export class EventController {
           case CellTypes.CORNER_CELL:
             this.spreadsheet.emit(S2Event.CORNER_CELL_HOVER, event);
             break;
-          case CellTypes.MERGED_CELLS:
+          case CellTypes.MERGED_CELL:
             this.spreadsheet.emit(S2Event.MERGED_CELLS_HOVER, event);
             break;
           default:
@@ -349,7 +349,7 @@ export class EventController {
             }
             this.spreadsheet.emit(S2Event.CORNER_CELL_CLICK, event);
             break;
-          case CellTypes.MERGED_CELLS:
+          case CellTypes.MERGED_CELL:
             this.spreadsheet.emit(S2Event.MERGED_CELLS_CLICK, event);
             break;
           default:
@@ -371,7 +371,7 @@ export class EventController {
         case CellTypes.CORNER_CELL:
           this.spreadsheet.emit(S2Event.CORNER_CELL_MOUSE_UP, event);
           break;
-        case CellTypes.MERGED_CELLS:
+        case CellTypes.MERGED_CELL:
           this.spreadsheet.emit(S2Event.MERGED_CELLS_MOUSE_UP, event);
           break;
         default:
@@ -403,7 +403,7 @@ export class EventController {
           case CellTypes.CORNER_CELL:
             spreadsheet.emit(S2Event.CORNER_CELL_DOUBLE_CLICK, event);
             break;
-          case CellTypes.MERGED_CELLS:
+          case CellTypes.MERGED_CELL:
             spreadsheet.emit(S2Event.MERGED_CELLS_DOUBLE_CLICK, event);
             break;
           default:

--- a/packages/s2-core/src/utils/interaction/merge-cells.ts
+++ b/packages/s2-core/src/utils/interaction/merge-cells.ts
@@ -98,7 +98,7 @@ export const getPolygonPoints = (cells: S2CellType[]) => {
  * @param invisibleCellInfo
  * @param sheet
  */
-const getInvisibleInfo = (
+export const getInvisibleInfo = (
   invisibleCellInfo: MergedCellInfo[],
   sheet: SpreadSheet,
 ) => {
@@ -285,7 +285,7 @@ const removeUnmergedCellsInfo = (
  * @param sheet
  */
 export const unmergeCell = (sheet: SpreadSheet, removedCells: MergedCell) => {
-  if (!removedCells || removedCells.cellType !== CellTypes.MERGED_CELLS) {
+  if (!removedCells || removedCells.cellType !== CellTypes.MERGED_CELL) {
     // eslint-disable-next-line no-console
     console.error(`unmergeCell: the ${removedCells} is not a MergedCell`);
     return;

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -95,7 +95,7 @@ export enum CellTypes {
   ROW_CELL = 'rowCell', // 行头单元格
   COL_CELL = 'colCell', // 列头单元格
   CORNER_CELL = 'cornerCell', // 角头单元格
-  MERGED_CELLS = 'mergedCells', // 合并后的单元格
+  MERGED_CELL = 'mergedCell', // 合并后的单元格
 }
 ```
 

--- a/s2-site/docs/manual/advanced/interaction/merge-cell.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/merge-cell.zh.md
@@ -324,7 +324,7 @@ const s2options = {
 const s2 = new PivotSheet(container, s2DataConfig, s2options);
 
 s2.render();
-// 监听 mergedCells 的点击事件，自定义点击后的交互操作
+// 监听 mergedCell 的点击事件，自定义点击后的交互操作
 s2.on(S2Event.MERGED_CELLS_CLICK, (event) => {
   const cell: MergedCell = s2.getCell(event.target);
   s2.tooltip.show({

--- a/s2-site/examples/interaction/advanced/demo/merge-cells.tsx
+++ b/s2-site/examples/interaction/advanced/demo/merge-cells.tsx
@@ -1,6 +1,7 @@
 import { PivotSheet, S2Event, MergedCell } from '@antv/s2';
 import React from 'react';
 import '@antv/s2/dist/s2.min.css';
+import { Button } from 'antd';
 
 fetch(
   'https://gw.alipayobjects.com/os/bmw-prod/cd9814d0-6dfa-42a6-8455-5a6bd0ff93ca.json',
@@ -10,24 +11,24 @@ fetch(
     const container = document.getElementById('container');
 
     const TooltipComponent = (
-      <button
+      <Button
         key={'button'}
         onClick={() => {
           s2.interaction.mergeCells();
         }}
       >
         合并单元格
-      </button>
+      </Button>
     );
 
     const mergedCellsTooltip = (mergedCell: MergedCell) => (
-      <button
+      <Button
         onClick={() => {
           s2.interaction.unmergeCell(mergedCell);
         }}
       >
         取消合并单元格
-      </button>
+      </Button>
     );
 
     const s2DataConfig = {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [X] Refactoring
- [X] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
1. 调整button 样式，保持风格统一
2. 修复点击合并单元格后 tooltip 难以选中
3. 将 MERGED_CELLS 调整为 MERGE_CELL ，保持名称一致。

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |
|![image](https://user-images.githubusercontent.com/20497176/142192624-5df476ee-477f-4619-a76c-898149af4271.png)|![image](https://user-images.githubusercontent.com/20497176/142192941-52a83ba8-53f5-4768-b6a4-1d8c3d6178d7.png)|
|![merged-cell的tooltip无法点击到](https://user-images.githubusercontent.com/20497176/142193868-c0f5dc5c-8767-4f28-8f83-72c014bc35a9.gif)|![merged-cell的tooltip可以保持](https://user-images.githubusercontent.com/20497176/142193905-fe73b974-c3c1-4037-9c13-e33f69c70d04.gif)|


### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
