### PR TITLE
fix(facet): 交叉表 compact 模式下行/列头宽度计算错误

### DIFF
--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -1,5 +1,14 @@
 import { IShape, Point, ShapeAttrs } from '@antv/g-canvas';
-import { isEmpty, isEqual, last, max } from 'lodash';
+import {
+  cond,
+  constant,
+  isEmpty,
+  isEqual,
+  last,
+  matches,
+  max,
+  stubTrue,
+} from 'lodash';
 import { TextAlign } from './../common/interface/theme';
 import { shouldAddResizeArea } from './../utils/interaction/resize';
 import { HeaderCell } from './header-cell';
@@ -305,12 +314,16 @@ export class CornerCell extends HeaderCell {
     const textCfg = this.textShapes?.[0]?.cfg.attrs;
     const { textBaseline, textAlign } = this.getTextStyle();
     const { size, margin } = this.getStyle().icon;
+
     const iconX =
       textCfg?.x +
-      (textAlign === 'center'
-        ? this.actualTextWidth / 2
-        : this.actualTextWidth) +
+      cond([
+        [matches('center'), constant(this.actualTextWidth / 2)],
+        [matches('right'), constant(0)],
+        [stubTrue, constant(this.actualTextWidth)],
+      ])(textAlign) +
       margin.left;
+
     const iconY = getVerticalPosition(
       this.getContentArea(),
       textBaseline,

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -710,7 +710,7 @@ export class PivotFacet extends BaseFacet {
     } = spreadsheet.theme.cornerCell;
     const { field, isLeaf } = node;
 
-    // rowNodeWitdh = maxLabelWidth + rowIconWidth + paddingWidth
+    // calc rowNodeWitdh
     const rowIconWidth = this.getExpectedCellIconWidth(
       CellTypes.ROW_CELL,
       !spreadsheet.isValueInCols() &&
@@ -733,7 +733,7 @@ export class PivotFacet extends BaseFacet {
       rowCellStyle.padding.left +
       rowCellStyle.padding.right;
 
-    // fieldNameNodeWidth = fieldNameWidth + cornerIconWidth + paddingWidth
+    // calc corner fieldNameNodeWidth
     const fieldName = dataSet.getFieldName(field);
     const cornerIconWidth = this.getExpectedCellIconWidth(
       CellTypes.CORNER_CELL,

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -463,7 +463,7 @@ export class PivotFacet extends BaseFacet {
       } else {
         // same level -> same width
         const levelSampleNode = sampleNodeByLevel.get(currentNode.level);
-        currentNode.width = levelSampleNode.width;
+        currentNode.width = levelSampleNode?.width;
       }
 
       layoutCoordinate(this.cfg, currentNode, null);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #969 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
主要修复点
- 计算节点预估宽度时使用了值字段的 field 而非 meta.name，场景：
  - 值在列头且为叶子节点
  - 值在行头
- 计算节点预估宽度时，未考虑默认的 actionIcon 宽
- 优化 calculateRowNodesCoordinate 宽度计算
  - grid 模式下，行头的每一列的宽度是一致的，直接取用 sampleNodeByLevel(node.width)
  - calculateRowLeafNodesWidth 移除 tree 模式的宽度调用，且按功能更名为 calculateGridRowNodesWidth


### 🖼️ Screenshot

- 值 field 设置了一个超长字符串
- 以下 gif 在 showDefaultHeaderActionIcon、valueInCols 反复切换录制

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-01-07 at 14 12 29](https://user-images.githubusercontent.com/6716092/148500388-7542d89f-0441-44ac-b23b-b3678a8f5c06.gif) |   ![CleanShot 2022-01-07 at 14 07 46](https://user-images.githubusercontent.com/6716092/148499962-70cadfeb-1b4a-4f6f-8a4d-5f6cb39815c0.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
