### PR TITLE
fix: 🐛 修复1px边框错位的问题

### DIFF
--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -257,10 +257,10 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
         ) {
           if (isNumber(style)) {
             const marginStyle = {
-              x: x + style / 2,
-              y: y + style / 2,
-              width: width - style,
-              height: height - style,
+              x: Math.ceil(x + style / 2),
+              y: Math.ceil(y + style / 2),
+              width: width - style - 1,
+              height: height - style - 1,
             };
             each(marginStyle, (style, styleKey) => {
               updateShapeAttr(shape, styleKey, style);

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -257,7 +257,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
         ) {
           if (isNumber(style)) {
             const marginStyle = {
-              x: Math.ceil(x + style / 2),
+              x: Math.ceil(x + style / 2), // TODO: 边框整体重构后需revisit
               y: Math.ceil(y + style / 2),
               width: width - style - 1,
               height: height - style - 1,


### PR DESCRIPTION
🐛 Bugfix




### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌            
![image](https://user-images.githubusercontent.com/9219215/142579743-c83fd9b7-06b5-4da3-bb9a-44a41340bf08.png)   | ✅                 
![image](https://user-images.githubusercontent.com/9219215/142579786-37e1fc27-a6c7-4be0-9bd5-6651daa12d09.png)
             |




画奇数宽的线条整个画在cell内部会导致法线两侧长度不一（1px是最小显示单位）   因此加上Math.Ceil 同时长宽上减去1的buffer，确保整个边框不被rowGroup和colGroup clip


