### PR TITLE
fix(s2-core): 修复延迟销毁表格时没有移除canvas节点的问题 close #1011

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -717,8 +717,14 @@ describe('PivotSheet Tests', () => {
     expect(facetDestroySpy).toHaveBeenCalledTimes(1);
     // destroy hdAdapter
     expect(hdAdapterDestroySpy).toHaveBeenCalledTimes(1);
-    // clear all canvas events
+    // clear all sheet events
     expect(s2.getEvents()).toEqual({});
+    // clear all canvas events
+    expect(s2.container.getEvents()).toEqual({});
+    // clear canvas group and shapes
+    expect(s2.container.getChildren()).not.toBeDefined();
+    // destroy canvas
+    expect(s2.container.get('el')).not.toBeDefined();
   });
 
   describe('Test Layout by dataCfg fields', () => {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -355,6 +355,7 @@ export abstract class SpreadSheet extends EE {
     this.store.clear();
     this.destroyTooltip();
     this.clearCanvasEvent();
+    this.container.destroy();
   }
 
   /**


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1011

### 📝 Description

`destroy` 方法没有销毁 g 生成的 `canvas` 节点, 如果公用一个 container 会导致销毁后再创建新表格时, 页面上会出现两个表格

```ts
const pivotSheet = new PivotSheet(container, mockDataConfig, s2options);
pivotSheet.render();

pivotSheet.destroy();

const tableSheet = new TableSheet(container, mockDataConfig, s2options);
tableSheet.render();
```

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
