### PR TITLE
fix(tooltip): tooltip don't show

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/interaction-tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-tooltip-spec.ts
@@ -1,0 +1,45 @@
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { createMockCellInfo, getContainer } from 'tests/util/helpers';
+import { Event as GEvent } from '@antv/g-canvas';
+import { PivotSheet, SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+import { S2Event } from '@/common/constant';
+
+const s2options: S2Options = {
+  width: 600,
+  height: 400,
+  tooltip: {
+    showTooltip: true,
+  },
+};
+
+describe('Interaction Tooltip Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    jest
+      .spyOn(SpreadSheet.prototype, 'getCell')
+      .mockImplementation(() => createMockCellInfo('testId').mockCell as any);
+
+    s2 = new PivotSheet(getContainer(), mockDataConfig, s2options);
+    s2.render();
+  });
+
+  afterEach(() => {
+    s2.destroy();
+  });
+
+  test('should display tooltip when data cell clicked', () => {
+    const showTooltipWithInfoSpy = jest
+      .spyOn(s2, 'showTooltipWithInfo')
+      .mockImplementation(() => {});
+
+    s2.emit(S2Event.DATA_CELL_CLICK, {
+      stopPropagation() {},
+    } as unknown as GEvent);
+
+    expect(showTooltipWithInfoSpy).toHaveBeenCalledTimes(1);
+    expect(s2.tooltip.container.style.display).not.toEqual('none');
+    expect(s2.tooltip.container.style.visibility).not.toEqual('hidden');
+  });
+});

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/data-cell-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/data-cell-click-spec.ts
@@ -1,8 +1,7 @@
-import { createFakeSpreadSheet } from 'tests/util/helpers';
+import { createFakeSpreadSheet, createMockCellInfo } from 'tests/util/helpers';
 import { Event as GEvent } from '@antv/g-canvas';
-import { omit } from 'lodash';
 import { DataCellClick } from '@/interaction/base-interaction/click';
-import { S2Options, ViewMeta } from '@/common/interface';
+import { S2Options } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import { InteractionStateName, S2Event } from '@/common/constant';
 
@@ -11,21 +10,11 @@ jest.mock('@/interaction/event-controller');
 describe('Interaction Data Cell Click Tests', () => {
   let dataCellClick: DataCellClick;
   let s2: SpreadSheet;
-  const mockCellViewMeta: Partial<ViewMeta> = {
-    id: '1',
-    colIndex: 0,
-    rowIndex: 0,
-    type: undefined,
-  };
-  const mockCellMeta = omit(mockCellViewMeta, 'update');
-  const mockCell = {
-    ...mockCellViewMeta,
-    getMeta: () => mockCellViewMeta,
-  };
+  const mockCellInfo = createMockCellInfo('testId');
 
   beforeEach(() => {
     s2 = createFakeSpreadSheet();
-    s2.getCell = () => mockCell as any;
+    s2.getCell = () => mockCellInfo as any;
     dataCellClick = new DataCellClick(s2 as unknown as SpreadSheet);
     s2.options = {
       tooltip: {
@@ -46,7 +35,7 @@ describe('Interaction Data Cell Click Tests', () => {
       stopPropagation() {},
     } as unknown as GEvent);
     expect(s2.interaction.getState()).toEqual({
-      cells: [mockCellMeta],
+      cells: [mockCellInfo.mockCellMeta],
       stateName: InteractionStateName.SELECTED,
     });
     expect(s2.showTooltipWithInfo).toHaveBeenCalled();
@@ -59,7 +48,7 @@ describe('Interaction Data Cell Click Tests', () => {
     s2.emit(S2Event.DATA_CELL_CLICK, {
       stopPropagation() {},
     } as unknown as GEvent);
-    expect(selected).toHaveBeenCalledWith([mockCell]);
+    expect(selected).toHaveBeenCalledWith([mockCellInfo.mockCell]);
   });
 
   test('should emit link field jump event when link field text click', () => {

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/data-cell-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/data-cell-click-spec.ts
@@ -14,7 +14,7 @@ describe('Interaction Data Cell Click Tests', () => {
 
   beforeEach(() => {
     s2 = createFakeSpreadSheet();
-    s2.getCell = () => mockCellInfo as any;
+    s2.getCell = () => mockCellInfo.mockCell as any;
     dataCellClick = new DataCellClick(s2 as unknown as SpreadSheet);
     s2.options = {
       tooltip: {

--- a/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
@@ -174,7 +174,7 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
     expect(s2.hideTooltip).toHaveBeenCalled();
   });
 
-  test('should set lastClickCell', () => {
+  test('should set lastClickedCell', () => {
     s2.interaction.changeState({
       cells: [],
       stateName: InteractionStateName.SELECTED,
@@ -187,6 +187,6 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
       stopPropagation() {},
     } as unknown as GEvent);
 
-    expect(s2.store.get('lastClickCell')).toEqual(mockCell00.mockCell);
+    expect(s2.store.get('lastClickedCell')).toEqual(mockCell00.mockCell);
   });
 });

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -3,9 +3,10 @@ import path from 'path';
 import { dsvFormat } from 'd3-dsv';
 import EE from '@antv/event-emitter';
 import { Canvas } from '@antv/g-canvas';
+import { omit } from 'lodash';
 import { RootInteraction } from '@/interaction/root';
 import { Store } from '@/common/store';
-import { S2Options } from '@/common/interface';
+import { S2Options, ViewMeta } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import { BaseTooltip } from '@/ui/tooltip';
 import { customMerge } from '@/utils/merge';
@@ -92,3 +93,26 @@ export function getGradient(
 
   return `rgb(${r},${g},${b})`;
 }
+
+export const createMockCellInfo = (
+  cellId: string,
+  { colIndex = 0, rowIndex = 0 } = {},
+) => {
+  const mockCellViewMeta: Partial<ViewMeta> = {
+    id: cellId,
+    colIndex,
+    rowIndex,
+    type: undefined,
+  };
+  const mockCellMeta = omit(mockCellViewMeta, 'update');
+  const mockCell = {
+    ...mockCellViewMeta,
+    getMeta: () => mockCellViewMeta,
+    hideInteractionShape: jest.fn(),
+  };
+
+  return {
+    mockCell,
+    mockCellMeta,
+  };
+};

--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -7,7 +7,7 @@ export enum InteractionName {
   BRUSH_SELECTION = 'brushSelection',
   COL_ROW_RESIZE = 'rowColResize',
   COL_ROW_MULTI_SELECTION = 'colRowMultiSelection',
-  COL_ROW_SHIHT_MULTI_SELECTION = 'colRowShiftMultiSelection',
+  COL_ROW_SHIFT_MULTI_SELECTION = 'colRowShiftMultiSelection',
 }
 
 export enum InteractionStateName {

--- a/packages/s2-core/src/common/interface/store.ts
+++ b/packages/s2-core/src/common/interface/store.ts
@@ -87,7 +87,7 @@ export interface StoreKey {
   visibleActionIcons: GuiIcon[];
 
   // last click cell
-  lastClickCell: S2CellType<ViewMeta>;
+  lastClickedCell: S2CellType<ViewMeta>;
 
   [key: string]: unknown;
 }

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -266,7 +266,7 @@ export class RootInteraction {
         new DataCellMultiSelection(this.spreadsheet),
       );
       this.interactions.set(
-        InteractionName.COL_ROW_SHIHT_MULTI_SELECTION,
+        InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
         new ShiftMultiSelection(this.spreadsheet),
       );
     }

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -1,20 +1,7 @@
-import { last } from 'lodash';
-import { Event as CanvasEvent } from '@antv/g-canvas';
 import { SpreadSheet } from './spread-sheet';
 import { DataCell } from '@/cell';
-import {
-  InterceptType,
-  S2Event,
-  TOOLTIP_OPERATOR_MENUS,
-} from '@/common/constant';
-import {
-  S2Options,
-  SortParam,
-  SpreadSheetFacetCfg,
-  TooltipOperatorOptions,
-  ViewMeta,
-} from '@/common/interface';
-import { Node } from '@/facet/layout/node';
+import { S2Event } from '@/common/constant';
+import { S2Options, SpreadSheetFacetCfg, ViewMeta } from '@/common/interface';
 import { RowCellCollapseTreeRowsType } from '@/common/interface/emitter';
 import { PivotDataSet } from '@/data-set';
 import { CustomTreePivotDataSet } from '@/data-set/custom-tree-pivot-data-set';


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复点击数值单元格 不显示 tooltip

原因是 https://github.com/antvis/S2/pull/732 加入 shift 多选后, 和 单选冲突

shift 的第一次点击本质上就是单选, 所以直接用 单选的逻辑即可

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
