### PR TITLE
docs: tweak tooltips in merge-cells

### DIFF
--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -45,7 +45,7 @@ export class BaseTooltip {
     if (getTooltipComponent) {
       getTooltipComponent(showOptions, container);
     } else {
-      const customComponent = tooltipComponent || element;
+      const customComponent = element || tooltipComponent;
       if (customComponent) {
         if (typeof customComponent === 'string') {
           this.container.innerHTML = customComponent;

--- a/s2-site/docs/manual/advanced/interaction/merge-cell.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/merge-cell.zh.md
@@ -1,5 +1,5 @@
 ---
-title: 合并单元格 Merge Cell
+title: 合并单元格
 order: 5
 ---
 
@@ -313,7 +313,7 @@ const s2options = {
     // 表格渲染后，会展示一个合并单元格
     mergedCellsInfo: [
       { colIndex: 1, rowIndex: 6, showText: true }, // 此单元格的 meta 信息将作为合并单元的 meta 信息
-      { colIndex: 1, rowIndex: 7 },
+      { colIndex: 1, rowIndex: 7 }, 
       { colIndex: 2, rowIndex: 6 },
       { colIndex: 2, rowIndex: 7 },
       { colIndex: 3, rowIndex: 6 },
@@ -337,7 +337,7 @@ s2.on(S2Event.MERGED_CELLS_CLICK, (event) => {
 
 ## demo 演示
 
-- 合并操作：shift + 单选操作，选择多个连续单元格通过 tooltip 进行合并
+- 合并操作：Cmd/Ctrl + 单选操作，选择多个连续单元格通过 tooltip 进行合并
 - 取消合并操作：点击合并单元格，通过 tooltip 取消合并
 
 <playground path='interaction/advanced/demo/merge-cells.tsx' rid='container' height='400'></playground>

--- a/s2-site/examples/case/proportion/demo/single-population-proportion.tsx
+++ b/s2-site/examples/case/proportion/demo/single-population-proportion.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import insertCss from 'insert-css';
 import { SheetComponent } from '@antv/s2-react';
 import '@antv/s2-react/dist/style.min.css';
+import { S2Options } from '@antv/s2';
 
 const PALETTE_COLORS = [
   {
@@ -108,8 +109,8 @@ fetch('../data/single-population-proportion.json')
       width: 800,
       height: 600,
       tooltip: {
+        showTooltip: true,
         operation: {
-          trend: true,
           hiddenColumns: true,
         },
       },
@@ -155,7 +156,7 @@ fetch('../data/single-population-proportion.json')
       <div className="root">
         <SheetComponent
           dataCfg={s2DataConfig}
-          options={s2options}
+          options={s2options as S2Options}
           sheetType="pivot"
           adaptive={false}
           header={{

--- a/s2-site/examples/interaction/advanced/demo/merge-cells.tsx
+++ b/s2-site/examples/interaction/advanced/demo/merge-cells.tsx
@@ -1,4 +1,4 @@
-import { PivotSheet, S2Event, MergedCell } from '@antv/s2';
+import { PivotSheet, S2Event } from '@antv/s2';
 import insertCss from 'insert-css';
 
 fetch(
@@ -7,7 +7,7 @@ fetch(
   .then((res) => res.json())
   .then((res) => {
     const container = document.getElementById('container');
-    const tooltipComponent = () => {
+    const dataCellTooltip = () => {
       const button = document.createElement('button');
       button.innerText = '点击合并单元格';
       button.className = 'merge-cells-button';
@@ -15,7 +15,7 @@ fetch(
       return button;
     } // (按住 Cmd/ Ctrl 多选)
 
-    const mergedCellsTooltip = (mergedCell: MergedCell) => {
+    const mergedCellsTooltip = (mergedCell) => {
       const button = document.createElement('button');
       button.innerText = '取消合并单元格';
       button.className = 'merge-cells-button';
@@ -37,10 +37,6 @@ fetch(
       width: 600,
       height: 480,
       selectedCellsSpotlight: true,
-      tooltip: {
-        showTooltip: true,
-        tooltipComponent: tooltipComponent(),
-      },
       mergedCellsInfo: [
         [
           { colIndex: 1, rowIndex: 6, showText: true },
@@ -54,11 +50,15 @@ fetch(
     };
     const s2 = new PivotSheet(container, s2DataConfig, s2Options);
 
+    s2.on(S2Event.DATA_CELL_CLICK, (event) => {
+      s2.tooltip.show({
+        position: { x: event.clientX, y: event.clientY },
+        element: dataCellTooltip(),
+      });
+    });
 
     s2.on(S2Event.MERGED_CELLS_CLICK, (event) => {
-      console.log('mergedCellsClick', event);
-      const cell: MergedCell = s2.getCell(event.target);
-      s2.tooltip.hide();
+      const cell = s2.getCell(event.target);
       s2.tooltip.show({
         position: { x: event.clientX, y: event.clientY },
         element: mergedCellsTooltip(cell),

--- a/s2-site/examples/interaction/advanced/demo/merge-cells.tsx
+++ b/s2-site/examples/interaction/advanced/demo/merge-cells.tsx
@@ -1,7 +1,5 @@
 import { PivotSheet, S2Event, MergedCell } from '@antv/s2';
-import React from 'react';
-
-import { Button } from 'antd';
+import insertCss from 'insert-css';
 
 fetch(
   'https://gw.alipayobjects.com/os/bmw-prod/cd9814d0-6dfa-42a6-8455-5a6bd0ff93ca.json',
@@ -9,28 +7,21 @@ fetch(
   .then((res) => res.json())
   .then((res) => {
     const container = document.getElementById('container');
+    const tooltipComponent = () => {
+      const button = document.createElement('button');
+      button.innerText = '点击合并单元格';
+      button.className = 'merge-cells-button';
+      button.onclick = () => s2.interaction.mergeCells();
+      return button;
+    } // (按住 Cmd/ Ctrl 多选)
 
-    const TooltipComponent = (
-      <Button
-        className="s2-action-btn"
-        key={'button'}
-        onClick={() => {
-          s2.interaction.mergeCells();
-        }}
-      >
-        合并单元格
-      </Button>
-    ); // (按住 Cmd/ Ctrl 多选)
-
-    const mergedCellsTooltip = (mergedCell: MergedCell) => (
-      <Button
-        onClick={() => {
-          s2.interaction.unmergeCell(mergedCell);
-        }}
-      >
-        取消合并单元格
-      </Button>
-    );
+    const mergedCellsTooltip = (mergedCell: MergedCell) => {
+      const button = document.createElement('button');
+      button.innerText = '取消合并单元格';
+      button.className = 'merge-cells-button';
+      button.onclick = () => s2.interaction.unmergeCell(mergedCell);
+      return button;
+    }
 
     const s2DataConfig = {
       fields: {
@@ -47,7 +38,8 @@ fetch(
       height: 480,
       selectedCellsSpotlight: true,
       tooltip: {
-        tooltipComponent: TooltipComponent,
+        showTooltip: true,
+        tooltipComponent: tooltipComponent(),
       },
       mergedCellsInfo: [
         [
@@ -60,11 +52,13 @@ fetch(
         ],
       ],
     };
-
     const s2 = new PivotSheet(container, s2DataConfig, s2Options);
 
+
     s2.on(S2Event.MERGED_CELLS_CLICK, (event) => {
+      console.log('mergedCellsClick', event);
       const cell: MergedCell = s2.getCell(event.target);
+      s2.tooltip.hide();
       s2.tooltip.show({
         position: { x: event.clientX, y: event.clientY },
         element: mergedCellsTooltip(cell),
@@ -75,6 +69,26 @@ fetch(
   });
 
 insertCss(`
+  .merge-cells-button {
+    border: 1px solid transparent;
+    box-shadow: 0 2px #00000004;
+    cursor: pointer;
+    height: 32px;
+    padding: 4px 15px;
+    font-size: 14px;
+    border-radius: 2px;
+    color: #000000d9;
+    border-color: #d9d9d9;
+    background: #fff;
+  }
+  .merge-cells-button:hover {
+    color: #40a9ff;
+    border-color: #40a9ff;
+  }
+  .merge-cells-button:active {
+    color: #096dd9;
+    border-color: #096dd9;
+  }
   .antv-s2-tooltip-container  {
     padding: 10px 64px;
   }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [X] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
1. 随 s2 和 tooltip 操作更新，更新使用方式。
2.  统一 merge-cell  的文档风格。
3. 调整了 customComponent 的优先级。
 -  tooltipComponent 一般在用户配置options 的时候就会固定，如果想再次更新就需要重新渲染表格，成本很高。而在 
 ```js
 s2.tooltip.show({
        position: { x: event.clientX, y: event.clientY },
        element: mergedCellsTooltip(cell), 
      });
```
用户可控制其何时展示，展示几次。容易配置，且成本较低。
 - 如果用户同时配置了tooltipComponent || element， element 不会生效。
 
### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
