### PR TITLE
fix(facet): scroll speed options & pagination totals

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1177,7 +1177,7 @@ export abstract class BaseFacet {
 
     const maxScrollY = Math.max(
       0,
-      this.viewCellHeights.getTotalHeight() - this.panelBBox.height,
+      this.viewCellHeights.getTotalHeight() - this.panelBBox.viewportHeight,
     );
 
     if (scrollY > maxScrollY) {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -340,10 +340,15 @@ export abstract class BaseFacet {
    the panel viewable area must vary with the horizontal distance of the scroll
    * @param scrollX
    * @param scrollY
-   * @public
+   * @protected
    */
-  public calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
-    const { viewportHeight: height, viewportWidth: width } = this.panelBBox;
+  protected calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
+    const {
+      viewportHeight: height,
+      viewportWidth: width,
+      x,
+      y,
+    } = this.panelBBox;
 
     const indexes = calculateInViewIndexes(
       scrollX,
@@ -353,8 +358,8 @@ export abstract class BaseFacet {
       {
         width,
         height,
-        x: 0,
-        y: 0,
+        x,
+        y,
       },
       this.getRealScrollX(this.cornerBBox.width),
     );

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -340,15 +340,10 @@ export abstract class BaseFacet {
    the panel viewable area must vary with the horizontal distance of the scroll
    * @param scrollX
    * @param scrollY
-   * @protected
+   * @public
    */
-  protected calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
-    const {
-      viewportHeight: height,
-      viewportWidth: width,
-      x,
-      y,
-    } = this.panelBBox;
+  public calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
+    const { viewportHeight: height, viewportWidth: width } = this.panelBBox;
 
     const indexes = calculateInViewIndexes(
       scrollX,
@@ -358,8 +353,8 @@ export abstract class BaseFacet {
       {
         width,
         height,
-        x,
-        y,
+        x: 0,
+        y: 0,
       },
       this.getRealScrollX(this.cornerBBox.width),
     );
@@ -822,7 +817,7 @@ export abstract class BaseFacet {
   };
 
   onWheel = (event: S2WheelEvent) => {
-    const ratio = this.cfg.interaction.scrollSpeedRatio;
+    const ratio = this.spreadsheet.options.interaction.scrollSpeedRatio;
     const { deltaX, deltaY, layerX, layerY } = event;
     const [optimizedDeltaX, optimizedDeltaY] = optimizeScrollXY(
       deltaX,

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -904,7 +904,7 @@ export class TableFacet extends BaseFacet {
     this.updateRowResizeArea();
   }
 
-  protected calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
+  public calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
     const colLength = this.layoutResult.colLeafNodes.length;
     const cellRange = this.getCellRange();
 

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -904,7 +904,7 @@ export class TableFacet extends BaseFacet {
     this.updateRowResizeArea();
   }
 
-  public calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
+  protected calculateXYIndexes(scrollX: number, scrollY: number): PanelIndexes {
     const colLength = this.layoutResult.colLeafNodes.length;
     const cellRange = this.getCellRange();
 

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -262,7 +262,10 @@ export const BaseSheet: React.FC<BaseSheetProps> = memo((props) => {
     if (!ownSpreadsheet) return;
     if (isFunction(reset)) reset();
     ownSpreadsheet.render(reloadData);
-    setTotal(ownSpreadsheet.facet.viewCellHeights.getTotalLength());
+    setTotal(
+      options?.pagination?.total ??
+        ownSpreadsheet.facet.viewCellHeights.getTotalLength(),
+    );
     setLoading(false);
   };
 

--- a/packages/s2-react/src/components/sheets/table-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/table-sheet/index.tsx
@@ -157,7 +157,10 @@ export const TableSheet: React.FC<BaseSheetProps> = memo((props) => {
     if (!ownSpreadsheet) return;
     if (isFunction(reset)) reset();
     ownSpreadsheet.render(reloadData);
-    setTotal(ownSpreadsheet.facet.viewCellHeights.getTotalLength());
+    setTotal(
+      options?.pagination?.total ??
+        ownSpreadsheet.facet.viewCellHeights.getTotalLength(),
+    );
     setLoading(false);
   };
 


### PR DESCRIPTION
### 👀 PR includes

修复 https://github.com/antvis/S2/issues/1017 中 setOptions 时 scrollSpeedRatio 取值不正确的问题。
修复 https://github.com/antvis/S2/issues/1016 中 React 组件未读取 pagination.total 的问题

### 🔗 Related issue link

close https://github.com/antvis/S2/issues/1017
close https://github.com/antvis/S2/issues/1016
