### PR TITLE
fix(table): column should not be formatted

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-840-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-840-spec.ts
@@ -1,0 +1,85 @@
+/**
+ * @description spec for issue #840
+ * https://github.com/antvis/S2/issues/840
+ * Column should not be formatted
+ *
+ */
+import { getContainer } from 'tests/util/helpers';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { TableSheet, SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+
+const s2options: S2Options = {
+  // 让被测试的单元格在首屏显示出来
+  width: 300,
+  height: 200,
+  style: {
+    colCfg: {
+      height: 60,
+    },
+    cellCfg: {
+      width: 100,
+      height: 50,
+    },
+  },
+};
+
+const dataCfg = {
+  ...mockDataConfig,
+  fields: {
+    columns: ['cost', 'type', 'province', 'price'],
+    valueInCols: true,
+  },
+  meta: [
+    {
+      field: 'type',
+      name: '类型',
+      formatter: (v) => `#${v}`,
+    },
+    {
+      field: 'cost',
+      name: '成本',
+      formatter: (v) => `@${v}`,
+    },
+  ],
+};
+
+describe('Column Formatter Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    s2 = new TableSheet(getContainer(), dataCfg, s2options);
+    s2.render();
+  });
+
+  test('column should not be formatted', () => {
+    const colNodes = s2.getColumnNodes();
+    const typeColNode = colNodes.find(({ field }) => field === 'type');
+    const costColNode = colNodes.find(({ field }) => field === 'cost');
+    expect(typeColNode.label).toStrictEqual('类型');
+    expect(typeColNode.value).toStrictEqual('类型');
+    expect(costColNode.label).toStrictEqual('成本');
+    expect(costColNode.value).toStrictEqual('成本');
+  });
+
+  test('date cell should render formatted value', () => {
+    const dataCells = s2.interaction.getPanelGroupAllDataCells();
+    const typeDataCells = dataCells.filter(
+      (cell) => cell.getMeta().valueField === 'type',
+    );
+    const costDataCells = dataCells.filter(
+      (cell) => cell.getMeta().valueField === 'cost',
+    );
+
+    // 确保下面的 forEach 断言能被触发
+    expect(typeDataCells).not.toHaveLength(0);
+    expect(costDataCells).not.toHaveLength(0);
+
+    typeDataCells.forEach((cell) => {
+      expect(cell.getActualText()).toStrictEqual('#笔');
+    });
+    costDataCells.forEach((cell) => {
+      expect(cell.getActualText()).toStrictEqual('@2');
+    });
+  });
+});

--- a/packages/s2-core/__tests__/data/simple-data.json
+++ b/packages/s2-core/__tests__/data/simple-data.json
@@ -10,20 +10,22 @@
       "province": "浙江",
       "city": "义乌",
       "type": "笔",
-      "cost": "2"
+      "price": 1,
+      "cost": 2
     },
     {
       "province": "浙江",
       "city": "义乌",
       "type": "笔",
-      "price": "8"
+      "price": 1,
+      "cost": 2
     },
     {
       "province": "浙江",
       "city": "杭州",
       "type": "笔",
-      "price": "",
-      "cost": 10
+      "price": 1,
+      "cost": 2
     }
   ]
 }

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -1,14 +1,5 @@
 import { BBox, Group, IShape, Point, SimpleBBox } from '@antv/g-canvas';
-import {
-  each,
-  forEach,
-  get,
-  includes,
-  isEmpty,
-  isNumber,
-  keys,
-  pickBy,
-} from 'lodash';
+import { each, get, includes, isNumber, keys, pickBy } from 'lodash';
 import {
   CellTypes,
   InteractionStateName,

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -94,9 +94,8 @@ export class ColCell extends HeaderCell {
 
   protected getFormattedFieldValue(): FormatResult {
     const { label, key } = this.meta;
-    // 格式化枚举值
-    const f = this.headerConfig.formatter(key);
-    const content = f(label);
+    const formatter = this.headerConfig.formatter(key);
+    const content = formatter(label);
     return {
       formattedValue: content,
       value: label,

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -8,7 +8,12 @@ import { isLastColumnAfterHidden } from '@/utils/hide-columns';
 import { S2Event, HORIZONTAL_RESIZE_AREA_KEY_PRE } from '@/common/constant';
 import { renderIcon, renderLine } from '@/utils/g-renders';
 import { ColCell } from '@/cell/col-cell';
-import { DefaultCellTheme, IconTheme, SortParam } from '@/common/interface';
+import {
+  DefaultCellTheme,
+  FormatResult,
+  IconTheme,
+  SortParam,
+} from '@/common/interface';
 import { KEY_GROUP_FROZEN_COL_RESIZE_AREA } from '@/common/constant';
 import { getOrCreateResizeAreaGroupById } from '@/utils/interaction/resize';
 
@@ -183,5 +188,14 @@ export class TableColCell extends ColCell {
 
   protected getHorizontalResizeAreaName() {
     return `${HORIZONTAL_RESIZE_AREA_KEY_PRE}${'table-col-cell'}`;
+  }
+
+  // 明细表列头不应该格式化 https://github.com/antvis/S2/issues/840
+  protected getFormattedFieldValue(): FormatResult {
+    const { label } = this.meta;
+    return {
+      formattedValue: label,
+      value: label,
+    };
   }
 }

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -728,8 +728,9 @@ export class TableFacet extends BaseFacet {
         data: this.layoutResult.colNodes,
         scrollContainsRowHeader:
           this.cfg.spreadsheet.isScrollContainsRowHeader(),
-        formatter: (field: string): Formatter =>
-          this.cfg.dataSet.getFieldFormatter(field),
+        formatter: (field) => {
+          return this.cfg.dataSet.getFieldFormatter(field);
+        },
         sortParam: this.cfg.spreadsheet.store.get('sortParam'),
         spreadsheet: this.spreadsheet,
       });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #840

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

修复 `明细表` 配置字段格式化, 会错误的格式列头的问题

```
  const s2DataConfig = {
    fields: {
      columns: ['type', 'sub_type', 'area', 'province', 'city', 'price', 'cost'],
      rows: [],
      values: [],
      valuesInCols: false
    },
    meta: [
      {
        field: 'price',
        name: '价格',
        formatter: (v) => `123`
      },
      {
        field: 'city',
        name: '城市',
        formatter: (v) => `123`
      },
    ]
}
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/144038853-ac837fa8-7d72-4229-807c-b35e617cd9c4.png) | ![image](https://user-images.githubusercontent.com/21015895/144038915-a3a3b17d-fa3f-47e8-8dc7-a6ccd571d614.png) |

### 🔗 Related issue link

close #840

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
