### PR TITLE
fix(interaction): shift区间多选在明细表序列号上失效

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -66,6 +66,7 @@ describe('RootInteraction Tests', () => {
       draw: jest.fn(),
     } as unknown as Canvas;
     mockSpreadSheetInstance.panelGroup = new Group('');
+    mockSpreadSheetInstance.isTableMode = jest.fn();
     rootInteraction = new RootInteraction(mockSpreadSheetInstance);
     rootInteraction.getPanelGroupAllDataCells = () => panelGroupAllDataCells;
     rootInteraction.getAllColHeaderCells = () => [];

--- a/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
@@ -37,6 +37,7 @@ describe('State Controller Utils Tests', () => {
       interaction: { selectedCellsSpotlight: false },
     } as S2Options;
     mockInstance.store = new Store();
+    mockInstance.isTableMode = jest.fn();
     mockInstance.interaction = new RootInteraction(mockInstance);
   });
 

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -72,6 +72,7 @@ export const createFakeSpreadSheet = () => {
   s2.hideTooltip = jest.fn();
   s2.showTooltip = jest.fn();
   s2.showTooltipWithInfo = jest.fn();
+  s2.isTableMode = jest.fn();
 
   const interaction = new RootInteraction(s2 as unknown as SpreadSheet);
   s2.interaction = interaction;

--- a/packages/s2-core/src/interaction/shift-multi-selection.ts
+++ b/packages/s2-core/src/interaction/shift-multi-selection.ts
@@ -48,6 +48,12 @@ export class ShiftMultiSelection
   }
 
   private bindColCellClick() {
+    if (this.spreadsheet.isTableMode()) {
+      // series-number click
+      this.spreadsheet.on(S2Event.ROW_CELL_CLICK, (event: Event) => {
+        this.handleColClick(event);
+      });
+    }
     this.spreadsheet.on(S2Event.COL_CELL_CLICK, (event: Event) => {
       this.handleColClick(event);
     });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

修复明细表中 序列号shift多选失效的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
