### PR TITLE
fix(facet): 数据量较少时，维持 panelBBox 宽高

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/bbox/panelBBox-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/bbox/panelBBox-spec.ts
@@ -1,0 +1,99 @@
+import { ThemeCfg } from 'src/common';
+import { BaseFacet } from 'src/facet/base-facet';
+import { PanelBBox } from 'src/facet/bbox/panelBBox';
+
+describe('PanelBBox test', () => {
+  const getMockFacet = (
+    realWidth: number,
+    realHeight: number,
+    extraOptions = {},
+  ) => {
+    return {
+      layoutResult: {
+        rowsHierarchy: {
+          height: 100,
+          width: 100,
+        },
+        colsHierarchy: {
+          height: 100,
+          width: 100,
+        },
+      },
+      cornerBBox: {
+        width: 20,
+        height: 20,
+        maxX: 20,
+        maxY: 20,
+      },
+      getRealWidth() {
+        return realWidth;
+      },
+      getRealHeight() {
+        return realHeight;
+      },
+      getSeriesNumberWidth() {
+        return 80;
+      },
+      spreadsheet: {
+        isScrollContainsRowHeader() {
+          return false;
+        },
+        theme: {
+          scrollBar: {
+            size: 5,
+          },
+        } as ThemeCfg,
+        options: {
+          width: 600,
+          height: 600,
+          ...extraOptions,
+        },
+      },
+    } as BaseFacet;
+  };
+
+  test('should return correct bbox when no scroll bar exist(small dataset)', () => {
+    const facet = getMockFacet(200, 200);
+    const bbox = new PanelBBox(facet, true);
+
+    expect(bbox.width).toBe(580);
+    expect(bbox.height).toBe(575);
+    expect(bbox.viewportWidth).toBe(200);
+    expect(bbox.viewportHeight).toBe(200);
+    expect(bbox.maxX).toBe(220);
+    expect(bbox.maxY).toBe(220);
+    expect(bbox.originalHeight).toBe(200);
+    expect(bbox.originalWidth).toBe(200);
+  });
+
+  test('should return correct bbox when scroll bar exist(large dataset)', () => {
+    const facet = getMockFacet(2000, 2000);
+    const bbox = new PanelBBox(facet, true);
+
+    expect(bbox.width).toBe(580);
+    expect(bbox.height).toBe(575);
+    expect(bbox.viewportWidth).toBe(580);
+    expect(bbox.viewportHeight).toBe(575);
+    expect(bbox.maxX).toBe(600);
+    expect(bbox.maxY).toBe(595);
+    expect(bbox.originalHeight).toBe(2000);
+    expect(bbox.originalWidth).toBe(2000);
+  });
+
+  test('should return full viewport when frozen trailing col and row', () => {
+    const facet = getMockFacet(200, 200, {
+      frozenTrailingColCount: 2,
+      frozenTrailingRowCount: 2,
+    });
+
+    const bbox = new PanelBBox(facet, true);
+    expect(bbox.width).toBe(580);
+    expect(bbox.height).toBe(575);
+    expect(bbox.viewportWidth).toBe(580);
+    expect(bbox.viewportHeight).toBe(575);
+    expect(bbox.maxX).toBe(600);
+    expect(bbox.maxY).toBe(595);
+    expect(bbox.originalHeight).toBe(200);
+    expect(bbox.originalWidth).toBe(200);
+  });
+});

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -197,7 +197,7 @@ export class ColCell extends HeaderCell {
       return;
     }
 
-    const { cornerWidth, width: headerWidth } = this.headerConfig;
+    const { cornerWidth, viewportWidth: headerWidth } = this.headerConfig;
     const { y, height } = this.meta;
     const resizeStyle = this.getResizeAreaStyle();
     const resizeArea = this.getColResizeArea();

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -342,12 +342,24 @@ export abstract class BaseFacet {
    * @protected
    */
   protected calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
+    const {
+      viewportHeight: height,
+      viewportWidth: width,
+      x,
+      y,
+    } = this.panelBBox;
+
     const indexes = calculateInViewIndexes(
       scrollX,
       scrollY,
       this.viewCellWidths,
       this.viewCellHeights,
-      this.panelBBox,
+      {
+        width,
+        height,
+        x,
+        y,
+      },
       this.getRealScrollX(this.cornerBBox.width),
     );
 
@@ -474,16 +486,22 @@ export abstract class BaseFacet {
   private getAdjustedScrollX = (scrollX: number): number => {
     const colsHierarchyWidth = this.layoutResult.colsHierarchy.width;
     const panelWidth = this.panelBBox.width;
-    if (scrollX + panelWidth >= colsHierarchyWidth) {
+    if (
+      scrollX + panelWidth >= colsHierarchyWidth &&
+      colsHierarchyWidth > panelWidth
+    ) {
       return colsHierarchyWidth - panelWidth;
     }
-    return scrollX;
+    return Math.max(0, scrollX);
   };
 
   private getAdjustedScrollY = (scrollY: number): number => {
     const rendererHeight = this.getRendererHeight();
     const panelHeight = this.panelBBox.height;
-    if (scrollY + panelHeight >= rendererHeight) {
+    if (
+      scrollY + panelHeight >= rendererHeight &&
+      rendererHeight > panelHeight
+    ) {
       return rendererHeight - panelHeight;
     }
     // 当数据为空时，rendererHeight 可能为 0，此时 scrollY 为负值，需要调整为 0。
@@ -1022,7 +1040,7 @@ export abstract class BaseFacet {
 
     this.rowHeader = this.getRowHeader();
     this.columnHeader = this.getColHeader();
-    if (seriesNumberWidth > 0) {
+    if (seriesNumberWidth > 0 && this.rowIndexHeader) {
       this.rowIndexHeader = this.getSeriesNumberHeader();
       this.foregroundGroup.add(this.rowIndexHeader);
     }
@@ -1039,13 +1057,13 @@ export abstract class BaseFacet {
 
   protected getRowHeader(): RowHeader {
     if (!this.rowHeader) {
-      const { y, width, height } = this.panelBBox;
+      const { y, viewportHeight, viewportWidth, height } = this.panelBBox;
       const seriesNumberWidth = this.getSeriesNumberWidth();
       return new RowHeader({
         width: this.cornerBBox.width,
         height,
-        viewportWidth: width,
-        viewportHeight: height,
+        viewportWidth,
+        viewportHeight,
         position: { x: 0, y },
         data: this.layoutResult.rowNodes,
         hierarchyType: this.cfg.hierarchyType,
@@ -1061,13 +1079,14 @@ export abstract class BaseFacet {
     if (!this.columnHeader) {
       const scrollContainsRowHeader =
         this.cfg.spreadsheet.isScrollContainsRowHeader();
-      const { x, width, height, originalWidth } = this.panelBBox;
+      const { x, originalWidth, viewportHeight, viewportWidth } =
+        this.panelBBox;
       return new ColHeader({
-        width: scrollContainsRowHeader ? originalWidth : width,
+        width: scrollContainsRowHeader ? originalWidth : viewportWidth,
         cornerWidth: this.cornerBBox.width,
         height: this.cornerBBox.height,
-        viewportWidth: width,
-        viewportHeight: height,
+        viewportWidth,
+        viewportHeight,
         position: { x, y: 0 },
         data: this.layoutResult.colNodes,
         scrollContainsRowHeader,
@@ -1106,7 +1125,7 @@ export abstract class BaseFacet {
 
   protected getCenterFrame(): Frame {
     if (!this.centerFrame) {
-      const { width, height } = this.panelBBox;
+      const { viewportWidth, viewportHeight } = this.panelBBox;
       const cornerWidth = this.cornerBBox.width;
       const cornerHeight = this.cornerBBox.height;
       const frame = this.cfg?.frame;
@@ -1117,8 +1136,8 @@ export abstract class BaseFacet {
         },
         width: cornerWidth,
         height: cornerHeight,
-        viewportWidth: width,
-        viewportHeight: height,
+        viewportWidth,
+        viewportHeight,
         showViewportLeftShadow: false,
         showViewportRightShadow: false,
         scrollContainsRowHeader:
@@ -1141,8 +1160,10 @@ export abstract class BaseFacet {
     const { scrollX, scrollY: sy, hRowScrollX } = this.getScrollOffset();
     let scrollY = sy + this.getPaginationScrollY();
 
-    const maxScrollY =
-      this.viewCellHeights.getTotalHeight() - this.panelBBox.height;
+    const maxScrollY = Math.max(
+      0,
+      this.viewCellHeights.getTotalHeight() - this.panelBBox.height,
+    );
 
     if (scrollY > maxScrollY) {
       scrollY = maxScrollY;

--- a/packages/s2-core/src/facet/bbox/baseBBox.ts
+++ b/packages/s2-core/src/facet/bbox/baseBBox.ts
@@ -32,6 +32,11 @@ export abstract class BaseBBox implements BBox {
 
   originalHeight = 0;
 
+  // 视口宽高，数据少时可能小于 bbox 的宽高
+  viewportHeight = 0;
+
+  viewportWidth = 0;
+
   constructor(facet: BaseFacet, autoCalculateBBoxWhenCreated = false) {
     this.facet = facet;
     this.spreadsheet = facet.spreadsheet;

--- a/packages/s2-core/src/facet/bbox/panelBBox.ts
+++ b/packages/s2-core/src/facet/bbox/panelBBox.ts
@@ -35,5 +35,16 @@ export class PanelBBox extends BaseBBox {
     this.maxY = cornerPosition.y + this.viewportHeight;
     this.minX = cornerPosition.x;
     this.minY = cornerPosition.y;
+
+    const { frozenTrailingColCount, frozenTrailingRowCount } =
+      this.spreadsheet.options;
+    if (frozenTrailingColCount > 0) {
+      this.viewportWidth = this.width;
+      this.maxX = cornerPosition.x + this.width;
+    }
+    if (frozenTrailingRowCount > 0) {
+      this.viewportHeight = this.height;
+      this.maxY = cornerPosition.y + this.height;
+    }
   }
 }

--- a/packages/s2-core/src/facet/bbox/panelBBox.ts
+++ b/packages/s2-core/src/facet/bbox/panelBBox.ts
@@ -15,23 +15,24 @@ export class PanelBBox extends BaseBBox {
     const { width: canvasWidth, height: canvasHeight } =
       this.spreadsheet.options;
 
-    let panelWidth = Math.max(0, canvasWidth - cornerPosition.x);
-    let panelHeight = Math.max(
+    const panelWidth = Math.max(0, canvasWidth - cornerPosition.x);
+    const panelHeight = Math.max(
       0,
       canvasHeight - cornerPosition.y - scrollBarSize,
-    );
-
-    panelWidth = Math.abs(Math.floor(Math.min(panelWidth, this.originalWidth)));
-    panelHeight = Math.abs(
-      Math.floor(Math.min(panelHeight, this.originalHeight)),
     );
 
     this.x = cornerPosition.x;
     this.y = cornerPosition.y;
     this.width = panelWidth;
     this.height = panelHeight;
-    this.maxX = cornerPosition.x + panelWidth;
-    this.maxY = cornerPosition.y + panelHeight;
+    this.viewportHeight = Math.abs(
+      Math.floor(Math.min(panelHeight, this.originalHeight)),
+    );
+    this.viewportWidth = Math.abs(
+      Math.floor(Math.min(panelWidth, this.originalWidth)),
+    );
+    this.maxX = cornerPosition.x + this.viewportWidth;
+    this.maxY = cornerPosition.y + this.viewportHeight;
     this.minX = cornerPosition.x;
     this.minY = cornerPosition.y;
   }

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -811,12 +811,12 @@ export class TableFacet extends BaseFacet {
 
   protected getColHeader(): ColHeader {
     if (!this.columnHeader) {
-      const { x, width, height } = this.panelBBox;
+      const { x, width, viewportHeight, viewportWidth } = this.panelBBox;
       return new TableColHeader({
         width,
         height: this.cornerBBox.height,
-        viewportWidth: width,
-        viewportHeight: height,
+        viewportWidth,
+        viewportHeight,
         cornerWidth: this.cornerBBox.width,
         position: { x, y: 0 },
         data: this.layoutResult.colNodes,


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #980 

### 📝 Description

当表格的数据不足以撑满 Canvas 的宽高时，依然有一些场景，比如行列冻结，需要把行列放到 Canvas 的边缘。因此 panelBBox 的绘制范围必须包括整个 Canvas。之前 panelBBox 在数据不足时，是按数据实际的宽高去绘制的，就导致无法实现 #980 这样的效果。

改动点：

+ panelBBox 新增 viewportHeight 和 viewportWidth，内容区域如果不撑满 Canvas 时，可用用这两个属性来获取内容区的宽高。原来的 width 和 height 固定为按 Canvas 计算的最大可用宽高。
+ Frozen SplitLine 的渲染逻辑做修改和梳理
+ 修改之前 base facet 中引用的 panelBBox viewport 宽高为 viewportHeight 和 viewportWidth
+ 修正 getAdjustedScrollX 的逻辑，防止返回负值。

本次改动对交叉表无影响。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌   ![image](https://user-images.githubusercontent.com/10339692/148877152-be63bf29-1182-46bb-a47d-d8c64b3cb312.png)| ✅  ![image](https://user-images.githubusercontent.com/10339692/148877104-d5c805cc-2ae4-4b5e-9217-4928100e31c9.png) |

### 🔗 Related issue link

close #980

