### PR TITLE
fix(scroll): 修复滚动表格后, 鼠标移动会重置已选中单元格 close #904

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -275,8 +275,8 @@ describe('Scroll By Group Tests', () => {
 
       canvas.dispatchEvent(wheelEvent);
 
-      // wait requestAnimationFrame
-      await sleep(500);
+      // wait requestAnimationFrame and debounce
+      await sleep(1000);
 
       // emit global canvas hover
       s2.container.emit(OriginEventType.MOUSE_MOVE, { target: {} });

--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -275,13 +275,14 @@ describe('Scroll By Group Tests', () => {
 
       canvas.dispatchEvent(wheelEvent);
 
+      expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+
       // wait requestAnimationFrame and debounce
       await sleep(1000);
 
       // emit global canvas hover
       s2.container.emit(OriginEventType.MOUSE_MOVE, { target: {} });
 
-      expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
       expect(s2.interaction.getState()).toEqual({
         stateName: InteractionStateName.SELECTED,
         cells: [cellA.mockCellMeta, cellB.mockCellMeta],

--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -1,9 +1,14 @@
 /* eslint-disable jest/no-conditional-expect */
 import * as mockDataConfig from 'tests/data/simple-data.json';
-import { getContainer, sleep } from 'tests/util/helpers';
+import { createMockCellInfo, getContainer, sleep } from 'tests/util/helpers';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
-import { S2Options } from '@/common/interface';
-import { InterceptType, S2Event } from '@/common/constant';
+import { CellMeta, S2Options } from '@/common/interface';
+import {
+  InteractionStateName,
+  InterceptType,
+  OriginEventType,
+  S2Event,
+} from '@/common/constant';
 
 const s2options: S2Options = {
   width: 200,
@@ -26,6 +31,10 @@ describe('Scroll By Group Tests', () => {
   let canvas: HTMLCanvasElement;
 
   beforeEach(() => {
+    jest
+      .spyOn(SpreadSheet.prototype, 'getCell')
+      .mockImplementation(() => createMockCellInfo('testId').mockCell as any);
+
     s2 = new PivotSheet(getContainer(), mockDataConfig, s2options);
     s2.render();
     canvas = s2.container.get('el') as HTMLCanvasElement;
@@ -220,6 +229,63 @@ describe('Scroll By Group Tests', () => {
       await sleep(200);
       // emit scroll event
       expect(onScroll).not.toHaveBeenCalled();
+    },
+  );
+
+  // https://github.com/antvis/S2/issues/904
+  test.each([
+    {
+      type: 'horizontal',
+      offset: {
+        scrollX: 20,
+        scrollY: 0,
+      },
+    },
+    {
+      type: 'vertical',
+      offset: {
+        scrollX: 0,
+        scrollY: 20,
+      },
+    },
+  ])(
+    'should not clear selected cells when hover cells after scroll by %o',
+    async ({ offset }) => {
+      const dataCellHover = jest.fn();
+
+      const cellA = createMockCellInfo('cell-a');
+      const cellB = createMockCellInfo('cell-b');
+
+      s2.on(S2Event.DATA_CELL_HOVER, dataCellHover);
+
+      s2.facet.cornerBBox.maxY = -9999;
+      s2.facet.panelBBox.minX = -9999;
+      s2.facet.panelBBox.minY = -9999;
+
+      // selected cells
+      s2.interaction.changeState({
+        stateName: InteractionStateName.SELECTED,
+        cells: [cellA.mockCellMeta, cellB.mockCellMeta] as CellMeta[],
+      });
+
+      const wheelEvent = new WheelEvent('wheel', {
+        deltaX: offset.scrollX,
+        deltaY: offset.scrollY,
+      });
+
+      canvas.dispatchEvent(wheelEvent);
+
+      // wait requestAnimationFrame
+      await sleep(500);
+
+      // emit global canvas hover
+      s2.container.emit(OriginEventType.MOUSE_MOVE, { target: {} });
+
+      expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+      expect(s2.interaction.getState()).toEqual({
+        stateName: InteractionStateName.SELECTED,
+        cells: [cellA.mockCellMeta, cellB.mockCellMeta],
+      });
     },
   );
 });

--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/expect-expect */
 import { Canvas, BBox } from '@antv/g-canvas';
 import { createFakeSpreadSheet } from 'tests/util/helpers';
 import { EmitterType } from '@/common/interface/emitter';

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1152,7 +1152,7 @@ export abstract class BaseFacet {
 
   protected onAfterScroll = debounce(() => {
     const { interaction } = this.spreadsheet;
-    // 如果是选中单元格状态, 则不取消 hover
+    // 如果是选中单元格状态, 则继续保留 hover 拦截, 避免滚动后 hover 清空已选单元格
     if (!interaction.isSelectedState()) {
       this.spreadsheet.interaction.removeIntercepts([InterceptType.HOVER]);
     }

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1151,7 +1151,11 @@ export abstract class BaseFacet {
   }
 
   protected onAfterScroll = debounce(() => {
-    this.spreadsheet.interaction.removeIntercepts([InterceptType.HOVER]);
+    const { interaction } = this.spreadsheet;
+    // 如果是选中单元格状态, 则不取消 hover
+    if (!interaction.isSelectedState()) {
+      this.spreadsheet.interaction.removeIntercepts([InterceptType.HOVER]);
+    }
   }, 300);
 
   protected abstract doLayout(): LayoutResult;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #904 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

RT

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2021-12-18 at 15 03 02](https://user-images.githubusercontent.com/21015895/146632635-3fc9dd62-5a58-4987-bfe7-875fac99515a.gif)| ![Kapture 2021-12-18 at 15 01 18](https://user-images.githubusercontent.com/21015895/146632603-d6bd4e3d-207f-4472-b32a-6fa00d829e55.gif)|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
