### PR TITLE
fix: 优化复制功能，解决大数据量复制导致的页面崩溃问题

### DIFF
--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@/common/constant';
 import { MultiData } from '@/common/interface';
 
-export const copyToClipboard = (str: string) => {
+export const copyToClipboardByExecCommand = (str: string) => {
   try {
     const el = document.createElement('textarea');
     el.value = str;
@@ -22,6 +22,27 @@ export const copyToClipboard = (str: string) => {
     // eslint-disable-next-line no-console
     console.error(e);
     return false;
+  }
+};
+
+export const copyToClipboardByClipboard = (str: string) => {
+  navigator.clipboard
+    .writeText(str)
+    .then(() => {
+      return true;
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      return false;
+    });
+};
+
+export const copyToClipboard = (str: string) => {
+  if (!navigator.clipboard) {
+    copyToClipboardByExecCommand(str);
+  } else {
+    copyToClipboardByClipboard(str);
   }
 };
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [x] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
当前s2中的复制功能是基于原生document.execCommand 实现的，由于它是同步操作，如果复制/粘贴大量数据，页面会出现卡顿。当前业务中，200万单元格的场景下，复制操作后页面直接崩溃。同时，document.execCommand  本身官方已经不推荐使用了，见：https://stackoverflow.com/questions/60217202/copy-text-to-clipboard-now-that-execcommandcopy-is-obsolete

改造方案采用了navigator.clipboard 的方案。Clipboard API 是下一代的剪贴板操作方法，比传统的document.execCommand()方法更强大、更合理。它的所有操作都是异步的，返回 Promise 对象，不会造成页面卡顿。而且，它可以将任意内容（比如图片）放入剪贴板。


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
