### PR TITLE
fix: 修复自定义树取值路径错误问题

### DIFF
--- a/packages/s2-core/src/common/interface/condition.ts
+++ b/packages/s2-core/src/common/interface/condition.ts
@@ -29,7 +29,7 @@ export interface Condition {
   readonly mapping: MappingFunction;
 }
 
-type IconPosition = 'left' | 'right';
+export type IconPosition = 'left' | 'right';
 
 export interface IconCondition extends Condition {
   readonly position?: IconPosition; // right by default

--- a/packages/s2-core/src/data-set/custom-tree-pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/custom-tree-pivot-data-set.ts
@@ -1,6 +1,8 @@
-import { get } from 'lodash';
+import { get, intersection } from 'lodash';
 import { PivotDataSet } from '@/data-set/pivot-data-set';
 import { CellDataParams, DataType } from '@/data-set/interface';
+import { S2DataConfig } from '@/common/interface';
+import { EXTRA_FIELD, VALUE_FIELD } from '@/common/constant';
 import { getDataPath, getQueryDimValues } from '@/utils/dataset/pivot-data-set';
 
 export class CustomTreePivotDataSet extends PivotDataSet {
@@ -21,5 +23,35 @@ export class CustomTreePivotDataSet extends PivotDataSet {
     });
     const data = get(this.indexesData, path);
     return data;
+  }
+
+  processDataCfg(dataCfg: S2DataConfig): S2DataConfig {
+    // 自定义行头有如下几个特点
+    // 1、rows配置必须是空，需要额外添加 $$extra$$ 定位数据（标记指标的id）
+    // 2、要有配置 fields.rowCustomTree(行头结构)
+    // 3、values 不需要参与计算，默认就在行头结构中
+    dataCfg.fields.rows = [EXTRA_FIELD];
+    dataCfg.fields.valueInCols = false;
+    const { values } = dataCfg.fields;
+    // 将源数据中的value值，映射为 $$extra$$,$$value$$
+    // {
+    // province: '四川',    province: '四川',
+    // city: '成都',   =>   city: '成都',
+    // price='11'           price='11'
+    //                      $$extra$$=price
+    //                      $$value$$=11
+    // 此时 province, city 均配置在columns里面
+    // }
+    dataCfg.data = dataCfg.data.map((data) => {
+      // 正常数据omit后只会唯一存在 value key
+      const keys = Object.keys(data);
+      const valueKey = get(intersection(values, keys), 0);
+      return {
+        ...data,
+        [EXTRA_FIELD]: valueKey,
+        [VALUE_FIELD]: data[valueKey],
+      };
+    });
+    return dataCfg;
   }
 }

--- a/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
@@ -40,7 +40,7 @@ export const buildRowCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
       level,
       parent: parentNode,
       field: key,
-      isTotals: false, // 自定义行头不会存在自定义行头概念
+      isTotals: false, // 自定义行头不会存在概念
       isCollapsed,
       hierarchy,
       query: valueQuery,

--- a/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
@@ -40,7 +40,7 @@ export const buildRowCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
       level,
       parent: parentNode,
       field: key,
-      isTotals: false, // 自定义行头不会存在概念
+      isTotals: false, // 自定义行头不会存在总计概念
       isCollapsed,
       hierarchy,
       query: valueQuery,

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -74,16 +74,18 @@ export class PivotFacet extends BaseFacet {
         row.isTotalMeasure ||
         col.isTotals ||
         col.isTotalMeasure;
+      const { hierarchyType } = spreadsheet.options;
       const hideMeasure =
         get(spreadsheet, 'facet.cfg.colCfg.hideMeasureColumn') ?? false;
-      // 如果hide measure query中是没有度量信息的，所以需要自动补上
+      // 如果在非自定义目录情况下hide measure query中是没有度量信息的，所以需要自动补上
       // 存在一个场景的冲突，如果是多个度量，定位数据数据是无法知道哪一列代表什么
       // 因此默认只会去 第一个度量拼接query
-      const measureInfo = hideMeasure
-        ? {
-            [EXTRA_FIELD]: dataSet.fields.values?.[0],
-          }
-        : {};
+      const measureInfo =
+        hideMeasure && hierarchyType !== 'customTree'
+          ? {
+              [EXTRA_FIELD]: dataSet.fields.values?.[0],
+            }
+          : {};
       const dataQuery = merge({}, rowQuery, colQuery, measureInfo);
       const data = dataSet.getCellData({
         query: dataQuery,


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

* 自定义目录树情况下，默认为 hideMeasure 模式，由于走了统一的补query的逻辑，导致取数异常
