### PR TITLE
fix(components): 修复配置的宽度超过浏览器可视窗口宽度无法滚动的问题 close #889

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,9 @@ on: [push, pull_request]
 
 jobs:
   test:
-    # jest-electron 需要 macos 环境, 但是 免费用户 并发有限制, 容易排队
-    runs-on: macos-latest
+    # jest-electron 需要 macos 环境, 但是 免费用户 并发有限制, 容易排队 https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+    # runs-on: macos-latest # (目前 macos-latest 对应的是 10.15)
+    runs-on: macos-11
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:

--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -275,8 +275,6 @@ describe('Scroll By Group Tests', () => {
 
       canvas.dispatchEvent(wheelEvent);
 
-      expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
-
       // wait requestAnimationFrame and debounce
       await sleep(1000);
 

--- a/packages/s2-react/__tests__/spreadsheet/adaptive-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/adaptive-spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import { SpreadSheet, S2Options } from '@antv/s2';
+import type { SpreadSheet, S2Options } from '@antv/s2';
 import * as mockDataConfig from '../data/simple-data.json';
 import { getContainer, sleep } from '../util/helpers';
 import { SheetComponent } from '@/components/sheets';

--- a/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { S2Options } from '@antv/s2';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { SheetComponent } from '../../src';
+import { getContainer } from '../util/helpers';
+
+const s2Options: S2Options = {
+  width: 600,
+  height: 600,
+  hierarchyType: 'grid',
+};
+
+describe('Spread Sheet Tests', () => {
+  const hasScrollBar = (container: HTMLElement) => {
+    const s2Container = container.querySelector('.antv-s2-container');
+    return (
+      (s2Container.scrollWidth > s2Container.clientWidth ||
+        document.body.scrollWidth > window.innerWidth) &&
+      window.getComputedStyle(s2Container).overflow !== 'hidden'
+    );
+  };
+
+  describe('Mount Sheet tests', () => {
+    test('should display scroll bar if s2Options.width more than browser window width', () => {
+      const container = getContainer();
+      act(() => {
+        ReactDOM.render(
+          <SheetComponent
+            options={{
+              ...s2Options,
+              width: window.innerWidth + 100,
+            }}
+            dataCfg={mockDataConfig}
+          />,
+          container,
+        );
+      });
+
+      expect(hasScrollBar(container)).toBeTruthy();
+    });
+
+    test('should hidden scroll bar if window width more than s2Options.width', () => {
+      const container = getContainer();
+
+      act(() => {
+        ReactDOM.render(
+          <SheetComponent options={s2Options} dataCfg={mockDataConfig} />,
+          container,
+        );
+      });
+
+      expect(hasScrollBar(container)).toBeFalsy();
+    });
+  });
+});

--- a/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -23,8 +23,16 @@ describe('Spread Sheet Tests', () => {
   };
 
   describe('Mount Sheet tests', () => {
+    let container: HTMLDivElement;
+    beforeEach(() => {
+      container = getContainer();
+    });
+
+    afterEach(() => {
+      container?.remove();
+    });
+
     test('should display scroll bar if s2Options.width more than browser window width', () => {
-      const container = getContainer();
       act(() => {
         ReactDOM.render(
           <SheetComponent
@@ -42,8 +50,6 @@ describe('Spread Sheet Tests', () => {
     });
 
     test('should hidden scroll bar if window width more than s2Options.width', () => {
-      const container = getContainer();
-
       act(() => {
         ReactDOM.render(
           <SheetComponent options={s2Options} dataCfg={mockDataConfig} />,

--- a/packages/s2-react/src/components/sheets/base-sheet/index.less
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.less
@@ -2,7 +2,7 @@
 
 .@{preCls} {
   &-container {
-    overflow: hidden;
+    overflow: auto;
 
     canvas {
       display: block;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #889 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

canvas 的父容器 `container` 有 overflow: hidden, 导致没有出现滚动条, 无法滚动

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/147053661-3ae1f514-52d1-4956-9e65-f8a9865f13f7.png)| ![image](https://user-images.githubusercontent.com/21015895/147053830-e62fa6ab-6ac5-496d-af30-9cf48d080203.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
