### PR TITLE
fix(table): table sheet sort

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.tsx
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.tsx
@@ -1,0 +1,93 @@
+import { getMockData } from '../../../s2-react/__tests__/util/helpers';
+import { TableSheet, S2Options, S2DataConfig } from '@/index';
+
+const data = getMockData(
+  '../../../s2-react/__tests__/data/tableau-supermarket.csv',
+);
+
+const columns = [
+  'order_id',
+  'order_date',
+  'ship_date',
+  'express_type',
+  'customer_name',
+  'customer_type',
+  'city',
+  'province',
+  'counter',
+  'area',
+  'type',
+  'sub_type',
+  'product_name',
+  'sale_amt',
+  'count',
+  'discount',
+  'profit',
+] as const;
+
+const meta = [
+  {
+    field: 'count',
+    name: '销售个数',
+  },
+  {
+    field: 'profit',
+    name: '利润',
+    formatter: (v) => `${v}元`,
+  },
+];
+
+const dataCfg: S2DataConfig = {
+  fields: {
+    columns,
+  },
+  meta,
+  data,
+  sortParams: [
+    {
+      sortFieldId: 'count',
+      sortMethod: 'DESC',
+    },
+    {
+      sortFieldId: 'profit',
+      sortMethod: 'ASC',
+    },
+  ],
+} as unknown as S2DataConfig;
+
+const options: S2Options = {
+  width: 800,
+  height: 600,
+  showSeriesNumber: true,
+  placeholder: '',
+  style: {
+    layoutWidthType: 'compact',
+    cellCfg: {
+      height: 32,
+    },
+    device: 'pc',
+  },
+  interaction: {
+    enableCopy: true,
+    hoverHighlight: false,
+    linkFields: ['order_id', 'customer_name'],
+  },
+  frozenRowCount: 2,
+  frozenColCount: 1,
+  frozenTrailingColCount: 1,
+  frozenTrailingRowCount: 1,
+  showDefaultHeaderActionIcon: true,
+};
+
+const container = document.createElement('div');
+document.body.appendChild(container);
+
+const s2 = new TableSheet(container, dataCfg, options);
+
+s2.render();
+
+describe('tablesheet normal spec', () => {
+  test('demo', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -173,7 +173,8 @@ export class ColCell extends HeaderCell {
 
   protected getActionIconsWidth() {
     const { size, margin } = this.getStyle().icon;
-    return (size + margin.left) * this.getActionIconsCount() + margin.right;
+    const iconCount = this.getActionIconsCount();
+    return (size + margin.left) * iconCount + iconCount > 0 ? margin.right : 0;
   }
 
   protected getColResizeAreaKey() {

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -1,17 +1,35 @@
-import { get, isEmpty } from 'lodash';
+import { get, isEmpty, find } from 'lodash';
 import { isFrozenCol, isFrozenTrailingCol } from 'src/facet/utils';
 import { getExtraPaddingForExpandIcon } from 'src/utils/cell/table-col-cell';
 import { getContentArea } from 'src/utils/cell/cell';
+import { getSortTypeIcon } from 'src/utils/sort-action';
 import { Group } from '@antv/g-canvas';
 import { isLastColumnAfterHidden } from '@/utils/hide-columns';
 import { S2Event, HORIZONTAL_RESIZE_AREA_KEY_PRE } from '@/common/constant';
 import { renderIcon, renderLine } from '@/utils/g-renders';
 import { ColCell } from '@/cell/col-cell';
-import { DefaultCellTheme, IconTheme } from '@/common/interface';
+import { DefaultCellTheme, IconTheme, SortParam } from '@/common/interface';
 import { KEY_GROUP_FROZEN_COL_RESIZE_AREA } from '@/common/constant';
 import { getOrCreateResizeAreaGroupById } from '@/utils/interaction/resize';
 
 export class TableColCell extends ColCell {
+  protected handleRestOptions(...[headerConfig]) {
+    this.headerConfig = { ...headerConfig };
+    const { field } = this.meta;
+    const sortParams = this.spreadsheet.dataCfg.sortParams;
+    const sortParam: SortParam = find(
+      sortParams,
+      (item) => item?.sortFieldId === field,
+    );
+
+    const type = getSortTypeIcon(sortParam, true);
+    this.headerConfig.sortParam = {
+      ...this.headerConfig.sortParam,
+      ...(sortParam || {}),
+      type,
+    };
+  }
+
   protected isFrozenCell() {
     const { frozenColCount, frozenTrailingColCount } = this.spreadsheet.options;
     const { colIndex } = this.meta;

--- a/packages/s2-core/src/common/constant/tooltip.ts
+++ b/packages/s2-core/src/common/constant/tooltip.ts
@@ -48,4 +48,17 @@ export const TOOLTIP_OPERATOR_MENUS: Record<
     },
     { id: 'none', text: i18n('不排序') },
   ],
+  TableSort: [
+    {
+      id: 'asc',
+      icon: 'groupAsc',
+      text: i18n('升序'),
+    },
+    {
+      id: 'desc',
+      icon: 'groupDesc',
+      text: i18n('降序'),
+    },
+    { id: 'none', text: i18n('不排序') },
+  ],
 };

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -160,6 +160,8 @@ export interface TooltipOperation {
   trend?: boolean;
   // 组内排序
   sort?: boolean;
+  // 明细表排序
+  tableSort?: boolean;
 }
 
 export interface AutoAdjustPositionOptions {

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -1,7 +1,20 @@
+import { Node } from 'src/facet/layout/node';
+import { Event as CanvasEvent } from '@antv/g-canvas';
+import { last } from 'lodash';
 import { SpreadSheet } from './spread-sheet';
 import { DataCell } from '@/cell';
-import { S2Event } from '@/common/constant';
-import { S2Options, SpreadSheetFacetCfg, ViewMeta } from '@/common/interface';
+import {
+  InterceptType,
+  S2Event,
+  TOOLTIP_OPERATOR_MENUS,
+} from '@/common/constant';
+import {
+  S2Options,
+  SortParam,
+  SpreadSheetFacetCfg,
+  TooltipOperatorOptions,
+  ViewMeta,
+} from '@/common/interface';
 import { RowCellCollapseTreeRowsType } from '@/common/interface/emitter';
 import { PivotDataSet } from '@/data-set';
 import { CustomTreePivotDataSet } from '@/data-set/custom-tree-pivot-data-set';
@@ -145,5 +158,37 @@ export class PivotSheet extends SpreadSheet {
     };
     this.setOptions(options);
     this.render(false);
+  }
+
+  public handleGroupSort(event: CanvasEvent, meta: Node) {
+    event.stopPropagation();
+    this.interaction.addIntercepts([InterceptType.HOVER]);
+    const operator: TooltipOperatorOptions = {
+      onClick: ({ key }) => {
+        const { rows, columns } = this.dataCfg.fields;
+        const sortFieldId = this.isValueInCols() ? last(rows) : last(columns);
+        const { query, value } = meta;
+        const sortParam: SortParam = {
+          sortFieldId,
+          sortMethod: key as SortParam['sortMethod'],
+          sortByMeasure: value,
+          query,
+        };
+        const prevSortParams = this.dataCfg.sortParams.filter(
+          (item) => item?.sortFieldId !== sortFieldId,
+        );
+        this.setDataCfg({
+          ...this.dataCfg,
+          sortParams: [...prevSortParams, sortParam],
+        });
+        this.render();
+      },
+      menus: TOOLTIP_OPERATOR_MENUS.Sort,
+    };
+
+    this.showTooltipWithInfo(event, [], {
+      operator,
+      onlyMenu: true,
+    });
   }
 }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -6,18 +6,15 @@ import {
   get,
   includes,
   isEmpty,
-  isObject,
   isString,
   merge,
   once,
-  last,
 } from 'lodash';
 import { hideColumnsByThunkGroup } from '@/utils/hide-columns';
 import { BaseCell } from '@/cell';
 import {
   BACK_GROUND_GROUP_CONTAINER_Z_INDEX,
   FRONT_GROUND_GROUP_CONTAINER_Z_INDEX,
-  InterceptType,
   KEY_GROUP_BACK_GROUND,
   KEY_GROUP_FORE_GROUND,
   KEY_GROUP_PANEL_GROUND,
@@ -25,7 +22,6 @@ import {
   PANEL_GROUP_GROUP_CONTAINER_Z_INDEX,
   PANEL_GROUP_SCROLL_GROUP_Z_INDEX,
   S2Event,
-  TOOLTIP_OPERATOR_MENUS,
 } from '@/common/constant';
 import { DebuggerUtil } from '@/common/debug';
 import { i18n } from '@/common/i18n';
@@ -37,11 +33,9 @@ import {
   S2DataConfig,
   S2MountContainer,
   S2Options,
-  SortParam,
   SpreadSheetFacetCfg,
   ThemeCfg,
   TooltipData,
-  TooltipOperatorOptions,
   TooltipOptions,
   TooltipShowOptions,
   Total,
@@ -256,37 +250,7 @@ export abstract class SpreadSheet extends EE {
   ): void;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public handleGroupSort(event: CanvasEvent, meta: Node) {
-    event.stopPropagation();
-    this.interaction.addIntercepts([InterceptType.HOVER]);
-    const operator: TooltipOperatorOptions = {
-      onClick: ({ key }) => {
-        const { rows, columns } = this.dataCfg.fields;
-        const sortFieldId = this.isValueInCols() ? last(rows) : last(columns);
-        const { query, value } = meta;
-        const sortParam: SortParam = {
-          sortFieldId,
-          sortMethod: key as SortParam['sortMethod'],
-          sortByMeasure: value,
-          query,
-        };
-        const prevSortParams = this.dataCfg.sortParams.filter(
-          (item) => item?.sortFieldId !== sortFieldId,
-        );
-        this.setDataCfg({
-          ...this.dataCfg,
-          sortParams: [...prevSortParams, sortParam],
-        });
-        this.render();
-      },
-      menus: TOOLTIP_OPERATOR_MENUS.Sort,
-    };
-
-    this.showTooltipWithInfo(event, [], {
-      operator,
-      onlyMenu: true,
-    });
-  }
+  public handleGroupSort(event: CanvasEvent, meta: Node) {}
 
   public showTooltip(showOptions: TooltipShowOptions) {
     this.tooltip.show?.(showOptions);

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -24,7 +24,7 @@ export const getTheme = (
         fontWeight: isWindows() ? 'bold' : 500,
         fill: basicColors[0],
         opacity: 1,
-        textAlign: 'left',
+        textAlign: isTable ? 'center' : 'left',
         textBaseline: 'middle',
       },
       text: {
@@ -33,7 +33,7 @@ export const getTheme = (
         fontWeight: 'normal',
         fill: basicColors[0],
         opacity: 1,
-        textAlign: 'left',
+        textAlign: isTable ? 'center' : 'left',
         textBaseline: 'middle',
       },
       cell: {


### PR DESCRIPTION
### 👀 PR includes

+ 修复明细表排序问题。之前使用公共的 handleGroupSort。后面发现交叉表和明细表排序实现有些不同点。所以还是恢复之前的各自继承实现。
+ 明细表排序的文本修正。
+ s2-core 中新增明细表的测试 live 文件