### PR TITLE
fix: 加载下钻数据引起render死循环

### DIFF
--- a/packages/s2-react/package.json
+++ b/packages/s2-react/package.json
@@ -59,6 +59,7 @@
     "react-dom": ">=16.8.0"
   },
   "dependencies": {
+    "ahooks": "^3.1.5",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",
     "react-beautiful-dnd": "^13.1.0"

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -2,6 +2,7 @@ import { Event as GEvent } from '@antv/g-canvas';
 import { isEmpty } from 'lodash';
 import React from 'react';
 import { SpreadSheet, getTooltipOptions } from '@antv/s2';
+import { useLatest } from 'ahooks';
 import { BaseSheet } from '../base-sheet';
 import { DrillDown } from '@/components/drill-down';
 import { SheetComponentsProps } from '@/components/sheets/interface';
@@ -11,6 +12,7 @@ import { handleDrillDown, handleDrillDownIcon } from '@/utils';
 export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
   (props) => {
     const { dataCfg, partDrillDown } = props;
+    const latestPropsRef = useLatest(props);
 
     const s2Ref = React.useRef<SpreadSheet>();
 
@@ -50,7 +52,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
     );
 
     const updateDrillDownOptions = React.useCallback(
-      (sheetProps: SheetComponentsProps = props) => {
+      (sheetProps: SheetComponentsProps = latestPropsRef.current) => {
         if (partDrillDown) {
           const drillDownOptions = handleDrillDownIcon(
             sheetProps,
@@ -60,7 +62,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
           s2Ref.current.setOptions(drillDownOptions);
         }
       },
-      [onDrillDownIconClick, partDrillDown, props, s2Ref],
+      [onDrillDownIconClick, partDrillDown, latestPropsRef, s2Ref],
     );
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,6 +2789,24 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+ahooks-v3-count@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ahooks-v3-count/-/ahooks-v3-count-1.0.0.tgz#ddeb392e009ad6e748905b3cbf63a9fd8262ca80"
+  integrity sha512-V7uUvAwnimu6eh/PED4mCDjE7tokeZQLKlxg9lCTMPhN+NjsSbtdacByVlR1oluXQzD3MOw55wylDmQo4+S9ZQ==
+
+ahooks@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/ahooks/-/ahooks-3.1.5.tgz#e4d7cab79ce86077ce85d0d553cead53cefd11c1"
+  integrity sha512-BQbKJ8sNrr8gJlOA4YY9zNeMqcHXLI6AGpiyzLJW2mJfjeuHIiWZsyDnbyyNCm9M/RRETlYTzgqT7brj5DBnyg==
+  dependencies:
+    ahooks-v3-count "^1.0.0"
+    dayjs "^1.9.1"
+    intersection-observer "^0.12.0"
+    js-cookie "^3.0.0"
+    lodash "^4.17.21"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.0.0"
+
 ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -4668,7 +4686,7 @@ dateformat@^3.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-dayjs@1.x:
+dayjs@1.x, dayjs@^1.9.1:
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
   integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
@@ -7004,6 +7022,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+intersection-observer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.0.tgz#6c84628f67ce8698e5f9ccf857d97718745837aa"
+  integrity sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ==
+
 into-stream@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-6.0.0.tgz#4bfc1244c0128224e18b8870e85b2de8e66c6702"
@@ -8325,6 +8348,11 @@ jest@^26.6.3:
     "@jest/core" "^26.6.3"
     import-local "^3.0.2"
     jest-cli "^26.6.3"
+
+js-cookie@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -12379,6 +12407,11 @@ scheduler@^0.20.2:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+screenfull@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
+  integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
 
 scroll-into-view-if-needed@^2.2.25:
   version "2.2.28"


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

#### 问题表现
点击下钻后，表组件 [drillFields](https://github.com/antvis/S2/blob/alpha/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx#L17) 不再为空。
此时若表组件任意 props 变化，将陷入加载死循环。

#### hooks 依赖路径
1. PivotSheet.updateDrillDownOptions [依赖了 props]( https://github.com/antvis/S2/blob/alpha/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx#L63)
2. 数据加载 effect [依赖 updateDrillDownOptions](https://github.com/antvis/S2/blob/alpha/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx#L99)
3. fetchData 函数由父组件传入，其中若有 setState 等触发 props 更新操作，则死循环

#### 修改方案
updateDrillDownOptions 仅使用了 props 作为默认参数，作为 dep 驱动 hook 执行的必要性不大。
故改用 [useLatest](https://ahooks.js.org/zh-CN/hooks/use-latest) 保存最新的 props 供下游使用

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
