### PR TITLE
chore: update less loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "jest": "^26.6.3",
     "jest-electron": "^0.1.12",
     "jest-extended": "^0.11.5",
-    "jest-less-loader": "^0.1.1",
+    "jest-less-loader": "^0.1.2",
     "jest-raw-loader": "^1.0.1",
     "jest-url-loader": "^0.1.0",
     "lerna": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7672,10 +7672,10 @@ jest-leak-detector@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-less-loader@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jest-less-loader/-/jest-less-loader-0.1.1.tgz#c087732315704f1989877493727814d218d82e1f"
-  integrity sha512-GXDx91QkBnSEFqxL5LFS3B6/Q1IbYmJRhss1D8IfcgyLbEsG1FxA3mYVnYQwsFCwlCpIJVir3F4qeWx58gR3CA==
+jest-less-loader@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/jest-less-loader/-/jest-less-loader-0.1.2.tgz#8d30c719a44a401304035aa7984e342afbd0f0b4"
+  integrity sha512-J04E9UnTq00I+maz9KADl/CtC+5ee2HhKPVo1ALRW3xVzmzx6ltY9L9IlupacE6uA5n/rPs1+aZexFt+1xFM/A==
 
 jest-matcher-utils@^22.0.0:
   version "22.4.3"


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🔧 Chore

- [x] 更新jest-less-loader版本

### 📝 Description

jest-less-loader在`0.1.1`时不支持less文件中包含`@import`语法，给老王提了一个[PR](https://github.com/hustcc/jest-less-loader/pull/2)，现在可以愉快的使用公共变量和mixin了

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
