### PR TITLE
fix: 下钻参数变更后未正确重置

### DIFF
--- a/packages/s2-react/__tests__/unit/utils/drill-down-spec.ts
+++ b/packages/s2-react/__tests__/unit/utils/drill-down-spec.ts
@@ -113,6 +113,9 @@ describe('Drill Down Test', () => {
       },
       mockInstance,
       iconClickCallback,
+      {
+        current: null,
+      },
     );
     expect(mergedOptions.headerActionIcons).not.toBeEmpty();
   });

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -78,7 +78,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
 
     React.useEffect(() => {
       s2Ref.current?.hideTooltip();
-      if (isEmpty(drillFields)) {
+      if (isEmpty(drillFields) || !partDrillDown?.fetchData) {
         clearDrillDownInfo(s2Ref.current.store.get('drillDownNode')?.id);
       } else {
         // TODO 下钻整体流程梳理

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -12,114 +12,112 @@ import { handleDrillDown, handleDrillDownIcon } from '@/utils';
 export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
   (props) => {
     const { dataCfg, partDrillDown } = props;
-    const latestPropsRef = useLatest(props);
+    // 记录 headerIcons 中的 下钻 icon
     const drillDownIconRef = React.useRef<HeaderActionIcon>();
+
+    // 一些 props 的 latest ref
+    const latestPropsRef = useLatest(props);
+    const drillConfigRef = useLatest(partDrillDown?.drillConfig);
+    const rowFieldsRef = useLatest(dataCfg.fields.rows);
+    const fetchDataRef = useLatest(partDrillDown?.fetchData);
+    const drillItemsNumRef = useLatest(partDrillDown?.drillItemsNum);
 
     const s2Ref = React.useRef<SpreadSheet>();
 
     const [drillFields, setDrillFields] = React.useState<string[]>([]);
 
-    const onDrillDownIconClick = React.useCallback(
-      (
-        sheetInstance: SpreadSheet,
-        cacheDrillFields?: string[],
-        disabledFields?: string[],
-        event?: GEvent,
-      ) => {
-        const content = (
-          <DrillDown
-            {...partDrillDown?.drillConfig}
-            setDrillFields={setDrillFields}
-            drillFields={cacheDrillFields}
-            disabledFields={disabledFields}
-          />
-        );
+    const onDrillDownIconClick = (
+      sheetInstance: SpreadSheet,
+      cacheDrillFields?: string[],
+      disabledFields?: string[],
+      event?: GEvent,
+    ) => {
+      const content = (
+        <DrillDown
+          {...drillConfigRef.current}
+          setDrillFields={setDrillFields}
+          drillFields={cacheDrillFields}
+          disabledFields={disabledFields}
+        />
+      );
 
-        if (event) {
-          const { showTooltip } = getTooltipOptions(sheetInstance, event);
-          if (!showTooltip) {
-            return;
-          }
-          sheetInstance.showTooltip<React.ReactNode>({
-            position: {
-              x: event.clientX,
-              y: event.clientY,
-            },
-            content,
-          });
+      if (event) {
+        const { showTooltip } = getTooltipOptions(sheetInstance, event);
+        if (!showTooltip) {
+          return;
         }
-      },
-      [partDrillDown?.drillConfig],
-    );
+        sheetInstance.showTooltip<React.ReactNode>({
+          position: {
+            x: event.clientX,
+            y: event.clientY,
+          },
+          content,
+        });
+      }
+    };
 
-    const updateDrillDownOptions = React.useCallback(
-      (sheetProps: SheetComponentsProps = latestPropsRef.current) => {
-        const drillDownOptions = handleDrillDownIcon(
-          sheetProps,
-          s2Ref.current,
-          onDrillDownIconClick,
-          drillDownIconRef,
-        );
-        s2Ref.current.setOptions(drillDownOptions);
-      },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [onDrillDownIconClick, partDrillDown, latestPropsRef, s2Ref],
-    );
+    const updateDrillDownOptions = (
+      sheetProps: SheetComponentsProps = latestPropsRef.current,
+    ) => {
+      const drillDownOptions = handleDrillDownIcon(
+        sheetProps,
+        s2Ref.current,
+        onDrillDownIconClick,
+        drillDownIconRef,
+      );
+      s2Ref.current.setOptions(drillDownOptions);
+    };
 
     /**
      * 清空下钻信息
      * @param rowId 不传表示全部清空
      */
-    const clearDrillDownInfo = React.useCallback(
-      (rowId?: string) => {
-        s2Ref.current?.clearDrillDownData(rowId);
-      },
-      [s2Ref],
-    );
+    const clearDrillDownInfo = (rowId?: string) => {
+      s2Ref.current?.clearDrillDownData(rowId);
+    };
 
+    /**
+     * 加载或清除下钻数据
+     * 仅由 drillFields 驱动
+     */
     React.useEffect(() => {
       s2Ref.current?.hideTooltip();
-      if (isEmpty(drillFields) || !partDrillDown?.fetchData) {
+      if (isEmpty(drillFields)) {
         clearDrillDownInfo(s2Ref.current.store.get('drillDownNode')?.id);
       } else {
         // TODO 下钻整体流程梳理
         // setLoading(true);
         handleDrillDown({
-          rows: dataCfg.fields.rows,
+          rows: rowFieldsRef.current,
           drillFields: drillFields,
-          fetchData: partDrillDown?.fetchData,
-          drillItemsNum: partDrillDown?.drillItemsNum,
+          fetchData: fetchDataRef.current,
+          drillItemsNum: drillItemsNumRef.current,
           spreadsheet: s2Ref.current,
         });
       }
       updateDrillDownOptions();
-    }, [
-      clearDrillDownInfo,
-      dataCfg.fields.rows,
-      drillFields,
-      partDrillDown,
-      s2Ref,
-      updateDrillDownOptions,
-    ]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [drillFields]);
 
     React.useEffect(() => {
       if (isEmpty(partDrillDown?.clearDrillDown)) {
         return;
       }
       clearDrillDownInfo(partDrillDown?.clearDrillDown?.rowId);
-    }, [clearDrillDownInfo, partDrillDown?.clearDrillDown]);
+    }, [partDrillDown?.clearDrillDown]);
 
     React.useEffect(() => {
       if (!partDrillDown?.drillItemsNum) {
         return;
       }
       clearDrillDownInfo();
-    }, [clearDrillDownInfo, partDrillDown?.drillItemsNum]);
+    }, [partDrillDown?.drillItemsNum]);
 
     React.useEffect(() => {
       updateDrillDownOptions();
       s2Ref.current.render();
-    }, [partDrillDown, s2Ref, updateDrillDownOptions]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [partDrillDown]);
 
     return <BaseSheet {...props} ref={s2Ref} />;
   },

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -85,8 +85,6 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
       if (isEmpty(drillFields)) {
         clearDrillDownInfo(s2Ref.current.store.get('drillDownNode')?.id);
       } else {
-        // TODO 下钻整体流程梳理
-        // setLoading(true);
         handleDrillDown({
           rows: rowFieldsRef.current,
           drillFields: drillFields,

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -1,7 +1,7 @@
 import { Event as GEvent } from '@antv/g-canvas';
 import { isEmpty } from 'lodash';
 import React from 'react';
-import { SpreadSheet, getTooltipOptions } from '@antv/s2';
+import { SpreadSheet, getTooltipOptions, HeaderActionIcon } from '@antv/s2';
 import { useLatest } from 'ahooks';
 import { BaseSheet } from '../base-sheet';
 import { DrillDown } from '@/components/drill-down';
@@ -13,6 +13,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
   (props) => {
     const { dataCfg, partDrillDown } = props;
     const latestPropsRef = useLatest(props);
+    const drillDownIconRef = React.useRef<HeaderActionIcon>();
 
     const s2Ref = React.useRef<SpreadSheet>();
 
@@ -53,15 +54,15 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
 
     const updateDrillDownOptions = React.useCallback(
       (sheetProps: SheetComponentsProps = latestPropsRef.current) => {
-        if (partDrillDown) {
-          const drillDownOptions = handleDrillDownIcon(
-            sheetProps,
-            s2Ref.current,
-            onDrillDownIconClick,
-          );
-          s2Ref.current.setOptions(drillDownOptions);
-        }
+        const drillDownOptions = handleDrillDownIcon(
+          sheetProps,
+          s2Ref.current,
+          onDrillDownIconClick,
+          drillDownIconRef,
+        );
+        s2Ref.current.setOptions(drillDownOptions);
       },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [onDrillDownIconClick, partDrillDown, latestPropsRef, s2Ref],
     );
 

--- a/packages/s2-react/src/utils/drill-down.ts
+++ b/packages/s2-react/src/utils/drill-down.ts
@@ -99,7 +99,12 @@ export const handleDrillDownIcon = (
   ) => void,
   drillDownIconRef: React.MutableRefObject<HeaderActionIcon>,
 ): S2Options => {
-  if (props?.partDrillDown && !drillDownIconRef.current) {
+  const nextHeaderIcons =
+    props.options.headerActionIcons?.filter(
+      (icon) => icon !== drillDownIconRef.current,
+    ) ?? [];
+
+  if (props?.partDrillDown) {
     let displayCondition = props.partDrillDown?.displayCondition;
     if (isEmpty(displayCondition)) {
       let iconLevel = spreadsheet.store.get('drillDownActionIconLevel', -1);
@@ -119,9 +124,7 @@ export const handleDrillDownIcon = (
         );
       };
     }
-    if (!props.options?.headerActionIcons) {
-      set(props.options, 'headerActionIcons', []);
-    }
+
     const drillDownActionIcon = {
       belongsCell: 'rowCell',
       iconNames: ['DrillDownIcon'],
@@ -139,17 +142,15 @@ export const handleDrillDownIcon = (
         }
       },
     };
-    props.options.headerActionIcons.push(drillDownActionIcon);
+
     drillDownIconRef.current = drillDownActionIcon;
+    nextHeaderIcons.push(drillDownActionIcon);
   } else if (!props?.partDrillDown && drillDownIconRef.current) {
-    // clear previous added icon
-    const nextHeaderIcons =
-      props.options.headerActionIcons?.filter(
-        (icon) => icon !== drillDownIconRef.current,
-      ) ?? [];
-    set(props.options, 'headerActionIcons', nextHeaderIcons);
+    // clear previous icon ref
     drillDownIconRef.current = null;
   }
+
+  set(props.options, 'headerActionIcons', nextHeaderIcons);
 
   return props.options;
 };

--- a/packages/s2-react/src/utils/drill-down.ts
+++ b/packages/s2-react/src/utils/drill-down.ts
@@ -7,7 +7,9 @@ import {
   SpreadSheet,
   Node,
   PivotDataSet,
+  HeaderActionIcon,
 } from '@antv/s2';
+import React from 'react';
 import { PartDrillDownInfo, SheetComponentsProps } from '@/components';
 import { PartDrillDownDataCache } from '@/components/sheets/interface';
 import { i18n } from '@/common/i18n';
@@ -95,8 +97,9 @@ export const handleDrillDownIcon = (
     disabledFields: string[],
     event?: Event,
   ) => void,
+  drillDownIconRef: React.MutableRefObject<HeaderActionIcon>,
 ): S2Options => {
-  if (props?.partDrillDown) {
+  if (props?.partDrillDown && !drillDownIconRef.current) {
     let displayCondition = props.partDrillDown?.displayCondition;
     if (isEmpty(displayCondition)) {
       let iconLevel = spreadsheet.store.get('drillDownActionIconLevel', -1);
@@ -136,12 +139,16 @@ export const handleDrillDownIcon = (
         }
       },
     };
-    if (
-      !JSON.stringify(props.options.headerActionIcons).includes('DrillDownIcon')
-    ) {
-      // 防止切换视图多次 push drillDownActionIcon
-      props.options.headerActionIcons.push(drillDownActionIcon);
-    }
+    props.options.headerActionIcons.push(drillDownActionIcon);
+    drillDownIconRef.current = drillDownActionIcon;
+  } else if (!props?.partDrillDown && drillDownIconRef.current) {
+    // clear previous added icon
+    const nextHeaderIcons =
+      props.options.headerActionIcons?.filter(
+        (icon) => icon !== drillDownIconRef.current,
+      ) ?? [];
+    set(props.options, 'headerActionIcons', nextHeaderIcons);
+    drillDownIconRef.current = null;
   }
 
   return props.options;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
修复下钻参数变更后交互未正确重置，主要改动点：
- `pivot-sheet/index.tsx ` 
  - 去掉 useCallback，并把作为参数的外部变量改用 useLatest，规避层层闭包带来的错误引用。
  - 精简 hooks deps，消除不相关 deps 变动带来的 effects
- `utils/drill-down.ts`
  - 添加 icon 时，避免 stringify 开销，改用 ref 记录 icon 增减

### 🖼️ Screenshot

截图中 playground 增加了一个 switch 开关的，用于切换下钻维度个数。
维度切换后，可见的问题有：
- 【杭州】左侧下钻 icon 仍然是展开态
- 点击下钻 icon 后，维度仍是选中态
- 点击下钻维度后，发现数据有重复（上一次的未清除）

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-01-18 at 17 52 56](https://user-images.githubusercontent.com/6716092/149913811-b2657718-2990-4cef-8e12-6618666dbff8.gif)      |  ![CleanShot 2022-01-18 at 17 51 30](https://user-images.githubusercontent.com/6716092/149913554-69097fc4-5878-402e-9e23-46283a4683cf.gif)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
