### PR TITLE
fix(frame): incorrect viewport splitline shadow

### DIFF
--- a/packages/s2-core/src/common/interface/frame.ts
+++ b/packages/s2-core/src/common/interface/frame.ts
@@ -9,7 +9,7 @@ export interface FrameConfig {
   height: number;
   viewportWidth: number;
   viewportHeight: number;
-  showViewPortLeftShadow: boolean;
+  showViewportLeftShadow: boolean;
   showViewPortRightShadow: boolean;
   scrollContainsRowHeader: boolean;
   isPivotMode: boolean;

--- a/packages/s2-core/src/common/interface/frame.ts
+++ b/packages/s2-core/src/common/interface/frame.ts
@@ -10,7 +10,7 @@ export interface FrameConfig {
   viewportWidth: number;
   viewportHeight: number;
   showViewportLeftShadow: boolean;
-  showViewPortRightShadow: boolean;
+  showViewportRightShadow: boolean;
   scrollContainsRowHeader: boolean;
   isPivotMode: boolean;
   spreadsheet: SpreadSheet;

--- a/packages/s2-core/src/common/interface/frame.ts
+++ b/packages/s2-core/src/common/interface/frame.ts
@@ -9,7 +9,7 @@ export interface FrameConfig {
   height: number;
   viewportWidth: number;
   viewportHeight: number;
-  showCornerRightShadow: boolean;
+  showViewPortLeftShadow: boolean;
   showViewPortRightShadow: boolean;
   scrollContainsRowHeader: boolean;
   isPivotMode: boolean;

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -4,16 +4,7 @@ import { Wheel } from '@antv/g-gesture';
 import { interpolateArray } from 'd3-interpolate';
 import * as d3Timer from 'd3-timer';
 import { Group } from '@antv/g-canvas';
-import {
-  debounce,
-  each,
-  find,
-  get,
-  isNil,
-  isUndefined,
-  last,
-  reduce,
-} from 'lodash';
+import { debounce, each, find, get, isUndefined, last, reduce } from 'lodash';
 import { CornerBBox } from './bbox/cornerBBox';
 import { PanelBBox } from './bbox/panelBBox';
 import {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1117,11 +1117,8 @@ export abstract class BaseFacet {
         height: cornerHeight,
         viewportWidth: width,
         viewportHeight: height,
-        // When both a row header and a panel scroll bar exist, show viewport shadow
-        showViewPortLeftShadow:
-          !isNil(this.hRowScrollBar) && !isNil(this.hScrollBar),
-        showViewPortRightShadow:
-          !isNil(this.hRowScrollBar) && !isNil(this.hScrollBar),
+        showViewPortLeftShadow: false,
+        showViewPortRightShadow: false,
         scrollContainsRowHeader:
           this.cfg.spreadsheet.isScrollContainsRowHeader(),
         isPivotMode: this.cfg.spreadsheet.isPivotMode(),

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -541,13 +541,6 @@ export abstract class BaseFacet {
           hRowScrollX,
           KEY_GROUP_ROW_INDEX_RESIZE_AREA,
         );
-        this.centerFrame.onChangeShadowVisibility(
-          hRowScrollX,
-          this.cornerBBox.originalWidth -
-            this.cornerBBox.width -
-            this.scrollBarSize * 2,
-          true,
-        );
         this.cornerHeader.onRowScrollX(
           hRowScrollX,
           KEY_GROUP_CORNER_RESIZE_AREA,
@@ -898,7 +891,6 @@ export abstract class BaseFacet {
     this.centerFrame.onChangeShadowVisibility(
       scrollX,
       this.getRealWidth() - this.panelBBox.width,
-      false,
     );
     this.centerFrame.onBorderScroll(this.getRealScrollX(scrollX));
     this.columnHeader.onColScroll(scrollX, KEY_GROUP_COL_RESIZE_AREA);
@@ -1125,8 +1117,9 @@ export abstract class BaseFacet {
         height: cornerHeight,
         viewportWidth: width,
         viewportHeight: height,
-        showCornerRightShadow: !isNil(this.hRowScrollBar),
         // When both a row header and a panel scroll bar exist, show viewport shadow
+        showViewPortLeftShadow:
+          !isNil(this.hRowScrollBar) && !isNil(this.hScrollBar),
         showViewPortRightShadow:
           !isNil(this.hRowScrollBar) && !isNil(this.hScrollBar),
         scrollContainsRowHeader:

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1108,8 +1108,8 @@ export abstract class BaseFacet {
         height: cornerHeight,
         viewportWidth: width,
         viewportHeight: height,
-        showViewPortLeftShadow: false,
-        showViewPortRightShadow: false,
+        showViewportLeftShadow: false,
+        showViewportRightShadow: false,
         scrollContainsRowHeader:
           this.cfg.spreadsheet.isScrollContainsRowHeader(),
         isPivotMode: this.cfg.spreadsheet.isPivotMode(),

--- a/packages/s2-core/src/facet/header/frame.ts
+++ b/packages/s2-core/src/facet/header/frame.ts
@@ -15,8 +15,8 @@ export class Frame extends Group {
     this.addCornerBottomBorder();
     // corner右边的竖线条
     this.addCornerRightBorder();
-    // 一级纵向分割线右侧的shadow
-    this.addSplitLineRightShadow();
+    // 一级纵向分割线两侧的shadow
+    this.addSplitLineShadow();
   }
 
   /**
@@ -34,17 +34,12 @@ export class Frame extends Group {
     this.render();
   }
 
-  public onChangeShadowVisibility(
-    scrollX: number,
-    maxScrollX: number,
-    cornerRightShadow: boolean,
-  ) {
-    const visible = scrollX < maxScrollX;
-    if (cornerRightShadow) {
-      this.cfg.showCornerRightShadow = visible;
-    } else {
-      this.cfg.showViewPortRightShadow = visible;
-    }
+  public onChangeShadowVisibility(scrollX: number, maxScrollX: number) {
+    this.cfg.showViewPortLeftShadow = scrollX > 0;
+    // baseFacet#renderHScrollBar render condition
+    this.cfg.showViewPortRightShadow =
+      Math.floor(scrollX) < Math.floor(maxScrollX);
+
     this.render();
   }
 
@@ -103,38 +98,68 @@ export class Frame extends Group {
     });
   }
 
-  private addSplitLineRightShadow() {
+  private addSplitLineShadow() {
     const cfg = this.cfg;
+    const { isPivotMode, spreadsheet } = cfg;
+    const splitLine = spreadsheet.theme?.splitLine;
+
+    if (
+      !isPivotMode ||
+      !splitLine.showShadow ||
+      !spreadsheet.isFrozenRowHeader()
+    ) {
+      return;
+    }
+
+    // do render...
+    this.addSplitLineLeftShadow();
+    this.addSplitLineRightShadow();
+  }
+
+  private addSplitLineLeftShadow() {
+    if (!this.cfg.showViewPortLeftShadow) {
+      return;
+    }
+
+    const { width, height, viewportHeight, position, spreadsheet } = this.cfg;
+    const splitLine = spreadsheet.theme?.splitLine;
+    const x = position.x + width;
+    const y = position.y;
+    this.addShape('rect', {
+      attrs: {
+        x,
+        y,
+        width: splitLine.shadowWidth,
+        height: viewportHeight + height,
+        fill: `l (0) 0:${splitLine.shadowColors?.left} 1:${splitLine.shadowColors?.right}`,
+      },
+    });
+  }
+
+  private addSplitLineRightShadow() {
+    if (!this.cfg.showViewPortRightShadow) {
+      return;
+    }
+
     const {
       width,
       height,
       viewportHeight,
+      viewportWidth,
       position,
-      isPivotMode,
       spreadsheet,
-      showViewPortRightShadow,
-    } = cfg;
-
-    if (!isPivotMode) {
-      return;
-    }
+    } = this.cfg;
     const splitLine = spreadsheet.theme?.splitLine;
-    if (
-      splitLine.showShadow &&
-      showViewPortRightShadow &&
-      this.cfg.spreadsheet.isFrozenRowHeader()
-    ) {
-      const x = position.x + width;
-      const y = position.y;
-      this.addShape('rect', {
-        attrs: {
-          x,
-          y,
-          width: splitLine.shadowWidth,
-          height: viewportHeight + height,
-          fill: `l (0) 0:${splitLine.shadowColors?.left} 1:${splitLine.shadowColors?.right}`,
-        },
-      });
-    }
+    const x = position.x + width + viewportWidth - splitLine.shadowWidth;
+    const y = position.y;
+    this.addShape('rect', {
+      attrs: {
+        x,
+        y,
+        width: splitLine.shadowWidth,
+        height: viewportHeight + height,
+        fill: `l (0) 0:${splitLine.shadowColors?.right} 1:${splitLine.shadowColors?.left}`,
+      },
+    });
   }
 }

--- a/packages/s2-core/src/facet/header/frame.ts
+++ b/packages/s2-core/src/facet/header/frame.ts
@@ -35,9 +35,9 @@ export class Frame extends Group {
   }
 
   public onChangeShadowVisibility(scrollX: number, maxScrollX: number) {
-    this.cfg.showViewPortLeftShadow = scrollX > 0;
+    this.cfg.showViewportLeftShadow = scrollX > 0;
     // baseFacet#renderHScrollBar render condition
-    this.cfg.showViewPortRightShadow =
+    this.cfg.showViewportRightShadow =
       Math.floor(scrollX) < Math.floor(maxScrollX);
 
     this.render();
@@ -117,7 +117,7 @@ export class Frame extends Group {
   }
 
   private addSplitLineLeftShadow() {
-    if (!this.cfg.showViewPortLeftShadow) {
+    if (!this.cfg.showViewportLeftShadow) {
       return;
     }
 
@@ -137,7 +137,7 @@ export class Frame extends Group {
   }
 
   private addSplitLineRightShadow() {
-    if (!this.cfg.showViewPortRightShadow) {
+    if (!this.cfg.showViewportRightShadow) {
       return;
     }
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

参考 ant-design table 的 [锁列阴影逻辑](https://ant.design/components/table-cn/#components-table-demo-fixed-columns-header)
1. 修复原有视窗左侧阴影错误逻辑
2. 新增视窗右侧阴影线
3. 移除废弃的 showCornerRightShadow 相关代码

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|  ![before](https://gw.alipayobjects.com/zos/antfincdn/vmBV13FdC/before.gif)    |  ![after](https://gw.alipayobjects.com/zos/antfincdn/IpPBjBuHXn/after.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
