### PR TITLE
fix(table): 明细表数据为空时添加兜底

### DIFF
--- a/packages/s2-core/__tests__/unit/dataset/table-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/dataset/table-dataset-spec.ts
@@ -75,6 +75,25 @@ describe('Table Mode Dataset Test', () => {
     });
   });
 
+  describe('test dataset query when no data', () => {
+    test('should handle getCellData when no data', () => {
+      MockTableSheet.mockClear();
+      const emptyDataSet = new TableDataSet(new MockTableSheet());
+      emptyDataSet.setDataCfg({
+        ...dataCfg,
+        data: [],
+      });
+      expect(
+        emptyDataSet.getCellData({
+          query: {
+            col: 'sub_type',
+            rowIndex: 0,
+          },
+        }),
+      ).toEqual(undefined);
+    });
+  });
+
   describe('test for sort and filter', () => {
     it('should getCellData with filteredValues', () => {
       dataSet.setDataCfg({

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -304,6 +304,10 @@ describe('Table Mode Facet With Frozen Test', () => {
       start: 37,
       end: 49,
     });
+    expect(viewCellHeights.getIndexRange(0, 0)).toStrictEqual({
+      start: 0,
+      end: 0,
+    });
 
     expect(viewCellHeights.getTotalHeight()).toBe(960);
     expect(viewCellHeights.getTotalLength()).toBe(32);
@@ -361,5 +365,34 @@ describe('Table Mode Facet Test With Custom Row Height', () => {
     expect(viewCellHeights.getTotalLength()).toBe(32);
     expect(viewCellHeights.getCellOffsetY(0)).toBe(0);
     expect(viewCellHeights.getCellOffsetY(7)).toBe(650);
+  });
+});
+
+describe('Table Mode Facet Test With Zero Height', () => {
+  const ss: SpreadSheet = new MockSpreadSheet();
+  const dataSet: TableDataSet = new MockTableDataSet(ss);
+  ss.options = merge({}, assembleOptions(), {
+    width: 0,
+    height: 0,
+  });
+  const facet: TableFacet = new TableFacet({
+    spreadsheet: ss,
+    dataSet: dataSet,
+    ...assembleDataCfg().fields,
+    ...merge({}, assembleOptions()),
+    ...DEFAULT_STYLE,
+    columns: ['province', 'city', 'type', 'sub_type', 'price'],
+  });
+
+  test('should get correct panelBBox', () => {
+    const panelBBox = facet.panelBBox;
+    expect(panelBBox.width).toBe(0);
+    expect(panelBBox.height).toBe(0);
+  });
+
+  test('should get correct initial scroll position', () => {
+    const { scrollX, scrollY } = facet.getScrollOffset();
+    expect(scrollX).toBe(0);
+    expect(scrollY).toBe(0);
   });
 });

--- a/packages/s2-core/src/data-set/table-data-set.ts
+++ b/packages/s2-core/src/data-set/table-data-set.ts
@@ -96,6 +96,9 @@ export class TableDataSet extends BaseDataSet {
   }
 
   public getCellData({ query }: CellDataParams): DataType {
+    if (this.displayData.length === 0 && query.rowIndex === 0) {
+      return;
+    }
     return this.displayData[query.rowIndex][query.col];
   }
 

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -486,6 +486,10 @@ export abstract class BaseFacet {
     if (scrollY + panelHeight >= rendererHeight) {
       return rendererHeight - panelHeight;
     }
+    // 当数据为空时，rendererHeight 可能为 0，此时 scrollY 为负值，需要调整为 0。
+    if (scrollY < 0) {
+      return 0;
+    }
     return Math.max(0, scrollY);
   };
 

--- a/packages/s2-core/src/facet/bbox/panelBBox.ts
+++ b/packages/s2-core/src/facet/bbox/panelBBox.ts
@@ -16,8 +16,11 @@ export class PanelBBox extends BaseBBox {
     const { width: canvasWidth, height: canvasHeight } =
       this.spreadsheet.options;
 
-    let panelWidth = canvasWidth - cornerPosition.x;
-    let panelHeight = canvasHeight - cornerPosition.y - scrollBarSize;
+    let panelWidth = Math.max(0, canvasWidth - cornerPosition.x);
+    let panelHeight = Math.max(
+      0,
+      canvasHeight - cornerPosition.y - scrollBarSize,
+    );
 
     const realWidth = this.facet.getRealWidth();
     const realHeight = this.facet.getRealHeight();

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -484,8 +484,8 @@ export class TableFacet extends BaseFacet {
             ? maxHeight / defaultCellHeight - 1
             : Math.floor(maxHeight / defaultCellHeight);
         return {
-          start: yMin,
-          end: yMax,
+          start: Math.max(0, yMin),
+          end: Math.max(0, yMax),
         };
       },
     };

--- a/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -52,7 +52,13 @@ describe('Spread Sheet Tests', () => {
     test('should hidden scroll bar if window width more than s2Options.width', () => {
       act(() => {
         ReactDOM.render(
-          <SheetComponent options={s2Options} dataCfg={mockDataConfig} />,
+          <SheetComponent
+            options={{
+              ...s2Options,
+              width: window.innerWidth - 100,
+            }}
+            dataCfg={mockDataConfig}
+          />,
           container,
         );
       });

--- a/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -52,13 +52,7 @@ describe('Spread Sheet Tests', () => {
     test('should hidden scroll bar if window width more than s2Options.width', () => {
       act(() => {
         ReactDOM.render(
-          <SheetComponent
-            options={{
-              ...s2Options,
-              width: window.innerWidth - 100,
-            }}
-            dataCfg={mockDataConfig}
-          />,
+          <SheetComponent options={s2Options} dataCfg={mockDataConfig} />,
           container,
         );
       });


### PR DESCRIPTION
### 👀 PR includes

明细表数据为空时，滚动坐标、计算 index、dataset 的逻辑添加兜底。防止报错。
