### PR TITLE
chore: only build s2-core esm for s2-react

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -16,5 +16,5 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         pattern: "./packages/**/dist/**/*.{js,css}"
-        build-script: "build"
+        build-script: "build:umd"
         clean-script: "clean:lock-file"

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: preactjs/compressed-size-action@v2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        pattern: "./packages/s2-core/dist/**/*.{js,css}"
+        pattern: "./packages/**/dist/**/*.{js,css}"
         build-script: "build"
         clean-script: "clean:lock-file"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          yarn build:s2-core-esm
+          yarn workspace @antv/s2 build:esm
           yarn build:umd
 
       - name: Lint scripts, type, style and docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         run: yarn
 
       - name: Build
-        run: yarn build
+        run: yarn workspace @antv/s2 build:esm
 
       - name: Lint scripts, type, style and docs
         run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Build
         run: |
-          yarn workspace @antv/s2 build:esm
-          yarn workspaces run build:umd
+          yarn build:s2-core-esm
+          yarn build:umd
 
       - name: Lint scripts, type, style and docs
         run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,9 @@ jobs:
         run: yarn
 
       - name: Build
-        run: yarn workspace @antv/s2 build:esm
+        run: |
+          yarn workspace @antv/s2 build:esm
+          yarn workspaces run build:umd
 
       - name: Lint scripts, type, style and docs
         run: yarn lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          ls -al  node_modules/@antv 
-          yarn build:s2-core-esm
+          yarn workspace @antv/s2 build:cjs
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install dependencies
         run: yarn
 
-      - run: yarn build
+      - name: Build
+        run: yarn workspace @antv/s2 build:esm
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,9 @@ jobs:
         run: yarn
 
       - name: Build
-        run: yarn workspace @antv/s2 build:esm
+        run: |
+          ls -al  node_modules/@antv 
+          yarn build:s2-core-esm
 
       - name: Test
         run: |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "clean:lock-file": "rm -rf yarn.lock",
     "core:start": "yarn workspace @antv/s2 start",
     "build": "lerna run build --include-dependencies --stream --concurrency 1",
+    "build:umd": "lerna run build:umd --include-dependencies --stream --concurrency 1",
+    "build:s2-core-esm": "lerna run build:esm --scope @antv/s2 --stream",
     "bundle:size": "lerna run bundle:size --stream",
     "release": "lerna exec --concurrency 1 -- npx --no-install semantic-release",
     "prepublish:manual": "yarn build",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "core:start": "yarn workspace @antv/s2 start",
     "build": "lerna run build --include-dependencies --stream --concurrency 1",
     "build:umd": "lerna run build:umd --include-dependencies --stream --concurrency 1",
-    "build:s2-core-esm": "lerna run build:esm --scope @antv/s2 --stream",
     "bundle:size": "lerna run bundle:size --stream",
     "release": "lerna exec --concurrency 1 -- npx --no-install semantic-release",
     "prepublish:manual": "yarn build",


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [x] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
在CI中，`s2-react`只依赖于`s2-core`的`esm`模块，所以无需build其他部分，减少CI执行时间

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
