### PR TITLE
fix(drilldown): 修复clearDrillDown下钻清除错误及重渲逻辑

### DIFF
--- a/packages/s2-core/src/utils/dataset/pivot-data-set.ts
+++ b/packages/s2-core/src/utils/dataset/pivot-data-set.ts
@@ -5,7 +5,7 @@ import {
   PivotMeta,
   SortedDimensionValues,
 } from '@/data-set/interface';
-import { ID_SEPARATOR } from '@/common/constant';
+import { ROOT_ID, ID_SEPARATOR } from '@/common/constant';
 
 interface Param {
   rows: string[];
@@ -276,7 +276,7 @@ export function deleteMetaById(meta: PivotMeta, nodeId: string) {
   const paths = nodeId.split(ID_SEPARATOR);
   const deletePath = last(paths);
   let currentMeta = meta;
-  forEach(paths, (path) => {
+  forEach(paths, (path, idx) => {
     const pathMeta = currentMeta.get(path);
     if (pathMeta) {
       if (path === deletePath) {
@@ -285,6 +285,10 @@ export function deleteMetaById(meta: PivotMeta, nodeId: string) {
       } else {
         currentMeta = pathMeta.children;
       }
+      return true;
     }
+
+    // exit iteration early when pathMeta not exists
+    return idx === 0 && path === ROOT_ID;
   });
 }

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -11,7 +11,7 @@ import { handleDrillDown, handleDrillDownIcon } from '@/utils';
 
 export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
   (props) => {
-    const { dataCfg, partDrillDown } = props;
+    const { dataCfg, partDrillDown, options } = props;
     // 记录 headerIcons 中的 下钻 icon
     const drillDownIconRef = React.useRef<HeaderActionIcon>();
 
@@ -115,6 +115,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
       partDrillDown?.drillConfig,
       partDrillDown?.displayCondition,
       partDrillDown?.drillItemsNum,
+      options.hierarchyType,
     ]);
 
     return <BaseSheet {...props} ref={s2Ref} />;

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -104,18 +104,18 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
       clearDrillDownInfo(partDrillDown?.clearDrillDown?.rowId);
     }, [partDrillDown?.clearDrillDown]);
 
-    React.useEffect(() => {
-      if (!partDrillDown?.drillItemsNum) {
-        return;
-      }
-      clearDrillDownInfo();
-    }, [partDrillDown?.drillItemsNum]);
-
+    /**
+     * 表格重渲染 effect
+     */
     React.useEffect(() => {
       updateDrillDownOptions();
       s2Ref.current.render();
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [partDrillDown]);
+    }, [
+      partDrillDown?.drillConfig,
+      partDrillDown?.displayCondition,
+      partDrillDown?.drillItemsNum,
+    ]);
 
     return <BaseSheet {...props} ref={s2Ref} />;
   },

--- a/s2-site/docs/api/components/drill-down.zh.md
+++ b/s2-site/docs/api/components/drill-down.zh.md
@@ -17,6 +17,8 @@ order: 2
 | clearDrillDown | 清除下钻信息，当有指定的rowId 传递时清除对应rowId的下钻信息；如果参数是 空对象 {}，则清空所有的下钻信息 | `{rowId: string;}` | - | |
 | displayCondition | 配置下钻  `icon` 的展示条件， 同 HeaderActionIcon | `(meta: Node) => boolean` | - | |
 
+注意：PartDrillDown 中 `drillConfig`、`displayCondition` 字段会影响下钻模式的重渲，请注意使用 memo 或 state 控制其可变性。
+
 ### FetchCallBack
 
 ```js


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

#### 1. 修改重渲的依赖项 `pivot-sheet/index.tsx` 
因为组件 memo，外界想 re-render 必须传入新的 props.partDrillDown，而修改 `props.partDrillDown.clearDrillDown` 并不需要重渲，所以修改 deps 数组以更精细地控制重渲。

#### 2. path 不存在时 deleteMetaById 误删 meta `/dataset/pivot-data-set.ts`
当 rowPivot 中存在 `杭州 -> 西湖区 -> 男` 时，想删除 nodeId=`root[&]杭州[&]技工[&]男` 的下钻数据。
此时 path 解析为 `['root', '杭州', '技工', '男']`，原逻辑会意外跳过不存在的 meta 节点，如本例的 `技工`。


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-01-19 at 17 43 38](https://user-images.githubusercontent.com/6716092/150105332-e9ad13dc-2796-45b2-877f-f07697a71a13.gif)  |  ![CleanShot 2022-01-19 at 17 41 44](https://user-images.githubusercontent.com/6716092/150104960-7ceca985-8365-418d-bdee-151496dbad4a.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
