### PR TITLE
feat: the order of the measure values in rows or cols, only works for PivotSheet (customValueOrder)

### DIFF
--- a/packages/s2-core/__tests__/unit/dataset/pivot-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/dataset/pivot-dataset-spec.ts
@@ -413,4 +413,55 @@ describe('Pivot Dataset Test', () => {
       expect(defaultFormatter).toEqual(dataConfig.meta[0].formatter);
     });
   });
+
+  describe('the order of the measure values in rows or cols', () => {
+    test('should index of the rows of EXTRA_FIELD is 1 when customValueOrder is 1 and valueInCols is false', () => {
+      const mockDataCfg: S2DataConfig = assembleDataCfg(dataCfg, {
+        fields: {
+          valueInCols: false,
+          customValueOrder: 1,
+        },
+      });
+      const newData = dataSet.processDataCfg(mockDataCfg);
+      expect(newData.fields.rows).toEqual(['province', EXTRA_FIELD, 'city']);
+      expect(newData.fields.columns).toEqual(['type', 'sub_type']);
+      expect(newData.fields.values).toEqual(['number']);
+    });
+    test('should index of the cols of EXTRA_FIELD is 0 when customValueOrder is 0 and valueInCols is true', () => {
+      const mockDataCfg: S2DataConfig = assembleDataCfg(dataCfg, {
+        fields: {
+          valueInCols: true,
+          customValueOrder: 0,
+        },
+      });
+      const newData = dataSet.processDataCfg(mockDataCfg);
+      expect(newData.fields.rows).toEqual(['province', 'city']);
+      expect(newData.fields.columns).toEqual([EXTRA_FIELD, 'type', 'sub_type']);
+      expect(newData.fields.values).toEqual(['number']);
+    });
+    test('should customValueOrder is too big, order feature does not work', () => {
+      const mockDataCfg: S2DataConfig = assembleDataCfg(dataCfg, {
+        fields: {
+          valueInCols: true,
+          customValueOrder: 3,
+        },
+      });
+      const newData = dataSet.processDataCfg(mockDataCfg);
+      expect(newData.fields.rows).toEqual(['province', 'city']);
+      expect(newData.fields.columns).toEqual(['type', 'sub_type', EXTRA_FIELD]);
+      expect(newData.fields.values).toEqual(['number']);
+    });
+    test('should customValueOrder is not number, order feature does not work', () => {
+      const mockDataCfg: S2DataConfig = assembleDataCfg(dataCfg, {
+        fields: {
+          valueInCols: true,
+          customValueOrder: undefined,
+        },
+      });
+      const newData = dataSet.processDataCfg(mockDataCfg);
+      expect(newData.fields.rows).toEqual(['province', 'city']);
+      expect(newData.fields.columns).toEqual(['type', 'sub_type', EXTRA_FIELD]);
+      expect(newData.fields.values).toEqual(['number']);
+    });
+  });
 });

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -78,6 +78,8 @@ export interface Fields {
   values?: string[];
   // measure values in cols as new col, only works for PivotSheet
   valueInCols?: boolean;
+  // the order of the measure values in rows or cols, only works for PivotSheet
+  customValueOrder?: number;
 }
 
 export interface Total {

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -13,6 +13,7 @@ import {
   filter,
   forEach,
   unset,
+  isNumber,
 } from 'lodash';
 import { Node } from '@/facet/layout/node';
 import {
@@ -268,10 +269,18 @@ export class PivotDataSet extends BaseDataSet {
 
   public processDataCfg(dataCfg: S2DataConfig): S2DataConfig {
     const { data, meta = [], fields, sortParams = [], totalData } = dataCfg;
-    const { columns, rows, values, valueInCols } = fields;
-
-    const newColumns = valueInCols ? uniq([...columns, EXTRA_FIELD]) : columns;
-    const newRows = !valueInCols ? uniq([...rows, EXTRA_FIELD]) : rows;
+    const { columns, rows, values, valueInCols, customValueOrder } = fields;
+    let newColumns = columns;
+    let newRows = rows;
+    if (valueInCols) {
+      newColumns = PivotDataSet.isCustomMeasuresPosition(customValueOrder)
+        ? PivotDataSet.handleCustomMeasuresOrder(customValueOrder, newColumns)
+        : uniq([...columns, EXTRA_FIELD]);
+    } else {
+      newRows = PivotDataSet.isCustomMeasuresPosition(customValueOrder)
+        ? PivotDataSet.handleCustomMeasuresOrder(customValueOrder, newRows)
+        : uniq([...rows, EXTRA_FIELD]);
+    }
 
     const valueFormatter = (value: string) => {
       const findOne = find(meta, (mt: Meta) => mt.field === value);
@@ -500,5 +509,28 @@ export class PivotDataSet extends BaseDataSet {
     valueField = valueField ?? get(this.fields.values, 0);
 
     return super.getFieldFormatter(valueField);
+  }
+
+  /**
+   * 自定义度量组位置值
+   * @param customValueOrder 用户配置度量组位置，从 0 开始
+   * @param fields Rows || Columns
+   */
+  private static handleCustomMeasuresOrder(
+    customValueOrder: number,
+    fields: string[],
+  ) {
+    const newFields = uniq([...fields]);
+    if (fields.length >= customValueOrder) {
+      newFields.splice(customValueOrder, 0, EXTRA_FIELD);
+      return newFields;
+    }
+    // 当用户配置的度量组位置大于等于度量组数量时，默认放在最后
+    return [...newFields, EXTRA_FIELD];
+  }
+
+  // 是否开启自定义度量组位置值
+  private static isCustomMeasuresPosition(customValueOrder?: number) {
+    return isNumber(customValueOrder);
   }
 }

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -273,12 +273,12 @@ export class PivotDataSet extends BaseDataSet {
     let newColumns = columns;
     let newRows = rows;
     if (valueInCols) {
-      newColumns = PivotDataSet.isCustomMeasuresPosition(customValueOrder)
-        ? PivotDataSet.handleCustomMeasuresOrder(customValueOrder, newColumns)
+      newColumns = this.isCustomMeasuresPosition(customValueOrder)
+        ? this.handleCustomMeasuresOrder(customValueOrder, newColumns)
         : uniq([...columns, EXTRA_FIELD]);
     } else {
-      newRows = PivotDataSet.isCustomMeasuresPosition(customValueOrder)
-        ? PivotDataSet.handleCustomMeasuresOrder(customValueOrder, newRows)
+      newRows = this.isCustomMeasuresPosition(customValueOrder)
+        ? this.handleCustomMeasuresOrder(customValueOrder, newRows)
         : uniq([...rows, EXTRA_FIELD]);
     }
 
@@ -516,7 +516,7 @@ export class PivotDataSet extends BaseDataSet {
    * @param customValueOrder 用户配置度量组位置，从 0 开始
    * @param fields Rows || Columns
    */
-  private static handleCustomMeasuresOrder(
+  private handleCustomMeasuresOrder(
     customValueOrder: number,
     fields: string[],
   ) {
@@ -530,7 +530,7 @@ export class PivotDataSet extends BaseDataSet {
   }
 
   // 是否开启自定义度量组位置值
-  private static isCustomMeasuresPosition(customValueOrder?: number) {
+  private isCustomMeasuresPosition(customValueOrder?: number) {
     return isNumber(customValueOrder);
   }
 }

--- a/s2-site/docs/api/general/S2DataConfig.zh.md
+++ b/s2-site/docs/api/general/S2DataConfig.zh.md
@@ -54,7 +54,8 @@ object **必选**,_default：null_
 | rows           | 行维度列表         | `string[]` | `[]`   |      |
 | columns        | 列维度列表         | `string[]` | `[]`   |      |
 | values         | 指标维度列表       | `string[]` | `[]`   |      |
-| valueInCols    | 指标维度是否在列头 | `boolean`  | `true` |      |
+| valueInCols    | 指标维度是否在列头   | `boolean`  | `true` |      |
+| customValueOrder | 自定义指标维度在行列头中的位置顺序 | `number`  | - |      |
 
 ### Meta
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [X] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [X] Test case
- [X] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
1. 添加自定义指标维度组在行列头中的位置顺序 功能
2. 添加自定义指标维度组在行列头中的位置顺序  测试和文档
### 🖼️ Screenshot

| Before                         | After                         |
| ------------------------------ | ------------------------------ |
| ❌                             | ✅                              |
|![image](https://user-images.githubusercontent.com/20497176/143864844-7bf507fc-5af9-45fd-8390-195a5cf94545.png) | ![image](https://user-images.githubusercontent.com/20497176/143864789-a393095a-2e6e-4ff0-a8fe-3487dd28ecb5.png)|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
