### PR TITLE
feat: 字段标记柱状图支持每列或行有独立的最大最小值

### DIFF
--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -21,6 +21,8 @@ import {
   ViewMeta,
   ViewMetaIndexType,
   CellBorderPosition,
+  ValueRange,
+  RangeDirection,
 } from '@/common/interface';
 import { getMaxTextWidth, getBorderPositionAndStyle } from '@/utils/cell/cell';
 import { includeCell } from '@/utils/cell/data-cell';
@@ -282,9 +284,31 @@ export class DataCell extends BaseCell<ViewMeta> {
       if (!attrs) {
         return;
       }
-      const { minValue, maxValue } = attrs.isCompare
-        ? attrs
-        : this.spreadsheet.dataSet.getValueRangeByField(this.meta.valueField);
+
+      let valueRange: ValueRange = {};
+      if (attrs.isCompare) {
+        if (
+          attrs.rangeDirection === RangeDirection.COL ||
+          attrs.rangeDirection === RangeDirection.ROW
+        ) {
+          // 计算单元格所在行或列的最大最小值
+          valueRange = this.spreadsheet.dataSet.getRowColValueRangeByCell(
+            this.meta,
+            attrs.rangeDirection,
+          );
+        } else {
+          // 自定义最大最小值
+          valueRange = { minValue: attrs.minValue, maxValue: attrs.maxValue };
+        }
+      } else {
+        // 计算 this.meta.fieldValue 所有值的最大最小值
+        valueRange = this.spreadsheet.dataSet.getValueRangeByField(
+          this.meta.valueField,
+        );
+      }
+      const minValue = valueRange?.minValue;
+      const maxValue = valueRange?.maxValue;
+
       const fieldValue = parseNumberWithPrecision(
         this.meta.fieldValue as number,
       );

--- a/packages/s2-core/src/common/interface/condition.ts
+++ b/packages/s2-core/src/common/interface/condition.ts
@@ -7,6 +7,13 @@ export interface ValueRange {
 
 export type ValueRanges = Record<string, ValueRange>;
 
+export enum RangeDirection {
+  // 计算行的最大最小值
+  COL = 'col',
+  // 计算列的最大最小值
+  ROW = 'row',
+}
+
 export interface MappingResult extends ValueRange {
   // only used in icon condition
   icon?: string;
@@ -14,6 +21,8 @@ export interface MappingResult extends ValueRange {
   fill: string;
   // only used in interval condition
   isCompare?: boolean;
+  // only used in interval condition
+  rangeDirection?: RangeDirection;
 }
 
 export type MappingFunction = (

--- a/s2-site/docs/common/conditions.zh.md
+++ b/s2-site/docs/common/conditions.zh.md
@@ -42,6 +42,7 @@ type MappingFunction = (
 
   // 仅用于柱状图字段标记，可选
   isCompare?: boolean;
+  rangeDirection?: 'col' | 'row';
   minValue?: number;
   maxValue?: number;
 } | null| undefined // 返回值为空时，表示当前字段不显示字段标记样式

--- a/s2-site/docs/manual/basic/conditions.zh.md
+++ b/s2-site/docs/manual/basic/conditions.zh.md
@@ -100,6 +100,7 @@ const s2options = {
 | isCompare |仅用于**柱状图**字段标记，当为 `true` 时，可以定制柱状图的最大最小值 |`boolean`| -      |      |
 | minValue | 仅用于**柱状图**字段标记且 `isCompare` 为 `true` 时，定制柱状图最小值  |`number` | -      |      |
 | maxValue |  仅用于**柱状图**字段标记且 `isCompare` 为 `true` 时，定制柱状图最大值 |`number` | -      |      |
+| rangeDirection | 仅用于**柱状图**字段标记且 `isCompare` 为 `true` 时，定制每列或行的柱状图有独立的最大最小值  |`'col'` &#124; `'row'`| -      |      |
 
 > 如果`mapping`函数返回值为空，则表明不渲染该单元格的字段标记
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
##### 现状
字段标记的柱状图目前是目标`field`的所有数值共用一组最大最小值。
###### 问题一
不同指标之间对比大小没有意义，希望可以针对各指标通过柱状图纵向对比大小（考虑到灵活性，也实现了横向）。
###### 问题二
实际应用中不同指标的值域可能相差甚远，导致某项指标的柱形图宽度特别小。
##### 解决
在 `MappingResult` 中新增 `rangeDirection` 配置项，作用是当 `isCompare` 为 `true` 时，自动计算单元格所在行/列的最大最小值，首次计算完成后将行/列 `id`和最值存入缓存中，因此每列/行的柱状图具有独立的最大最小值。
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|[![image.jpg](https://i.postimg.cc/4dmyBxQ9/image.jpg)](https://postimg.cc/YGBtSkVr)|[![image.jpg](https://i.postimg.cc/C57Gk1hf/image.jpg)](https://postimg.cc/hQJQqK7S)|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
