### PR TITLE
fix: remove exports config close #790

### DIFF
--- a/packages/s2-react/package.json
+++ b/packages/s2-react/package.json
@@ -5,12 +5,6 @@
   "module": "esm/index.js",
   "unpkg": "dist/index.min.js",
   "types": "esm/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./esm/index.js",
-      "require": "./lib/index.js"
-    }
-  },
   "description": "effective spreadsheet render react lib",
   "license": "MIT",
   "homepage": "https://s2.antv.vision",


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #790 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
当定义了 "exports" 字段，所有子路径都会被封闭，不再对使用者开放，为了灵活只能使用`./*: ./*`，但就失去了封闭的意义，所以这里直接删除掉该配置

### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |

### 🔗 Related issue link

<!-- close #0 -->
close #790 
### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
