### PR TITLE
feat(interaction): 支持禁用刷选功能

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -205,91 +205,6 @@ describe('RootInteraction Tests', () => {
     expect(rootInteraction.eventController.domEventListeners).toBeFalsy();
   });
 
-  test('should register default interaction', () => {
-    expect(rootInteraction.interactions.size).toEqual(9);
-    Object.keys(InteractionName).forEach((key) => {
-      expect(
-        rootInteraction.interactions.has(InteractionName[key]),
-      ).toBeTruthy();
-    });
-
-    // 保证对应的交互实例注册正确
-    expect(
-      rootInteraction.interactions.get(InteractionName.DATA_CELL_CLICK),
-    ).toBeInstanceOf(DataCellClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.ROW_COLUMN_CLICK),
-    ).toBeInstanceOf(RowColumnClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.ROW_TEXT_CLICK),
-    ).toBeInstanceOf(RowTextClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.MERGED_CELLS_CLICK),
-    ).toBeInstanceOf(MergedCellClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.HOVER),
-    ).toBeInstanceOf(HoverEvent);
-    expect(
-      rootInteraction.interactions.get(InteractionName.BRUSH_SELECTION),
-    ).toBeInstanceOf(BrushSelection);
-    expect(
-      rootInteraction.interactions.get(InteractionName.COL_ROW_RESIZE),
-    ).toBeInstanceOf(RowColumnResize);
-    expect(
-      rootInteraction.interactions.get(
-        InteractionName.DATA_CELL_MULTI_SELECTION,
-      ),
-    ).toBeInstanceOf(DataCellMultiSelection);
-    expect(
-      rootInteraction.interactions.get(
-        InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
-      ),
-    ).toBeInstanceOf(ShiftMultiSelection);
-  });
-
-  test('should register custom interaction', () => {
-    class MyInteraction extends BaseEvent {
-      bindEvents() {}
-    }
-
-    const customInteraction = {
-      key: 'customInteraction',
-      interaction: MyInteraction,
-    };
-
-    mockSpreadSheetInstance.options.interaction.customInteractions = [
-      customInteraction,
-    ];
-
-    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
-    expect(rootInteraction.interactions.size).toEqual(10);
-    expect(
-      rootInteraction.interactions.has(customInteraction.key),
-    ).toBeTruthy();
-    expect(
-      rootInteraction.interactions.get(customInteraction.key),
-    ).toBeInstanceOf(MyInteraction);
-  });
-
-  test('should disable brush and resize interaction by options', () => {
-    mockSpreadSheetInstance.options = {
-      interaction: {
-        brushSelection: false,
-        resize: false,
-      },
-    } as S2Options;
-
-    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
-    expect(rootInteraction.interactions.size).toEqual(7);
-    expect(
-      rootInteraction.interactions.has(InteractionName.BRUSH_SELECTION),
-    ).toBeFalsy();
-    [...rootInteraction.interactions.values()].forEach((interaction) => {
-      expect(interaction).not.toBeInstanceOf(BrushSelection);
-      expect(interaction).not.toBeInstanceOf(RowColumnResize);
-    });
-  });
-
   describe('RootInteraction Change State', () => {
     test('should update cell style when update interaction state', () => {
       const cells = [mockCell, mockCell, mockCell];
@@ -461,6 +376,92 @@ describe('RootInteraction Tests', () => {
       await sleep(300);
 
       expect(flag).toBeFalsy();
+    });
+  });
+
+  test('should register default interaction', () => {
+    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
+    expect(rootInteraction.interactions.size).toEqual(9);
+    Object.keys(InteractionName).forEach((key) => {
+      expect(
+        rootInteraction.interactions.has(InteractionName[key]),
+      ).toBeTruthy();
+    });
+
+    // 保证对应的交互实例注册正确
+    expect(
+      rootInteraction.interactions.get(InteractionName.DATA_CELL_CLICK),
+    ).toBeInstanceOf(DataCellClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.ROW_COLUMN_CLICK),
+    ).toBeInstanceOf(RowColumnClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.ROW_TEXT_CLICK),
+    ).toBeInstanceOf(RowTextClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.MERGED_CELLS_CLICK),
+    ).toBeInstanceOf(MergedCellClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.HOVER),
+    ).toBeInstanceOf(HoverEvent);
+    expect(
+      rootInteraction.interactions.get(InteractionName.BRUSH_SELECTION),
+    ).toBeInstanceOf(BrushSelection);
+    expect(
+      rootInteraction.interactions.get(InteractionName.COL_ROW_RESIZE),
+    ).toBeInstanceOf(RowColumnResize);
+    expect(
+      rootInteraction.interactions.get(
+        InteractionName.DATA_CELL_MULTI_SELECTION,
+      ),
+    ).toBeInstanceOf(DataCellMultiSelection);
+    expect(
+      rootInteraction.interactions.get(
+        InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
+      ),
+    ).toBeInstanceOf(ShiftMultiSelection);
+  });
+
+  test('should register custom interaction', () => {
+    class MyInteraction extends BaseEvent {
+      bindEvents() {}
+    }
+
+    const customInteraction = {
+      key: 'customInteraction',
+      interaction: MyInteraction,
+    };
+
+    mockSpreadSheetInstance.options.interaction.customInteractions = [
+      customInteraction,
+    ];
+
+    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
+    expect(rootInteraction.interactions.size).toEqual(10);
+    expect(
+      rootInteraction.interactions.has(customInteraction.key),
+    ).toBeTruthy();
+    expect(
+      rootInteraction.interactions.get(customInteraction.key),
+    ).toBeInstanceOf(MyInteraction);
+  });
+
+  test('should disable brush and resize interaction by options', () => {
+    mockSpreadSheetInstance.options = {
+      interaction: {
+        brushSelection: false,
+        resize: false,
+      },
+    } as S2Options;
+
+    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
+    expect(rootInteraction.interactions.size).toEqual(7);
+    expect(
+      rootInteraction.interactions.has(InteractionName.BRUSH_SELECTION),
+    ).toBeFalsy();
+    [...rootInteraction.interactions.values()].forEach((interaction) => {
+      expect(interaction).not.toBeInstanceOf(BrushSelection);
+      expect(interaction).not.toBeInstanceOf(RowColumnResize);
     });
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -11,6 +11,17 @@ import {
   S2Options,
   SpreadSheet,
   MergedCell,
+  InteractionName,
+  DataCellClick,
+  RowColumnClick,
+  RowTextClick,
+  MergedCellClick,
+  HoverEvent,
+  BrushSelection,
+  RowColumnResize,
+  DataCellMultiSelection,
+  ShiftMultiSelection,
+  BaseEvent,
 } from '@/index';
 import { Store } from '@/common/store';
 import { mergeCell, unmergeCell } from '@/utils/interaction/merge-cell';
@@ -192,6 +203,91 @@ describe('RootInteraction Tests', () => {
     // clear events
     expect(rootInteraction.eventController.canvasEventHandlers).toBeFalsy();
     expect(rootInteraction.eventController.domEventListeners).toBeFalsy();
+  });
+
+  test('should register default interaction', () => {
+    expect(rootInteraction.interactions.size).toEqual(9);
+    Object.keys(InteractionName).forEach((key) => {
+      expect(
+        rootInteraction.interactions.has(InteractionName[key]),
+      ).toBeTruthy();
+    });
+
+    // 保证对应的交互实例注册正确
+    expect(
+      rootInteraction.interactions.get(InteractionName.DATA_CELL_CLICK),
+    ).toBeInstanceOf(DataCellClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.ROW_COLUMN_CLICK),
+    ).toBeInstanceOf(RowColumnClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.ROW_TEXT_CLICK),
+    ).toBeInstanceOf(RowTextClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.MERGED_CELLS_CLICK),
+    ).toBeInstanceOf(MergedCellClick);
+    expect(
+      rootInteraction.interactions.get(InteractionName.HOVER),
+    ).toBeInstanceOf(HoverEvent);
+    expect(
+      rootInteraction.interactions.get(InteractionName.BRUSH_SELECTION),
+    ).toBeInstanceOf(BrushSelection);
+    expect(
+      rootInteraction.interactions.get(InteractionName.COL_ROW_RESIZE),
+    ).toBeInstanceOf(RowColumnResize);
+    expect(
+      rootInteraction.interactions.get(
+        InteractionName.DATA_CELL_MULTI_SELECTION,
+      ),
+    ).toBeInstanceOf(DataCellMultiSelection);
+    expect(
+      rootInteraction.interactions.get(
+        InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
+      ),
+    ).toBeInstanceOf(ShiftMultiSelection);
+  });
+
+  test('should register custom interaction', () => {
+    class MyInteraction extends BaseEvent {
+      bindEvents() {}
+    }
+
+    const customInteraction = {
+      key: 'customInteraction',
+      interaction: MyInteraction,
+    };
+
+    mockSpreadSheetInstance.options.interaction.customInteractions = [
+      customInteraction,
+    ];
+
+    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
+    expect(rootInteraction.interactions.size).toEqual(10);
+    expect(
+      rootInteraction.interactions.has(customInteraction.key),
+    ).toBeTruthy();
+    expect(
+      rootInteraction.interactions.get(customInteraction.key),
+    ).toBeInstanceOf(MyInteraction);
+  });
+
+  test('should disable brush and resize interaction by options', () => {
+    mockSpreadSheetInstance.options = {
+      interaction: {
+        brushSelection: false,
+        resize: false,
+      },
+    } as S2Options;
+
+    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
+    expect(rootInteraction.interactions.size).toEqual(7);
+    expect(
+      rootInteraction.interactions.has(InteractionName.BRUSH_SELECTION),
+    ).toBeFalsy();
+    [...rootInteraction.interactions.values()].forEach((interaction) => {
+      expect(interaction).not.toBeInstanceOf(BrushSelection);
+      expect(interaction).not.toBeInstanceOf(RowColumnResize);
+    });
   });
 
   describe('RootInteraction Change State', () => {

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -387,39 +387,22 @@ describe('RootInteraction Tests', () => {
         rootInteraction.interactions.has(InteractionName[key]),
       ).toBeTruthy();
     });
+  });
 
+  test.each`
+    key                                              | expected
+    ${InteractionName.DATA_CELL_CLICK}               | ${DataCellClick}
+    ${InteractionName.ROW_COLUMN_CLICK}              | ${RowColumnClick}
+    ${InteractionName.ROW_TEXT_CLICK}                | ${RowTextClick}
+    ${InteractionName.MERGED_CELLS_CLICK}            | ${MergedCellClick}
+    ${InteractionName.HOVER}                         | ${HoverEvent}
+    ${InteractionName.BRUSH_SELECTION}               | ${BrushSelection}
+    ${InteractionName.COL_ROW_RESIZE}                | ${RowColumnResize}
+    ${InteractionName.DATA_CELL_MULTI_SELECTION}     | ${DataCellMultiSelection}
+    ${InteractionName.COL_ROW_SHIFT_MULTI_SELECTION} | ${ShiftMultiSelection}
+  `('should register correctly interaction instance', ({ key, expected }) => {
     // 保证对应的交互实例注册正确
-    expect(
-      rootInteraction.interactions.get(InteractionName.DATA_CELL_CLICK),
-    ).toBeInstanceOf(DataCellClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.ROW_COLUMN_CLICK),
-    ).toBeInstanceOf(RowColumnClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.ROW_TEXT_CLICK),
-    ).toBeInstanceOf(RowTextClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.MERGED_CELLS_CLICK),
-    ).toBeInstanceOf(MergedCellClick);
-    expect(
-      rootInteraction.interactions.get(InteractionName.HOVER),
-    ).toBeInstanceOf(HoverEvent);
-    expect(
-      rootInteraction.interactions.get(InteractionName.BRUSH_SELECTION),
-    ).toBeInstanceOf(BrushSelection);
-    expect(
-      rootInteraction.interactions.get(InteractionName.COL_ROW_RESIZE),
-    ).toBeInstanceOf(RowColumnResize);
-    expect(
-      rootInteraction.interactions.get(
-        InteractionName.DATA_CELL_MULTI_SELECTION,
-      ),
-    ).toBeInstanceOf(DataCellMultiSelection);
-    expect(
-      rootInteraction.interactions.get(
-        InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
-      ),
-    ).toBeInstanceOf(ShiftMultiSelection);
+    expect(rootInteraction.interactions.get(key)).toBeInstanceOf(expected);
   });
 
   test('should register custom interaction', () => {

--- a/packages/s2-core/__tests__/unit/utils/merge-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-spec.ts
@@ -116,6 +116,7 @@ describe('merge test', () => {
         },
         autoResetSheetStyle: true,
         resize: true,
+        brushSelection: true,
       },
       frozenRowHeader: true,
       showSeriesNumber: false,

--- a/packages/s2-core/src/common/constant/options.ts
+++ b/packages/s2-core/src/common/constant/options.ts
@@ -59,6 +59,7 @@ export const DEFAULT_OPTIONS: Readonly<S2Options> = {
     },
     autoResetSheetStyle: true,
     resize: true,
+    brushSelection: true,
   },
   showSeriesNumber: false,
   scrollReachNodeField: {},

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -49,6 +49,8 @@ export interface InteractionOptions {
   readonly scrollSpeedRatio?: ScrollRatio;
   // enable resize area, default set to all enable
   readonly resize?: boolean | ResizeActiveOptions;
+  // enable mouse drag brush selection
+  readonly brushSelection?: boolean;
   /** ***********CUSTOM INTERACTION HOOKS**************** */
   // register custom interactions
   customInteractions?: CustomInteraction[];

--- a/packages/s2-core/src/interaction/index.ts
+++ b/packages/s2-core/src/interaction/index.ts
@@ -5,3 +5,4 @@ export * from './data-cell-multi-selection';
 export * from './event-controller';
 export * from './root';
 export * from './row-column-resize';
+export * from './shift-multi-selection';

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -237,55 +237,65 @@ export class RootInteraction {
     hideColumns(this.spreadsheet, hiddenColumnFields, true);
   }
 
-  /**
-   * 注册交互（组件按自己的场景写交互，继承此方法注册）
-   * @param options
-   */
+  private getDefaultInteractions() {
+    const { resize, brushSelection } = this.spreadsheet.options.interaction;
+    return [
+      {
+        key: InteractionName.DATA_CELL_CLICK,
+        interaction: DataCellClick,
+      },
+      {
+        key: InteractionName.ROW_COLUMN_CLICK,
+        interaction: RowColumnClick,
+      },
+      {
+        key: InteractionName.ROW_TEXT_CLICK,
+        interaction: RowTextClick,
+      },
+      {
+        key: InteractionName.MERGED_CELLS_CLICK,
+        interaction: MergedCellClick,
+      },
+      {
+        key: InteractionName.HOVER,
+        interaction: HoverEvent,
+        enable: !isMobile(),
+      },
+      {
+        key: InteractionName.BRUSH_SELECTION,
+        interaction: BrushSelection,
+        enable: !isMobile() && brushSelection,
+      },
+      {
+        key: InteractionName.COL_ROW_RESIZE,
+        interaction: RowColumnResize,
+        enable: !isMobile() && resize,
+      },
+      {
+        key: InteractionName.DATA_CELL_MULTI_SELECTION,
+        interaction: DataCellMultiSelection,
+        enable: !isMobile(),
+      },
+      {
+        key: InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
+        interaction: ShiftMultiSelection,
+        enable: !isMobile(),
+      },
+    ];
+  }
+
   private registerInteractions() {
+    const { customInteractions } = this.spreadsheet.options.interaction;
+
     this.interactions.clear();
 
-    this.interactions.set(
-      InteractionName.DATA_CELL_CLICK,
-      new DataCellClick(this.spreadsheet),
-    );
-    this.interactions.set(
-      InteractionName.ROW_COLUMN_CLICK,
-      new RowColumnClick(this.spreadsheet),
-    );
-    this.interactions.set(
-      InteractionName.ROW_TEXT_CLICK,
-      new RowTextClick(this.spreadsheet),
-    );
-    this.interactions.set(
-      InteractionName.MERGED_CELLS_CLICK,
-      new MergedCellClick(this.spreadsheet),
-    );
-    this.interactions.set(
-      InteractionName.HOVER,
-      new HoverEvent(this.spreadsheet),
-    );
+    const defaultInteractions = this.getDefaultInteractions();
+    defaultInteractions.forEach(({ key, interaction: Interaction, enable }) => {
+      if (enable !== false) {
+        this.interactions.set(key, new Interaction(this.spreadsheet));
+      }
+    });
 
-    if (!isMobile()) {
-      this.interactions.set(
-        InteractionName.BRUSH_SELECTION,
-        new BrushSelection(this.spreadsheet),
-      );
-      this.interactions.set(
-        InteractionName.COL_ROW_RESIZE,
-        new RowColumnResize(this.spreadsheet),
-      );
-      this.interactions.set(
-        InteractionName.DATA_CELL_MULTI_SELECTION,
-        new DataCellMultiSelection(this.spreadsheet),
-      );
-      this.interactions.set(
-        InteractionName.COL_ROW_SHIFT_MULTI_SELECTION,
-        new ShiftMultiSelection(this.spreadsheet),
-      );
-    }
-
-    const customInteractions =
-      this.spreadsheet.options?.interaction.customInteractions;
     if (!isEmpty(customInteractions)) {
       forEach(customInteractions, (customInteraction: CustomInteraction) => {
         const CustomInteractionClass = customInteraction.interaction;

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -21,7 +21,6 @@ import {
   RESIZE_START_GUIDE_LINE_ID,
   RESIZE_END_GUIDE_LINE_ID,
   S2Event,
-  CORNER_MAX_WIDTH_RATIO,
   ResizeDirectionType,
   ResizeAreaEffect,
 } from '@/common/constant';

--- a/packages/s2-react/__tests__/unit/utils/options-spec.ts
+++ b/packages/s2-react/__tests__/unit/utils/options-spec.ts
@@ -38,6 +38,7 @@ describe('Options Tests', () => {
         },
         autoResetSheetStyle: true,
         resize: true,
+        brushSelection: true,
       },
       frozenRowHeader: true,
       showSeriesNumber: false,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -456,7 +456,9 @@ function MainLayout() {
                   </Button>
                 </Popover>
               </Space>
-              <Space style={{ margin: '20px 0', display: 'flex' }}>
+              <Space
+                style={{ marginTop: 20, display: 'flex', flexWrap: 'wrap' }}
+              >
                 <Switch
                   checkedChildren="渲染组件"
                   unCheckedChildren="卸载组件"
@@ -527,24 +529,6 @@ function MainLayout() {
                   defaultChecked={adaptive}
                   onChange={setAdaptive}
                 />
-                <Tooltip title="开启后,点击空白处,按下ESC键, 取消高亮, 清空选中单元格, 等交互样式">
-                  <Switch
-                    checkedChildren="自动重置交互样式开"
-                    unCheckedChildren="自动重置交互样式关"
-                    defaultChecked={
-                      mergedOptions?.interaction?.autoResetSheetStyle
-                    }
-                    onChange={(checked) => {
-                      updateOptions({
-                        interaction: {
-                          autoResetSheetStyle: checked,
-                        },
-                      });
-                    }}
-                  />
-                </Tooltip>
-              </Space>
-              <Space size="middle">
                 <Switch
                   checkedChildren="显示序号"
                   unCheckedChildren="不显示序号"
@@ -566,30 +550,6 @@ function MainLayout() {
                   unCheckedChildren="无汇总"
                   checked={showTotals}
                   onChange={setShowTotals}
-                />
-                <Switch
-                  checkedChildren="选中聚光灯开"
-                  unCheckedChildren="选中聚光灯关"
-                  checked={mergedOptions.interaction.selectedCellsSpotlight}
-                  onChange={(checked) => {
-                    updateOptions({
-                      interaction: {
-                        selectedCellsSpotlight: checked,
-                      },
-                    });
-                  }}
-                />
-                <Switch
-                  checkedChildren="hover十字器开"
-                  unCheckedChildren="hover十字器关"
-                  checked={mergedOptions.interaction.hoverHighlight}
-                  onChange={(checked) => {
-                    updateOptions({
-                      interaction: {
-                        hoverHighlight: checked,
-                      },
-                    });
-                  }}
                 />
                 <Switch
                   checkedChildren="默认actionIcons"
@@ -619,6 +579,50 @@ function MainLayout() {
                   checked={showCustomTooltip}
                   onChange={setShowCustomTooltip}
                 />
+              </Space>
+            </Collapse.Panel>
+            <Collapse.Panel header="交互配置" key="interaction">
+              <Space>
+                <Switch
+                  checkedChildren="选中聚光灯开"
+                  unCheckedChildren="选中聚光灯关"
+                  checked={mergedOptions.interaction.selectedCellsSpotlight}
+                  onChange={(checked) => {
+                    updateOptions({
+                      interaction: {
+                        selectedCellsSpotlight: checked,
+                      },
+                    });
+                  }}
+                />
+                <Switch
+                  checkedChildren="hover十字器开"
+                  unCheckedChildren="hover十字器关"
+                  checked={mergedOptions.interaction.hoverHighlight}
+                  onChange={(checked) => {
+                    updateOptions({
+                      interaction: {
+                        hoverHighlight: checked,
+                      },
+                    });
+                  }}
+                />
+                <Tooltip title="开启后,点击空白处,按下ESC键, 取消高亮, 清空选中单元格, 等交互样式">
+                  <Switch
+                    checkedChildren="自动重置交互样式开"
+                    unCheckedChildren="自动重置交互样式关"
+                    defaultChecked={
+                      mergedOptions?.interaction?.autoResetSheetStyle
+                    }
+                    onChange={(checked) => {
+                      updateOptions({
+                        interaction: {
+                          autoResetSheetStyle: checked,
+                        },
+                      });
+                    }}
+                  />
+                </Tooltip>
               </Space>
             </Collapse.Panel>
             <Collapse.Panel header="宽高调整热区配置" key="resize">

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -26,6 +26,8 @@ const getStrategySheetOptions: GetStrategySheetOptions = (
     },
     interaction: {
       autoResetSheetStyle: true,
+      // 趋势分析表不开启刷选
+      brushSelection: false,
     },
     tooltip: {
       operation: {

--- a/s2-site/docs/common/interaction.zh.md
+++ b/s2-site/docs/common/interaction.zh.md
@@ -13,10 +13,11 @@ order: 5
 | hiddenColumnFields     | 隐藏列 （明细表有效）                                 | `string[]`                                                                               |         |       |
 | enableCopy             | 是否允许复制                                          | `boolean`                                                                                | `false` |       |
 | copyWithFormat         | 是否使用 field format 格式复制                        | `boolean`                                                                                | `false` |       |
-| customInteractions     | 自定义交互                                            | [CustomInteraction[]](#custominteraction)                                                |         |       |
+| customInteractions     | 自定义交互 [详情](zh/docs/manual/advanced/interaction/custom)                                          | [CustomInteraction[]](#custominteraction)                                                |         |       |
 | scrollSpeedRatio       | 用于控制滚动速率，分水平和垂直两个方向，默认为 1      | [ScrollRatio](/zh/docs/api/general/S2Options#scrollratio)                                |         |       |
 | autoResetSheetStyle    | 用于控制点击表格外区域和按下 esc 键时是否重置交互状态 | `boolean`                                                                                | `true`  |       |
 | resize                 | 用于控制 resize 热区是否显示                          | `boolean`   \| [ResizeActiveOptions](/zh/docs/api/general/S2Options#resizeactiveoptions) | `true`  |       |
+| brushSelection                 | 是否允许刷选                         | `boolean` | `true`  |       |
 
 ### CustomInteraction
 

--- a/s2-site/docs/manual/advanced/interaction/custom.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/custom.zh.md
@@ -3,7 +3,7 @@ title: 自定义交互
 order: 1
 ---
 
-如果内置交互未能覆盖实际的使用场景，不用担心。你可以使用 [`S2Event`](https://github.com/antvis/S2/blob/master/packages/s2-core/src/common/constant/events/basic.ts) 所提供的交互事件，进行任意排列组合，自定义交互。这里以**明细表双击隐藏列头**的例子说明。
+如果内置交互未能覆盖实际的使用场景，不用担心。你可以使用 [`S2Event`](https://github.com/antvis/S2/blob/master/packages/s2-core/src/common/constant/events/basic.ts) 所提供的交互事件，进行任意排列组合，自定义交互。这里以 [**明细表双击隐藏列头**](/zh/examples/interaction/custom#double-click-hide-columns) 的例子说明。
 
 ## 1. 自定义交互类
 
@@ -21,7 +21,7 @@ class HiddenInteraction extends BaseEvent {
 }
 ```
 
-监听 `列头` 双击事件: `S2Event.COL_CELL_DOUBLE_CLICK`
+监听 `列头` 双击事件：`S2Event.COL_CELL_DOUBLE_CLICK`
 
 ```ts
 import { BaseEvent, S2Event } from '@antv/s2';
@@ -103,4 +103,4 @@ const s2 = new TableSheet(container, s2DataConfig, s2options);
 s2.render();
 ```
 
-<playground path='interaction/advanced/demo/custom.ts' rid='container' height='400'></playground>
+<playground path='interaction/advanced/demo/double-click-hide-columns.ts' rid='container' height='400'></playground>

--- a/s2-site/docs/manual/faq.zh.md
+++ b/s2-site/docs/manual/faq.zh.md
@@ -59,13 +59,13 @@ s2.render();
 <link rel="stylesheet" href="https://unpkg.com/@antv/s2-react@latest/dist/style.min.css"/>
 ```
 
-### 官网访问有点慢, 或打不开, 有国内镜像吗?
+### 官网访问有点慢，或打不开，有国内镜像吗？
 
-有, 国内镜像部署在 `gitee` 上面 [点击访问](https://antv-s2.gitee.io/)
+有，国内镜像部署在 `gitee` 上面 [点击访问](https://antv-s2.gitee.io/)
 
-### 父级元素使用了 `transform: scale` 后, 图表鼠标坐标响应不正确
+### 父级元素使用了 `transform: scale` 后，图表鼠标坐标响应不正确
 
-可以调用 `s2.changeSize` 根据缩放比改变图表大小, 使图表和父元素缩放比保持一致
+可以调用 `s2.changeSize` 根据缩放比改变图表大小，使图表和父元素缩放比保持一致
 
 ```ts
 const scale = 0.8
@@ -73,11 +73,11 @@ s2.changeSize(width * scale, height * scale)
 s2.render(false)
 ```
 
-可参考 [issue #808](https://github.com/antvis/S2/issues/808) (感谢[cylnet](https://github.com/cylnet))
+可参考 [issue #808](https://github.com/antvis/S2/issues/808) （感谢 [cylnet](https://github.com/cylnet))
 
-### 图表渲染不出来, 怎么回事?
+### 图表渲染不出来，怎么回事？
 
-图表需要挂载在 `dom` 节点上, 请确保该节点存在
+图表需要挂载在 `dom` 节点上，请确保该节点存在
 
 ```html
 <div id="container"></div>
@@ -87,7 +87,7 @@ s2.render(false)
 const pivotSheet = new PivotSheet(document.getElementById('container'), dataCfg, options);
 ```
 
-如果传入的是选择器, S2 会使用 [`document.querySelector()`](https://developer.mozilla.org/zh-CN/docs/Web/API/Document/querySelector) 去查找, 也就意味着, 只要节点存在, 且选择器符合 `querySelector` 的语法, 都是可以的
+如果传入的是选择器，S2 会使用 [`document.querySelector()`](https://developer.mozilla.org/zh-CN/docs/Web/API/Document/querySelector) 去查找，也就意味着，只要节点存在，且选择器符合 `querySelector` 的语法，都是可以的
 
 ```ts
 const pivotSheet = new PivotSheet('#container', dataCfg, options);
@@ -96,8 +96,8 @@ const pivotSheet = new PivotSheet('#container > div', dataCfg, options);
 const pivotSheet = new PivotSheet('#container > div[title="xx"]', dataCfg, options);
 ```
 
-### 为什么在小程序上面图表无法显示?
+### 为什么在小程序上面图表无法显示？
 
-目前 `S2` 只支持 `web` 平台, 小程序暂不支持.
+目前 `S2` 只支持 `web` 平台，小程序暂不支持。
 
 ## 2. 错误和警告


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

1. 刷选功能支持配置是否开启 `interaction.brushSelection: boolean`
2. 趋势分析表关闭刷选功能
3. 优化注册交互的方式, 移动端关闭 `hover` 交互
4. 修复交互文档 demo 不显示的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
