### PR TITLE
ci: 修复发布成功后自动创建pr失败, 以及调整推送策略

### DIFF
--- a/.github/workflows/auto-release-notify.yml
+++ b/.github/workflows/auto-release-notify.yml
@@ -1,0 +1,29 @@
+name: 🎉 Auto Release Notify
+
+# 自动发布 action 执行完成后再执行 (无论成功失败都会执行)
+on:
+  workflow_run:
+    workflows: ["🚀 Auto Release"]
+    types:
+      - completed
+
+jobs:
+  sync-site-lock:
+    runs-on: ubuntu-latest
+    # 自动发布成功后
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      # 内部开发和服务群, 官方对外讨论群
+      - name: Release success ding talk official group notify
+        if: ${{ contains(github.ref_name, 'latest') }}
+        uses: visiky/dingtalk-release-notify@main
+        with:
+          DING_TALK_TOKEN: |
+            ${{ secrets.DING_TALK_ACCESS_TOKEN }}
+            ${{ secrets.DING_TALK_GROUP_TOKEN }}
+            ${{ secrets.DING_TALK_PUBLIC_TOKEN }}
+          notify_title: '🎉 {release_tag} 发布 🎉'
+          notify_body: '### { title } <hr /> ![preview](https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png) <hr /> { body } <hr />'
+          at_all: false
+          # enable_prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}
+          enable_prerelease: false

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,45 +33,6 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: yarn release
 
-      # # 内部开发和服务群
-      # - name: Release success ding talk official group notify
-      #   if: ${{ success() }}
-      #   uses: visiky/dingtalk-release-notify@main
-      #   with:
-      #     DING_TALK_TOKEN: |
-      #       ${{ secrets.DING_TALK_ACCESS_TOKEN }}
-      #       ${{ secrets.DING_TALK_GROUP_TOKEN }}
-      #     notify_title: '🎉 {release_tag} 发布 🎉'
-      #     notify_body: '### { title } <hr /> ![preview](https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png) <hr /> { body } <hr />'
-      #     at_all: false
-      #     enable_prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}
-
-      # # 官方对外讨论群, 只推送正式版发布通知
-      # - name: Latest release success ding talk public group notify
-      #   if: ${{ success() && contains(github.ref_name, 'latest-release') }}
-      #   uses: visiky/dingtalk-release-notify@main
-      #   with:
-      #     DING_TALK_TOKEN: ${{ secrets.DING_TALK_PUBLIC_TOKEN }}
-      #     notify_title: '🎉 {release_tag} 发布 🎉'
-      #     notify_body: '### { title } <hr /> ![preview](https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png) <hr /> { body } <hr />'
-      #     at_all: false
-      #     enable_prerelease: false
-
-      - name: Release success ding talk official group notify
-        if: ${{ success() }}
-        uses: zcong1993/actions-ding@master
-        with:
-          dingToken: ${{ secrets.DING_TALK_ACCESS_TOKEN }}
-          body: |
-            {
-              "msgtype": "link",
-              "link": {
-                "title": "🎉 自动发布成功",
-                "text": "🔗 点击查看具体详情",
-                "messageUrl": "https://github.com/antvis/S2/releases",
-                "picUrl": "https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png"
-              }
-            }
 
       # 发布失败通知内部开发群
       - name: Release failed ding talk dev group notify
@@ -79,6 +40,7 @@ jobs:
         uses: zcong1993/actions-ding@master
         with:
           dingToken: ${{ secrets.DING_TALK_ACCESS_TOKEN }}
+          ignoreError: true
           body: |
             {
               "msgtype": "link",

--- a/.github/workflows/manual-release-notify.yml
+++ b/.github/workflows/manual-release-notify.yml
@@ -1,4 +1,4 @@
-name: 🎉  Manual Release Notify
+name: 🎉 Manual Release Notify
 
 on:
   release:

--- a/.github/workflows/sync-site-lock-changelog-with-pr.yml
+++ b/.github/workflows/sync-site-lock-changelog-with-pr.yml
@@ -50,6 +50,6 @@ jobs:
       # 使用官方的 github cli 便捷的创建 pr
       - name: Create PR
         run: |
-          gh pr create --fill --base master
+          gh pr create --title "chore: 🤖 auto sync site s2 lock and changelog [skip ci]" --body "🤖"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [x] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

1. 将 自动发布 和 通知 分开, 方便管理和直接在 github 上 禁用通知
2. 修改发布通知策略, 调整为只有正式版发布时再发布通知
3. 修复发布成功后, 自动创建pr失败的问题

### 🖼️ Screenshot

![image](https://user-images.githubusercontent.com/21015895/146638478-c244603d-f24f-44c3-a0c2-fa1b4c6abb31.png)


### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
