### PR TITLE
fix(tooltip): 修复明细表列头的 tooltip 内容被错误的格式化 close #998

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
@@ -43,7 +43,6 @@ describe('Interaction Hover Tests', () => {
         getActualText: () => '...',
         getFieldValue: () => '',
       } as any);
-    hoverEvent = new HoverEvent(s2 as unknown as SpreadSheet);
     s2.options = {
       interaction: {
         hoverHighlight: true,
@@ -53,6 +52,7 @@ describe('Interaction Hover Tests', () => {
       },
     } as S2Options;
     s2.isTableMode = jest.fn(() => true);
+    hoverEvent = new HoverEvent(s2 as unknown as SpreadSheet);
   });
 
   afterEach(() => {

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -73,6 +73,7 @@ export const createFakeSpreadSheet = () => {
   s2.showTooltip = jest.fn();
   s2.showTooltipWithInfo = jest.fn();
   s2.isTableMode = jest.fn();
+  s2.isPivotMode = jest.fn();
 
   const interaction = new RootInteraction(s2 as unknown as SpreadSheet);
   s2.interaction = interaction;

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -42,6 +42,7 @@ export interface TooltipOptions {
   isTotals?: boolean;
   showSingleTips?: boolean;
   onlyMenu?: boolean;
+  enableFormat?: boolean;
 }
 
 export interface TooltipSummaryOptions {

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -113,6 +113,7 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
         enterable: true,
         hideSummary: true,
         showSingleTips,
+        enableFormat: this.spreadsheet.isPivotMode(),
       };
       const data = this.getCellInfo(meta, showSingleTips);
       this.spreadsheet.showTooltipWithInfo(event, data, options);

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -277,7 +277,10 @@ export abstract class SpreadSheet extends EE {
     const tooltipData = getTooltipData({
       spreadsheet: this,
       cellInfos: data,
-      options,
+      options: {
+        enableFormat: true,
+        ...options,
+      },
     });
 
     this.showTooltip({

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -165,6 +165,7 @@ export const getTooltipDefaultOptions = (options?: TooltipOptions) => {
   return {
     operator: { onClick: noop, menus: [] },
     enterable: true,
+    enableFormat: true,
     ...options,
   } as TooltipOptions;
 };
@@ -473,16 +474,19 @@ export const getTooltipData = (params: TooltipDataParam) => {
     });
   } else if (options.showSingleTips) {
     // 行列头hover & 明细表所有hover
-    const metaName = find(
-      spreadsheet?.dataCfg?.meta,
-      (item) => item?.field === firstCellInfo.value,
-    )?.name;
+    const getFieldName = (field: string) =>
+      find(spreadsheet.dataCfg?.meta, (item) => item?.field === field)?.name;
+
     const currentFormatter = getFieldFormatter(
       spreadsheet,
-      firstCellInfo?.valueField,
+      firstCellInfo.valueField,
     );
-    firstCellInfo.name =
-      metaName || currentFormatter(firstCellInfo.value) || '';
+    const formattedValue = currentFormatter(firstCellInfo.value);
+    const cellName = options.enableFormat
+      ? getFieldName(firstCellInfo.value) || formattedValue
+      : getFieldName(firstCellInfo.valueField);
+
+    firstCellInfo.name = cellName || '';
   } else {
     headInfo = getHeadInfo(spreadsheet, firstCellInfo, options);
     details = getDetailList(spreadsheet, firstCellInfo, options);

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -6,31 +6,7 @@ import { data, totalData, meta } from '../__tests__/data/mock-dataset.json';
 export const tableSheetDataCfg: Partial<S2DataConfig> = {
   data,
   totalData,
-  meta: [
-    {
-      field: 'number',
-      name: '数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量',
-      formatter: (v) => {
-        return `${v} 元`;
-      },
-    },
-    {
-      field: 'province',
-      name: '省份',
-    },
-    {
-      field: 'city',
-      name: '城市',
-    },
-    {
-      field: 'type',
-      name: '类别',
-    },
-    {
-      field: 'sub_type',
-      name: '子类别',
-    },
-  ],
+  meta,
   fields: {
     columns: ['province', 'city', 'type', 'sub_type', 'number'],
     valueInCols: true,
@@ -40,31 +16,7 @@ export const tableSheetDataCfg: Partial<S2DataConfig> = {
 export const pivotSheetDataCfg: S2DataConfig = {
   data,
   totalData,
-  meta: [
-    {
-      field: 'number',
-      name: '数量',
-      formatter: (v) => {
-        return `${v} 元`;
-      },
-    },
-    {
-      field: 'province',
-      name: '省份',
-    },
-    {
-      field: 'city',
-      name: '城市',
-    },
-    {
-      field: 'type',
-      name: '类别',
-    },
-    {
-      field: 'sub_type',
-      name: '子类别',
-    },
-  ],
+  meta,
   fields: {
     rows: ['province', 'city'],
     columns: ['type', 'sub_type'],

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -6,7 +6,31 @@ import { data, totalData, meta } from '../__tests__/data/mock-dataset.json';
 export const tableSheetDataCfg: Partial<S2DataConfig> = {
   data,
   totalData,
-  meta,
+  meta: [
+    {
+      field: 'number',
+      name: '数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量',
+      formatter: (v) => {
+        return `${v} 元`;
+      },
+    },
+    {
+      field: 'province',
+      name: '省份',
+    },
+    {
+      field: 'city',
+      name: '城市',
+    },
+    {
+      field: 'type',
+      name: '类别',
+    },
+    {
+      field: 'sub_type',
+      name: '子类别',
+    },
+  ],
   fields: {
     columns: ['province', 'city', 'type', 'sub_type', 'number'],
     valueInCols: true,
@@ -16,7 +40,31 @@ export const tableSheetDataCfg: Partial<S2DataConfig> = {
 export const pivotSheetDataCfg: S2DataConfig = {
   data,
   totalData,
-  meta,
+  meta: [
+    {
+      field: 'number',
+      name: '数量',
+      formatter: (v) => {
+        return `${v} 元`;
+      },
+    },
+    {
+      field: 'province',
+      name: '省份',
+    },
+    {
+      field: 'city',
+      name: '城市',
+    },
+    {
+      field: 'type',
+      name: '类别',
+    },
+    {
+      field: 'sub_type',
+      name: '子类别',
+    },
+  ],
   fields: {
     rows: ['province', 'city'],
     columns: ['type', 'sub_type'],

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -140,7 +140,6 @@ const defaultOptions: S2Options = customMerge(
 function MainLayout() {
   const [render, setRender] = React.useState(true);
   const [sheetType, setSheetType] = React.useState<SheetType>('pivot');
-  const [isPivotSheet, setIsPivotSheet] = React.useState(true);
   const [showPagination, setShowPagination] = React.useState(false);
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({ name: 'default' });
@@ -213,7 +212,6 @@ function MainLayout() {
   };
 
   const onSheetTypeChange = (checked: boolean) => {
-    setIsPivotSheet(checked);
     // 透视表
     if (checked) {
       setSheetType('pivot');
@@ -594,7 +592,7 @@ function MainLayout() {
             <Switch
               checkedChildren="透视表"
               unCheckedChildren="明细表"
-              checked={isPivotSheet}
+              checked={sheetType === 'pivot'}
               onChange={onSheetTypeChange}
             />
           </Space>


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #998 

### 📝 Description

RT.

```ts
  meta: [
    {
      field: 'number',
      name: '数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量',
      formatter: (v) => {
        return `${v} 元`;
      },
    },
  ]
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/150498023-cb0b985a-8b00-4cf0-a1ce-b2b7417a22ba.png) | ![image](https://user-images.githubusercontent.com/21015895/150498006-44ff9f6c-0ef2-44b2-b6cf-2504cbd5f4ca.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
