### PR TITLE
fix(tooltip): 修复单元格文字过长时 tooltip 显示被截断 close #1028

### DIFF
--- a/packages/s2-core/src/ui/tooltip/index.less
+++ b/packages/s2-core/src/ui/tooltip/index.less
@@ -10,6 +10,7 @@
     background: rgba(255, 255, 255, 0.96);
     border-radius: 2px;
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
+    font-size: 12px;
     font-family:
       'Roboto',
       'PingFang SC',

--- a/packages/s2-react/src/components/tooltip/components/simple-tips.tsx
+++ b/packages/s2-react/src/components/tooltip/components/simple-tips.tsx
@@ -7,9 +7,7 @@ export const SimpleTips = (props: TooltipNameTipsOptions) => {
   return (
     <>
       {name && <div className={`${TOOLTIP_PREFIX_CLS}-name`}>{name}</div>}
-      {(name || tips) && (
-        <div className={`${TOOLTIP_PREFIX_CLS}-tips`}>{tips}</div>
-      )}
+      {tips && <div className={`${TOOLTIP_PREFIX_CLS}-tips`}>{tips}</div>}
     </>
   );
 };

--- a/packages/s2-react/src/components/tooltip/components/summary.tsx
+++ b/packages/s2-react/src/components/tooltip/components/summary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { size, reduce } from 'lodash';
 import { SummaryProps, TOOLTIP_PREFIX_CLS } from '@antv/s2';
+import cls from 'classnames';
 import { i18n } from '@/common/i18n';
 
 export const TooltipSummary: React.FC<SummaryProps> = React.memo((props) => {
@@ -14,9 +15,9 @@ export const TooltipSummary: React.FC<SummaryProps> = React.memo((props) => {
     );
     return (
       <div className={`${TOOLTIP_PREFIX_CLS}-summary-item`}>
-        <span className={`${TOOLTIP_PREFIX_CLS}-bold`}>
+        <span className={`${TOOLTIP_PREFIX_CLS}-selected`}>
           {count} {i18n('项')}
-        </span>{' '}
+        </span>
         {i18n('已选择')}
       </div>
     );
@@ -38,7 +39,10 @@ export const TooltipSummary: React.FC<SummaryProps> = React.memo((props) => {
             {name}（{i18n('总和')})
           </span>
           <span
-            className={`${TOOLTIP_PREFIX_CLS}-summary-val ${TOOLTIP_PREFIX_CLS}-bold`}
+            className={cls(
+              `${TOOLTIP_PREFIX_CLS}-summary-val`,
+              `${TOOLTIP_PREFIX_CLS}-bold`,
+            )}
           >
             {value}
           </span>

--- a/packages/s2-react/src/components/tooltip/index.less
+++ b/packages/s2-react/src/components/tooltip/index.less
@@ -3,53 +3,23 @@
 @tooltip-prefix-cls: antv-s2-tooltip;
 
 .@{tooltip-prefix-cls} {
-  &.trans-2-middle {
-    transform: translateX(-90px) translateY(-160%);
-    pointer-events: none;
-  }
-
   &-tips,
   &-name {
-    padding: 12px 12px 4px 12px;
+    padding: 12px;
     line-height: 16px;
-    font-size: 12px;
-    letter-spacing: -0.2px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    -webkit-line-clamp: 2;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
     overflow-wrap: break-word;
-    text-align: left;
-    font-family: PingFangSC-Regular;
-    opacity: 0.85;
-    color: #000;
-
-    &::after {
-      position: absolute;
-      left: 50%;
-      bottom: -12px;
-      content: '';
-      transform: translateX(-3px);
-      width: 0;
-      height: 0;
-    }
+    color: rgba(0, 0, 0, 0.85);
   }
 
   &-tips {
     padding: 4px 12px;
-    opacity: 0.45;
-    color: #000;
+    color: rgba(0, 0, 0, 0.45);
   }
 
   &-infos {
     padding: 4px 12px;
     line-height: 20px;
-    font-size: 12px;
-    opacity: 0.45;
-    font-family: PingFangSC-Regular;
-    color: #000;
-    letter-spacing: -0.2px;
+    color: rgba(0, 0, 0, 0.45);
     overflow: hidden;
     text-overflow: ellipsis;
     -webkit-line-clamp: 2;
@@ -62,23 +32,32 @@
   }
 
   &-summary {
-    text-align: left;
     line-height: 20px;
-    font-size: 12px;
     color: rgba(0, 0, 0, 0.65);
     overflow: hidden;
-    padding: 12px 12px 4px;
+    padding: 12px;
 
-    .@{tooltip-prefix-cls}-summary-val {
-      float: right;
+    &-item {
+      display: flex;
+    }
+
+    &-key {
+      margin-right: 20px;
+    }
+
+    &-val {
+      flex: 1;
+      text-align: right;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
     }
   }
 
   &-interpretation {
-    font-size: 12px;
     color: rgba(0, 0, 0, 0.65);
     overflow: hidden;
-    padding: 12px 12px 4px;
+    padding: 12px;
 
     .@{tooltip-prefix-cls}-interpretation-head {
       margin-bottom: 12px;
@@ -95,17 +74,18 @@
   }
 
   &-head-info-list {
-    font-family: PingFangSC-Regular;
-    font-size: 12px;
     color: #a2a2a2;
-    letter-spacing: 0;
-    text-align: left;
     padding: 12px 12px 4px;
     line-height: 20px;
   }
 
-  &-bold {
+  &-bold,
+  &-selected {
     font-weight: bold;
+  }
+
+  &-selected {
+    margin-right: 5px;
   }
 
   &-highlight {
@@ -120,109 +100,24 @@
     padding: 2px 12px 8px;
 
     .@{tooltip-prefix-cls}-detail-item {
-      font-size: 12px;
       color: rgba(0, 0, 0, 0.65);
       overflow: hidden;
       margin: 4px 0;
+      display: flex;
+      justify-content: space-around;
+      align-items: center;
 
       &-key {
         margin-right: 20px;
       }
 
       &-val {
-        float: right;
+        flex: 1;
+        text-align: right;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
       }
-    }
-  }
-
-  &-rich-text {
-    padding: 2px 0 8px;
-    color: #666;
-    font-size: 12px;
-    line-height: 1.5;
-    font-weight: 400;
-    letter-spacing: -0.2px;
-
-    * {
-      padding: 0;
-      margin: 0;
-    }
-
-    h1 {
-      font-size: 28px;
-      font-weight: 700;
-      line-height: 36px;
-      letter-spacing: -0.2px;
-      color: #222;
-    }
-
-    h2 {
-      font-size: 24px;
-      font-weight: 700;
-      line-height: 32px;
-      letter-spacing: -0.2px;
-      color: #222;
-    }
-
-    h3 {
-      font-size: 20px;
-      font-weight: 700;
-      line-height: 28px;
-      letter-spacing: -0.2px;
-      color: #222;
-    }
-
-    h4 {
-      font-size: 16px;
-      font-weight: 700;
-      line-height: 24px;
-      letter-spacing: -0.2px;
-      color: #222;
-    }
-
-    a {
-      text-decoration: none;
-    }
-
-    a:hover,
-    a:active,
-    a:visited,
-    a:focus {
-      text-decoration: none;
-      transition: color 86400s ease-in 86400s;
-    }
-
-    ul {
-      display: block;
-      list-style-type: disc;
-      margin-block-start: 1em;
-      margin-block-end: 1em;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-      padding-inline-start: 0;
-    }
-
-    ol {
-      display: block;
-      list-style-type: decimal;
-      margin-block-start: 1em;
-      margin-block-end: 1em;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-      padding-inline-start: 0;
-    }
-
-    li {
-      margin-left: 23px;
-    }
-
-    span {
-      line-height: 1.2;
-    }
-
-    strong,
-    b {
-      font-weight: 700;
     }
   }
 }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [x] Code style optimization

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复单元格内容过长tooltip显示不全
2. 简化一些样式
3. 兼容其他可能存在的过长的场景

![image](https://user-images.githubusercontent.com/21015895/150480581-622b5ee9-3e71-4099-81d5-c512cbad64f3.png) 
![image](https://user-images.githubusercontent.com/21015895/150480613-125c5900-5653-43b5-a6bd-e5b018a69726.png) ![image](https://user-images.githubusercontent.com/21015895/150480621-d760201c-2f93-4cce-9dce-3692854f45d3.png)

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/150480644-01bcd280-4960-418f-bdff-1995928c7c0b.png) | ![image](https://user-images.githubusercontent.com/21015895/150480856-6fba6ff0-a2a7-4007-894d-32a468106e38.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
