### PR TITLE
fix(startegysheet): 趋势分析表列头文字根据数值坐标动态计算

### DIFF
--- a/packages/s2-core/src/common/interface/s2DataConfig.ts
+++ b/packages/s2-core/src/common/interface/s2DataConfig.ts
@@ -20,7 +20,7 @@ export interface MultiData {
   // the title of one cell of the gridAnalysisSheet
   label?: string;
   values: (string | number)[][];
-  [key: string]: unknown;
+  [key: string]: any;
 }
 
 export type SimpleDataItem = string | number;

--- a/packages/s2-core/src/common/interface/s2DataConfig.ts
+++ b/packages/s2-core/src/common/interface/s2DataConfig.ts
@@ -20,7 +20,7 @@ export interface MultiData {
   // the title of one cell of the gridAnalysisSheet
   label?: string;
   values: (string | number)[][];
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export type SimpleDataItem = string | number;

--- a/packages/s2-core/src/facet/layout/node.ts
+++ b/packages/s2-core/src/facet/layout/node.ts
@@ -261,6 +261,8 @@ export class Node {
   // node is grand total or subtotal(not normal node)
   public isTotals: boolean;
 
+  public colId: string;
+
   public static blankNode(): Node {
     return new Node({
       id: '',
@@ -301,6 +303,10 @@ export class Node {
   public inCollapseNode?: boolean;
 
   public cornerType?: CornerNodeType;
+
+  public isGrandTotals?: boolean;
+
+  public isSubTotals?: boolean;
 
   [key: string]: any;
 

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -1,6 +1,7 @@
-import type { S2DataConfig, S2Options } from '@antv/s2';
+import { customMerge, isUpDataValue, S2DataConfig, S2Options } from '@antv/s2';
 import type { SliderSingleProps } from 'antd';
 import React from 'react';
+import { getSheetComponentOptions } from '../src/utils';
 import { data, totalData, meta } from '../__tests__/data/mock-dataset.json';
 
 const BASIC_BACKGROUND_COLOR = '#FFFFFF';
@@ -84,7 +85,7 @@ export const pivotSheetDataCfg: S2DataConfig = {
   },
 };
 
-export const s2Options: S2Options<React.ReactNode> = {
+export const s2Options: S2Options = {
   debug: true,
   width: 600,
   height: 600,
@@ -101,3 +102,85 @@ export const sliderOptions: SliderSingleProps = {
     10: '10',
   },
 };
+
+export const strategyOptions: S2Options = {
+  width: 1000,
+  height: 400,
+  cornerText: '指标',
+  headerActionIcons: [
+    {
+      iconNames: ['Trend'],
+      belongsCell: 'rowCell',
+      defaultHide: true,
+      action: () => {},
+    },
+  ],
+  style: {
+    cellCfg: {
+      valuesCfg: {
+        widthPercentCfg: [50, 30, 30],
+        originalValueField: 'originalValue',
+        conditions: {
+          text: {
+            mapping: (value, cellInfo) => {
+              const { colIndex } = cellInfo;
+              if (colIndex === 0) {
+                return {
+                  fill: '#000',
+                };
+              }
+              return {
+                fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
+              };
+            },
+          },
+        },
+        fieldLabels: [['指标', '环比值', '环比率']],
+      },
+    },
+  },
+};
+
+export const mockGridAnalysisOptions: S2Options = {
+  width: 1600,
+  height: 600,
+  style: {
+    layoutWidthType: 'colAdaptive',
+    cellCfg: {
+      width: 400,
+      height: 100,
+      valuesCfg: {
+        widthPercentCfg: [40, 20, 20, 20],
+        conditions: {
+          text: {
+            mapping: (value, cellInfo) => {
+              const { colIndex } = cellInfo;
+              if (colIndex <= 1) {
+                return {
+                  fill: '#000',
+                };
+              }
+              return {
+                fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
+              };
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const defaultOptions: S2Options = customMerge(
+  s2Options,
+  getSheetComponentOptions({
+    tooltip: {
+      operation: {
+        sort: true,
+        tableSort: true,
+        trend: true,
+        hiddenColumns: true,
+      },
+    },
+  }),
+);

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -33,7 +33,6 @@ import {
 import corePkg from '@antv/s2/package.json';
 import { forEach, random } from 'lodash';
 import { DataType } from '@antv/s2';
-import { isUpDataValue } from '@antv/s2';
 import { mockGridAnalysisDataCfg } from '../__tests__/data/grid-analysis-data';
 import {
   singleMeasure,
@@ -42,13 +41,14 @@ import {
 import reactPkg from '../package.json';
 import {
   pivotSheetDataCfg,
-  s2Options as playgroundS2Options,
   sliderOptions,
   tableSheetDataCfg,
   defaultTheme,
+  strategyOptions,
+  mockGridAnalysisOptions,
+  defaultOptions,
 } from './config';
 import { ResizeConfig } from './resize';
-import { getSheetComponentOptions } from '@/utils';
 import {
   SheetComponent,
   SheetType,
@@ -66,7 +66,7 @@ const fieldMap = {
   sex: ['男', '女'],
 };
 
-const partDrillDown = {
+const partDrillDown: PartDrillDown = {
   drillConfig: {
     dataSet: [
       {
@@ -124,74 +124,7 @@ const partDrillDown = {
         drillData: drillDownData,
       });
     }),
-} as PartDrillDown;
-
-const strategyOptions = {
-  width: 1000,
-  height: 400,
-  cornerText: '指标',
-  headerActionIcons: [
-    {
-      iconNames: ['Trend'],
-      belongsCell: 'rowCell',
-      defaultHide: true,
-      action: () => {},
-    },
-  ],
-  style: {
-    cellCfg: {
-      valuesCfg: {
-        originalValueField: 'originalValue',
-        conditions: {
-          text: {
-            mapping: (value, cellInfo) => {
-              const { colIndex } = cellInfo;
-              if (colIndex === 0) {
-                return {
-                  fill: '#000',
-                };
-              }
-              return {
-                fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
-              };
-            },
-          },
-        },
-        fieldLabels: [['指标', '环比值', '环比率']],
-      },
-    },
-  },
-} as S2Options;
-
-const mockGridAnalysisOptions = {
-  width: 1600,
-  height: 600,
-  style: {
-    layoutWidthType: 'colAdaptive',
-    cellCfg: {
-      width: 400,
-      height: 100,
-      valuesCfg: {
-        widthPercentCfg: [40, 20, 20, 20],
-        conditions: {
-          text: {
-            mapping: (value, cellInfo) => {
-              const { colIndex } = cellInfo;
-              if (colIndex <= 1) {
-                return {
-                  fill: '#000',
-                };
-              }
-              return {
-                fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
-              };
-            },
-          },
-        },
-      },
-    },
-  },
-} as S2Options;
+};
 
 const CustomTooltip = () => (
   <div>
@@ -203,20 +136,6 @@ const CustomTooltip = () => (
 const CustomColTooltip = () => <div>custom colTooltip</div>;
 
 const ActionIconTooltip = ({ name }) => <div>{name} Tooltip</div>;
-
-const defaultOptions: S2Options = customMerge(
-  getSheetComponentOptions({
-    tooltip: {
-      operation: {
-        sort: true,
-        tableSort: true,
-        trend: true,
-        hiddenColumns: true,
-      },
-    },
-  }),
-  playgroundS2Options,
-);
 
 function MainLayout() {
   const [render, setRender] = React.useState(true);

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-col-cell.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-col-cell.ts
@@ -1,20 +1,20 @@
 import {
+  CellTypes,
   ColCell,
+  DataCell,
   InteractionStateName,
   Node,
   SpreadSheet,
   updateShapeAttr,
 } from '@antv/s2';
 import { ColHeaderConfig } from '@antv/s2/esm/facet/header/col';
+import { get, isEmpty } from 'lodash';
 
 // hover时 指标名与单元格原始文字间隔
 const CELL_TEXT_ACTIVE_MARGIN = {
   top: 8,
   bottom: 10,
 };
-
-// 每个指标名之间的间隔
-const INDICATOR_LABEL_MARGIN = 10;
 
 /**
  * Cell for StrategySheet
@@ -37,39 +37,90 @@ export class CustomColCell extends ColCell {
     this.drawIndicatorLabels();
   }
 
+  // 拿到当前列对应的有数据的 data cell, 目的是获取实际渲染的 text shape 的坐标
+  private getCurrentColumnDataCell(): DataCell {
+    return this.spreadsheet.interaction
+      .getPanelGroupAllDataCells()
+      .find((dataCell) => {
+        const dataCellMeta = dataCell.getMeta();
+        return (
+          dataCellMeta.colIndex === this.meta.colIndex &&
+          !isEmpty(dataCellMeta.data)
+        );
+      });
+  }
+
+  private getCurrentColumnDataCellTextShapes() {
+    const dataCell = this.getCurrentColumnDataCell();
+    const shapes = dataCell?.getChildren() || [];
+    return shapes.filter((shape) => shape?.get('type') === 'text');
+  }
+
   private drawIndicatorLabels() {
-    const { x, y, width, height } = this.meta;
-    const indicatorFieldLabels = this.getIndicatorLabels();
-    const textStyle = this.spreadsheet?.theme?.colCell?.text;
+    const { y, height } = this.meta;
+    const indicatorLabelDetail = this.getIndicatorLabelDetail();
+    const dataCellStyle = this.getStyle(CellTypes.DATA_CELL);
+    const colCellStyle = this.getStyle(CellTypes.COL_CELL);
 
     // 初次渲染时, 将指标文本绘制在单元格里, 默认隐藏, 后面 hover 只需要改变 visible 即可
-    this.addShape('text', {
+    const group = this.addGroup({
       id: this.meta.id,
       visible: false,
-      attrs: {
-        ...textStyle,
-        x: x + width / 2,
-        y: y + height - CELL_TEXT_ACTIVE_MARGIN.bottom,
-        text: indicatorFieldLabels,
-        opacity: 0.45,
-      },
+      capture: false,
+    });
+
+    indicatorLabelDetail.forEach((field) => {
+      const dataCellTextX = field.x + dataCellStyle.cell.padding.left;
+      const colCellTextY = y + height - CELL_TEXT_ACTIVE_MARGIN.bottom;
+      group.addShape('text', {
+        attrs: {
+          ...colCellStyle.text,
+          x: dataCellTextX,
+          y: colCellTextY,
+          text: field.label,
+          opacity: 0.45,
+        },
+      });
     });
   }
 
-  private getIndicatorLabels() {
-    const { fieldLabels } = this.spreadsheet.options.style.cellCfg.valuesCfg;
-    const whiteSpace = ' '.repeat(INDICATOR_LABEL_MARGIN);
-    return fieldLabels?.[0]?.map((label) => label).join(whiteSpace);
+  private getIndicatorLabelDetail(): Array<{
+    label: string;
+    x: number;
+    y: number;
+  }> {
+    const { fieldLabels = [] } =
+      this.spreadsheet.options.style?.cellCfg?.valuesCfg || {};
+    if (isEmpty(fieldLabels)) {
+      return;
+    }
+
+    const dataCellTextShapes = this.getCurrentColumnDataCellTextShapes();
+    return dataCellTextShapes.map((shape, i) => {
+      return {
+        label: get(fieldLabels, [0, i]),
+        x: shape.attr('x'),
+        y: shape.attr('y'),
+      };
+    });
   }
 
   private toggleDisplayIndicatorLabel(visible: boolean) {
-    const indicatorLabelShape = this.findById(this.meta.id);
-    indicatorLabelShape?.set('visible', visible);
+    this.toggleIndicatorLabelGroup(visible);
+    this.toggleOriginalColumnTextPosition(visible);
+  }
+
+  private toggleOriginalColumnTextPosition(visible: boolean) {
     const textPosition = this.getTextPosition();
     const textY = visible
       ? textPosition.y - CELL_TEXT_ACTIVE_MARGIN.top
       : textPosition.y;
     updateShapeAttr(this.textShape, 'y', textY);
+  }
+
+  private toggleIndicatorLabelGroup(visible: boolean) {
+    const indicatorLabelGroup = this.findById(this.meta.id);
+    indicatorLabelGroup?.set('visible', visible);
   }
 
   public updateByState(name: InteractionStateName) {

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import cls from 'classnames';
 import { first, get, isEmpty, last } from 'lodash';
-import { isUpDataValue } from '@antv/s2';
+import { isUpDataValue, MultiData } from '@antv/s2';
 import { CustomTooltipProps } from './interface';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -15,7 +15,8 @@ export const DataTooltip: React.FC<CustomTooltipProps> = ({
   const meta = cell.getMeta();
   const currentRow = last(defaultTooltipShowOptions.data?.headInfo?.rows);
   const rowName = currentRow?.value;
-  const [value, ...derivedValues] = first(meta.fieldValue?.values) || [];
+  const [value, ...derivedValues] =
+    first((meta.fieldValue as MultiData)?.values) || [];
   const { placeholder, style } = meta.spreadsheet.options;
   const valuesCfg = style.cellCfg?.valuesCfg;
   const originalValue = get(meta.fieldValue, valuesCfg?.originalValueField);

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -9,55 +9,53 @@ import { CustomColCell } from './custom-col-cell';
 import { CustomDataCell } from './custom-data-cell';
 import { SheetComponentsProps } from '@/components/sheets/interface';
 
-const getStrategySheetOptions = (): Partial<S2Options<React.ReactNode>> => {
-  return {
-    dataCell: (viewMeta) => new CustomDataCell(viewMeta, viewMeta.spreadsheet),
-    colCell: (...args) => new CustomColCell(...args),
-    hierarchyType: 'tree',
-    showDefaultHeaderActionIcon: false,
-    style: {
-      colCfg: {
-        height: 38,
-        hideMeasureColumn: true,
-      },
+const strategySheetOptions: Partial<S2Options<React.ReactNode>> = {
+  dataCell: (viewMeta) => new CustomDataCell(viewMeta, viewMeta.spreadsheet),
+  colCell: (...args) => new CustomColCell(...args),
+  hierarchyType: 'tree',
+  showDefaultHeaderActionIcon: false,
+  style: {
+    colCfg: {
+      height: 38,
+      hideMeasureColumn: true,
     },
-    interaction: {
-      autoResetSheetStyle: true,
-      // 趋势分析表禁用 刷选, 多选, 区间多选
-      brushSelection: true,
-      multiSelection: false,
-      rangeSelection: false,
+  },
+  interaction: {
+    autoResetSheetStyle: true,
+    // 趋势分析表禁用 刷选, 多选, 区间多选
+    brushSelection: false,
+    multiSelection: false,
+    rangeSelection: false,
+  },
+  tooltip: {
+    operation: {
+      hiddenColumns: true,
     },
-    tooltip: {
-      operation: {
-        hiddenColumns: true,
-      },
-      row: {
-        content: (cell, defaultTooltipShowOptions) => (
-          <RowTooltip
-            cell={cell}
-            defaultTooltipShowOptions={defaultTooltipShowOptions}
-          />
-        ),
-      },
-      col: {
-        content: (cell, defaultTooltipShowOptions) => (
-          <ColTooltip
-            cell={cell}
-            defaultTooltipShowOptions={defaultTooltipShowOptions}
-          />
-        ),
-      },
-      data: {
-        content: (cell, defaultTooltipShowOptions) => (
-          <DataTooltip
-            cell={cell}
-            defaultTooltipShowOptions={defaultTooltipShowOptions}
-          />
-        ),
-      },
+    row: {
+      content: (cell, defaultTooltipShowOptions) => (
+        <RowTooltip
+          cell={cell}
+          defaultTooltipShowOptions={defaultTooltipShowOptions}
+        />
+      ),
     },
-  };
+    col: {
+      content: (cell, defaultTooltipShowOptions) => (
+        <ColTooltip
+          cell={cell}
+          defaultTooltipShowOptions={defaultTooltipShowOptions}
+        />
+      ),
+    },
+    data: {
+      content: (cell, defaultTooltipShowOptions) => (
+        <DataTooltip
+          cell={cell}
+          defaultTooltipShowOptions={defaultTooltipShowOptions}
+        />
+      ),
+    },
+  },
 };
 
 export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
@@ -65,17 +63,18 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
     const { options, themeCfg, ...restProps } = props;
     const s2Ref = React.useRef<SpreadSheet>();
 
-    const S2ThemeCfg = React.useMemo(() => {
+    const s2ThemeCfg = React.useMemo(() => {
       return customMerge({}, themeCfg, { theme: StrategyTheme });
     }, [themeCfg]);
+
     const s2Options = React.useMemo(() => {
-      return customMerge({}, options, getStrategySheetOptions());
+      return customMerge({}, options, strategySheetOptions);
     }, [options]);
 
     return (
       <BaseSheet
         options={s2Options}
-        themeCfg={S2ThemeCfg}
+        themeCfg={s2ThemeCfg}
         ref={s2Ref}
         {...restProps}
       />


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [ ] Code style optimization
- [x] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

### 📝 Description

列头的文字 之前的处理是直接写死的 margin, 现在改为根据 当前列对应的 data cell 的 text 的坐标来做渲染 (即: 列头标题和数值对齐)

### 🖼️ Screenshot

![Kapture 2021-12-22 at 11 48 39](https://user-images.githubusercontent.com/21015895/147041155-09b52545-eb1d-4826-b316-8b5c93f56809.gif)

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
