### PR TITLE
refactor(facet): 在锁行时使用列头内部的clip实现列头滚动

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1059,18 +1059,17 @@ export abstract class BaseFacet {
 
   protected getColHeader(): ColHeader {
     if (!this.columnHeader) {
-      const scrollContainsRowHeader =
-        this.cfg.spreadsheet.isScrollContainsRowHeader();
-      const { x, width, height, originalWidth } = this.panelBBox;
+      const { x, width, height } = this.panelBBox;
       return new ColHeader({
-        width: scrollContainsRowHeader ? originalWidth : width,
+        width,
         cornerWidth: this.cornerBBox.width,
         height: this.cornerBBox.height,
         viewportWidth: width,
         viewportHeight: height,
         position: { x, y: 0 },
         data: this.layoutResult.colNodes,
-        scrollContainsRowHeader,
+        scrollContainsRowHeader:
+          this.cfg.spreadsheet.isScrollContainsRowHeader(),
         formatter: (field: string): Formatter =>
           this.cfg.dataSet.getFieldFormatter(field),
         sortParam: this.cfg.spreadsheet.store.get('sortParam'),

--- a/packages/s2-core/src/facet/header/col.ts
+++ b/packages/s2-core/src/facet/header/col.ts
@@ -51,13 +51,14 @@ export class ColHeader extends BaseHeader<ColHeaderConfig> {
 
   protected clip() {
     const { width, height, scrollX, spreadsheet } = this.headerConfig;
-    const scrollXOffset = spreadsheet.isFrozenRowHeader() ? scrollX : 0;
+    const isFrozenRowHeader = spreadsheet.isFrozenRowHeader();
+
     this.scrollGroup.setClip({
       type: 'rect',
       attrs: {
-        x: scrollXOffset,
+        x: isFrozenRowHeader ? scrollX : 0,
         y: 0,
-        width: width + scrollXOffset,
+        width: isFrozenRowHeader ? width : width + scrollX,
         height,
       },
     });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [x] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

在解决锁行列头展示不全的问题时，原有解决方法 https://github.com/antvis/S2/pull/975 是通过扩大列头宽度达到效果。
实际更好的是使用 header/col.ts 内部 clip 计算来解决

### 🖼️ Screenshot

参考 https://github.com/antvis/S2/pull/975

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
