### PR TITLE
fix(facet): getAdjustedScrollY add negative check

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -494,6 +494,9 @@ export abstract class BaseFacet {
     if (scrollY + panelHeight >= rendererHeight) {
       return rendererHeight - panelHeight;
     }
+    if (scrollY < 0) {
+      scrollY = 0;
+    }
     return scrollY;
   };
 

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -494,10 +494,7 @@ export abstract class BaseFacet {
     if (scrollY + panelHeight >= rendererHeight) {
       return rendererHeight - panelHeight;
     }
-    if (scrollY < 0) {
-      scrollY = 0;
-    }
-    return scrollY;
+    return Math.max(0, scrollY);
   };
 
   private getAdjustedScrollOffset = ({


### PR DESCRIPTION
### 👀 PR includes


🐛 Bugfix

修复 getAdjustedScrollY 在数据为空时，scrollY 为 负数 的问题。