### PR TITLE
fix: :bug: 修复指标列头 hover 行为和维值列头不一致问题

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
@@ -40,7 +40,8 @@ describe('Interaction Hover Tests', () => {
       ({
         update: mockCellUpdate,
         getMeta: () => mockCell,
-        getActualText: () => '',
+        getActualText: () => '...',
+        getFieldValue: () => '',
       } as any);
     hoverEvent = new HoverEvent(s2 as unknown as SpreadSheet);
     s2.options = {

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -94,6 +94,10 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     return this.actualText;
   }
 
+  public getFieldValue() {
+    return this.getFormattedFieldValue().formattedValue;
+  }
+
   /**
    * in case there are more params to be handled
    * @param options any type's rest params

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -106,7 +106,7 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
     });
     cell.update();
 
-    if (cell.getActualText() !== meta.value) {
+    if (cell.getActualText() !== cell.getFieldValue()) {
       const showSingleTips = true;
       const options: TooltipOptions = {
         isTotals: meta.isTotals,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #893 

### 🖼️ Screenshot

只有单元格文本被省略行列头才展示 tooltip

![hover](https://user-images.githubusercontent.com/10885578/146538569-bf379bb6-b405-4193-a044-8f41e50074ec.gif)

