### PR TITLE
fix: 自定义目录树切换优化

### DIFF
--- a/packages/s2-core/src/data-set/base-data-set.ts
+++ b/packages/s2-core/src/data-set/base-data-set.ts
@@ -18,7 +18,6 @@ import {
   SortParams,
 } from '../common/interface';
 import { ValueRange } from './../common/interface/condition';
-import { ViewMeta } from '@/common/interface';
 import { CellDataParams, DataType } from '@/data-set/interface';
 import { SpreadSheet } from '@/sheet-type';
 import {

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -1,5 +1,5 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
-import { clone, last, set } from 'lodash';
+import { clone, last } from 'lodash';
 import { SpreadSheet } from './spread-sheet';
 import { Node } from '@/facet/layout/node';
 import { DataCell } from '@/cell';
@@ -28,7 +28,6 @@ export class PivotSheet extends SpreadSheet {
     if (dataSet) {
       return dataSet(this);
     }
-
     const realDataSet =
       hierarchyType === 'customTree'
         ? new CustomTreePivotDataSet(this)
@@ -140,10 +139,10 @@ export class PivotSheet extends SpreadSheet {
         },
       },
     };
-    // post to x-report to store state
     this.emit(S2Event.LAYOUT_COLLAPSE_ROWS, {
       collapsedRows: options.style.collapsedRows,
     });
+
     this.setOptions(options);
     this.render(false);
     this.emit(S2Event.LAYOUT_AFTER_COLLAPSE_ROWS, {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -60,9 +60,6 @@ import { registerIcon, getIcon } from '@/common/icons/factory';
 import { getSafetyDataConfig, getSafetyOptions } from '@/utils/merge';
 
 export abstract class SpreadSheet extends EE {
-  // dom id
-  public dom: S2MountContainer;
-
   // theme config
   public theme: S2Theme;
 

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -138,13 +138,12 @@ export abstract class SpreadSheet extends EE {
     options: S2Options,
   ) {
     super();
-    this.dom = this.getMountContainer(dom);
     this.dataCfg = getSafetyDataConfig(dataCfg);
     this.options = getSafetyOptions(options);
     this.dataSet = this.getDataSet(this.options);
 
     this.initTooltip();
-    this.initGroups();
+    this.initGroups(dom);
     this.bindEvents();
     this.initInteraction();
     this.initTheme();
@@ -339,8 +338,11 @@ export abstract class SpreadSheet extends EE {
     this.registerIcons();
   }
 
-  public render(reloadData = true) {
+  public render(reloadData = true, reBuildDataSet = false) {
     this.emit(S2Event.LAYOUT_BEFORE_RENDER);
+    if (reBuildDataSet) {
+      this.dataSet = this.getDataSet(this.options);
+    }
     if (reloadData) {
       this.clearDrillDownData('', true);
       this.dataSet.setDataCfg(this.dataCfg);
@@ -525,14 +527,13 @@ export abstract class SpreadSheet extends EE {
    * 3. panelGroup -- main facet group belongs to
    * 4. foregroundGroup
    * @param dom
-   * @param options
    * @private
    */
-  protected initGroups() {
+  protected initGroups(dom: S2MountContainer) {
     const { width, height } = this.options;
     // base canvas group
     this.container = new Canvas({
-      container: this.dom as HTMLElement,
+      container: this.getMountContainer(dom) as HTMLElement,
       width,
       height,
       localRefresh: false,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -721,6 +721,7 @@ function MainLayout() {
             sheetType="strategy"
             dataCfg={strategyDataCfg}
             options={strategyOptions}
+            onRowCellClick={(v) => console.log(v)}
             themeCfg={{
               theme: defaultTheme as unknown as S2Theme,
               name: 'gray',

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -36,6 +36,13 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
       if (isEmpty(dataCfg)) {
         return {};
       }
+      let hideMeasureColumn = false;
+      if (
+        size(dataCfg?.fields?.values) === 1 &&
+        options.hierarchyType !== 'customTree'
+      ) {
+        hideMeasureColumn = true;
+      }
       return {
         dataCell: (viewMeta: ViewMeta) =>
           new CustomDataCell(viewMeta, viewMeta.spreadsheet),
@@ -50,7 +57,7 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
         style: {
           colCfg: {
             height: 38,
-            hideMeasureColumn: !(size(dataCfg?.fields?.values) > 1),
+            hideMeasureColumn,
           },
         },
         interaction: {
@@ -95,7 +102,7 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
     const s2DataCfg = React.useMemo(() => {
       const defaultFields = {
         fields: {
-          valueInCols: !(size(dataCfg.fields.values) > 1),
+          valueInCols: !(size(dataCfg?.fields?.values) > 1), // 多指标数值挂行头，单指标挂列头
         },
       };
       return customMerge({}, dataCfg, defaultFields);

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -71,17 +71,28 @@ export function useSpreadSheet(
   // dataCfg, options or theme changed
   React.useEffect(() => {
     let reloadData = false;
+    let reBuildDataSet = false;
     if (!Object.is(prevDataCfg, dataCfg)) {
       reloadData = true;
       s2Ref.current?.setDataCfg(dataCfg);
     }
+
     if (!Object.is(prevOptions, options)) {
+      if (
+        !Object.is(prevOptions?.hierarchyType, options?.hierarchyType) &&
+        Object.is(options?.hierarchyType, 'customTree')
+      ) {
+        // 自定义树目录需要重新构建 CustomTreePivotDataSet
+        reBuildDataSet = true;
+        reloadData = true;
+        s2Ref.current?.setDataCfg(dataCfg);
+      }
       s2Ref.current?.setOptions(options);
     }
     if (!Object.is(prevThemeCfg, themeCfg)) {
       s2Ref.current?.setThemeCfg(themeCfg);
     }
-    s2Ref.current?.render(reloadData);
+    s2Ref.current?.render(reloadData, reBuildDataSet);
   }, [dataCfg, options, prevDataCfg, prevOptions, prevThemeCfg, themeCfg]);
 
   useResize({


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

* 当 `hierarchyType` 切换为 `customTree`， 需要重新构建 CustomTreePivotDataSet 和训练数据
* 移除 `SpreadSheet` 的 `dom` 属性
