### PR TITLE
fix: 修复未配置 label时, hover 数值单元格报错, 并且列头文字上移的问题

### DIFF
--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-col-cell.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-col-cell.ts
@@ -59,6 +59,9 @@ export class CustomColCell extends ColCell {
   private drawIndicatorLabels() {
     const { y, height } = this.meta;
     const indicatorLabelDetail = this.getIndicatorLabelDetail();
+    if (isEmpty(indicatorLabelDetail)) {
+      return;
+    }
     const dataCellStyle = this.getStyle(CellTypes.DATA_CELL);
     const colCellStyle = this.getStyle(CellTypes.COL_CELL);
 
@@ -92,7 +95,7 @@ export class CustomColCell extends ColCell {
     const { fieldLabels = [] } =
       this.spreadsheet.options.style?.cellCfg?.valuesCfg || {};
     if (isEmpty(fieldLabels)) {
-      return;
+      return [];
     }
 
     const dataCellTextShapes = this.getCurrentColumnDataCellTextShapes();
@@ -107,7 +110,6 @@ export class CustomColCell extends ColCell {
 
   private toggleDisplayIndicatorLabel(visible: boolean) {
     this.toggleIndicatorLabelGroup(visible);
-    this.toggleOriginalColumnTextPosition(visible);
   }
 
   private toggleOriginalColumnTextPosition(visible: boolean) {
@@ -120,7 +122,12 @@ export class CustomColCell extends ColCell {
 
   private toggleIndicatorLabelGroup(visible: boolean) {
     const indicatorLabelGroup = this.findById(this.meta.id);
-    indicatorLabelGroup?.set('visible', visible);
+
+    // 配置了 label, 才显示 label shape, 并且把原始列头文字上移
+    if (indicatorLabelGroup) {
+      indicatorLabelGroup?.set('visible', visible);
+      this.toggleOriginalColumnTextPosition(visible);
+    }
   }
 
   public updateByState(name: InteractionStateName) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

![image](https://user-images.githubusercontent.com/21015895/147313122-f5addd6b-1909-4702-af45-2dd21748f8c5.png)

![Kapture 2021-12-24 at 11 38 15](https://user-images.githubusercontent.com/21015895/147313308-6df1f274-27c8-4a25-821c-d36373e6bba7.gif)


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
