### PR TITLE
fix(facet): frozenRowHeader=false滚动时列头展示不全

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1059,17 +1059,18 @@ export abstract class BaseFacet {
 
   protected getColHeader(): ColHeader {
     if (!this.columnHeader) {
-      const { x, width, height } = this.panelBBox;
+      const scrollContainsRowHeader =
+        this.cfg.spreadsheet.isScrollContainsRowHeader();
+      const { x, width, height, originalWidth } = this.panelBBox;
       return new ColHeader({
-        width,
+        width: scrollContainsRowHeader ? originalWidth : width,
         cornerWidth: this.cornerBBox.width,
         height: this.cornerBBox.height,
         viewportWidth: width,
         viewportHeight: height,
         position: { x, y: 0 },
         data: this.layoutResult.colNodes,
-        scrollContainsRowHeader:
-          this.cfg.spreadsheet.isScrollContainsRowHeader(),
+        scrollContainsRowHeader,
         formatter: (field: string): Formatter =>
           this.cfg.dataSet.getFieldFormatter(field),
         sortParam: this.cfg.spreadsheet.store.get('sortParam'),

--- a/packages/s2-core/src/facet/bbox/panelBBox.ts
+++ b/packages/s2-core/src/facet/bbox/panelBBox.ts
@@ -2,9 +2,8 @@ import { BaseBBox } from './baseBBox';
 
 export class PanelBBox extends BaseBBox {
   calculateBBox() {
-    const { rowsHierarchy, colsHierarchy } = this.layoutResult;
-    this.originalWidth = Math.floor(rowsHierarchy.width);
-    this.originalHeight = Math.floor(colsHierarchy.height);
+    this.originalWidth = this.facet.getRealWidth();
+    this.originalHeight = this.facet.getRealHeight();
 
     const { cornerBBox } = this.facet;
     const cornerPosition = {
@@ -22,11 +21,10 @@ export class PanelBBox extends BaseBBox {
       canvasHeight - cornerPosition.y - scrollBarSize,
     );
 
-    const realWidth = this.facet.getRealWidth();
-    const realHeight = this.facet.getRealHeight();
-
-    panelWidth = Math.abs(Math.floor(Math.min(panelWidth, realWidth)));
-    panelHeight = Math.abs(Math.floor(Math.min(panelHeight, realHeight)));
+    panelWidth = Math.abs(Math.floor(Math.min(panelWidth, this.originalWidth)));
+    panelHeight = Math.abs(
+      Math.floor(Math.min(panelHeight, this.originalHeight)),
+    );
 
     this.x = cornerPosition.x;
     this.y = cornerPosition.y;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
BUG 触发条件
- frozenRowHeader=false
- canvas 宽度不足

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-01-07 at 16 17 03](https://user-images.githubusercontent.com/6716092/148513488-a2432bda-6aa5-4adb-8d3d-53181c6015fc.gif)   |   ![CleanShot 2022-01-07 at 16 15 18](https://user-images.githubusercontent.com/6716092/148513280-3f65c04c-9b9e-4817-9060-11271acf9f51.gif)   |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
