### PR TITLE
feat(tooltip): 支持自定义 tooltip 操作项

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/merge-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-spec.ts
@@ -111,6 +111,7 @@ describe('merge test', () => {
           hiddenColumns: false,
           trend: false,
           sort: false,
+          menus: [],
         },
       },
       interaction: {
@@ -160,6 +161,12 @@ describe('merge test', () => {
         showTooltip: false,
         operation: {
           sort: false,
+          menus: [
+            {
+              key: 'custom',
+              text: 'custom',
+            },
+          ],
         },
       },
     });
@@ -169,6 +176,12 @@ describe('merge test', () => {
         hiddenColumns: false,
         trend: false,
         sort: false,
+        menus: [
+          {
+            key: 'custom',
+            text: 'custom',
+          },
+        ],
       },
       showTooltip: false,
     });

--- a/packages/s2-core/__tests__/unit/utils/text-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/text-spec.ts
@@ -73,16 +73,16 @@ describe('Text Utils Tests', () => {
 
   test('should get correct text width', () => {
     const width = measureTextWidth('test', font);
-    expect(Math.floor(width)).toEqual(21);
+    expect(Math.floor(width)).toEqual(16);
   });
 
   test('should get correct text width roughly', () => {
     const width = measureTextWidth('test', font);
-    expect(Math.floor(width)).toEqual(21);
+    expect(Math.floor(width)).toEqual(16);
   });
 
   test('should get correct ellipsis text inner', () => {
-    const text = getEllipsisTextInner('test', 20, font);
+    const text = getEllipsisTextInner('test', 15, font);
     expect(text).toEqual('t...');
   });
 

--- a/packages/s2-core/src/common/constant/options.ts
+++ b/packages/s2-core/src/common/constant/options.ts
@@ -46,6 +46,7 @@ export const DEFAULT_OPTIONS: Readonly<S2Options> = {
       hiddenColumns: false,
       trend: false,
       sort: false,
+      menus: [],
     },
   },
   interaction: {

--- a/packages/s2-core/src/common/constant/tooltip.ts
+++ b/packages/s2-core/src/common/constant/tooltip.ts
@@ -1,8 +1,4 @@
-import {
-  TooltipOperation,
-  TooltipOperatorMenu,
-  TooltipPosition,
-} from '@/common/interface';
+import { TooltipOperatorMenu, TooltipPosition } from '@/common/interface';
 import { S2_PREFIX_CLS } from '@/common/constant/classnames';
 import { i18n } from '@/common/i18n';
 

--- a/packages/s2-core/src/common/constant/tooltip.ts
+++ b/packages/s2-core/src/common/constant/tooltip.ts
@@ -17,48 +17,48 @@ export const TOOLTIP_POSITION_OFFSET: TooltipPosition = {
   y: 10,
 };
 
-export const TOOLTIP_OPERATOR_MENUS: Record<
-  Capitalize<keyof TooltipOperation>,
-  TooltipOperatorMenu[]
-> = {
-  Trend: [
-    {
-      id: 'trend',
-      text: i18n('趋势'),
-      icon: 'Trend',
-    },
-  ],
-  HiddenColumns: [
-    {
-      id: 'hiddenColumns',
-      text: i18n('隐藏'),
-      icon: 'EyeOutlined',
-    },
-  ],
-  Sort: [
-    {
-      id: 'asc',
-      icon: 'groupAsc',
-      text: i18n('组内升序'),
-    },
-    {
-      id: 'desc',
-      icon: 'groupDesc',
-      text: i18n('组内降序'),
-    },
-    { id: 'none', text: i18n('不排序') },
-  ],
-  TableSort: [
-    {
-      id: 'asc',
-      icon: 'groupAsc',
-      text: i18n('升序'),
-    },
-    {
-      id: 'desc',
-      icon: 'groupDesc',
-      text: i18n('降序'),
-    },
-    { id: 'none', text: i18n('不排序') },
-  ],
+export const TOOLTIP_OPERATOR_HIDDEN_COLUMNS_MENU: TooltipOperatorMenu = {
+  key: 'hiddenColumns',
+  text: i18n('隐藏'),
+  icon: 'EyeOutlined',
 };
+
+export const TOOLTIP_OPERATOR_TREND_MENU: TooltipOperatorMenu = {
+  key: 'trend',
+  text: i18n('趋势'),
+  icon: 'Trend',
+};
+
+export const TOOLTIP_OPERATOR_SORT_MENUS: TooltipOperatorMenu[] = [
+  {
+    key: 'asc',
+    icon: 'groupAsc',
+    text: i18n('组内升序'),
+  },
+  {
+    key: 'desc',
+    icon: 'groupDesc',
+    text: i18n('组内降序'),
+  },
+  {
+    key: 'none',
+    text: i18n('不排序'),
+  },
+];
+
+export const TOOLTIP_OPERATOR_TABLE_SORT_MENUS: TooltipOperatorMenu[] = [
+  {
+    key: 'asc',
+    icon: 'groupAsc',
+    text: i18n('升序'),
+  },
+  {
+    key: 'desc',
+    icon: 'groupDesc',
+    text: i18n('降序'),
+  },
+  {
+    key: 'none',
+    text: i18n('不排序'),
+  },
+];

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -14,12 +14,8 @@ export interface TooltipOperatorMenu {
 }
 
 export interface TooltipOperatorOptions {
-  onClick?: (options: {
-    key: string[];
-    keyPath: string[];
-    [key: string]: unknown;
-  }) => void;
-  menus: TooltipOperatorMenu[];
+  onClick?: (...args: unknown[]) => void;
+  menus?: TooltipOperatorMenu[];
 }
 
 export interface TooltipPosition {
@@ -166,7 +162,7 @@ export interface Tooltip<T = TooltipContentType> extends BaseTooltipConfig<T> {
   readonly data?: BaseTooltipConfig<T>;
 }
 
-export interface TooltipOperation {
+export interface TooltipOperation extends TooltipOperatorOptions {
   // 隐藏列 (明细表有效)
   hiddenColumns?: boolean;
   // 趋势图
@@ -175,8 +171,6 @@ export interface TooltipOperation {
   sort?: boolean;
   // 明细表排序
   tableSort?: boolean;
-  // 自定义操作项
-  menus?: TooltipOperatorMenu[];
 }
 
 export interface AutoAdjustPositionOptions {

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -6,16 +6,20 @@ import type { BaseTooltip } from '@/ui/tooltip';
 export type TooltipDataItem = Record<string, any>;
 
 export interface TooltipOperatorMenu {
-  id: string;
+  key: string;
   icon?: Element | string;
   text?: string;
+  onClick?: () => void;
   children?: TooltipOperatorMenu[]; // subMenu
 }
 
 export interface TooltipOperatorOptions {
-  onClick: (...params: unknown[]) => void;
+  onClick?: (options: {
+    key: string[];
+    keyPath: string[];
+    [key: string]: unknown;
+  }) => void;
   menus: TooltipOperatorMenu[];
-  [key: string]: unknown;
 }
 
 export interface TooltipPosition {
@@ -171,6 +175,8 @@ export interface TooltipOperation {
   sort?: boolean;
   // 明细表排序
   tableSort?: boolean;
+  // 自定义操作项
+  menus?: TooltipOperatorMenu[];
 }
 
 export interface AutoAdjustPositionOptions {

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -383,7 +383,7 @@ export class PivotDataSet extends BaseDataSet {
     const { aggregation, calcFunc } =
       getAggregationAndCalcFuncByQuery(
         this.getTotalStatus(query),
-        this.spreadsheet.options.totals,
+        this.spreadsheet.options?.totals,
       ) || {};
     // 前端计算汇总值
     if (aggregation || calcFunc) {

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -4,9 +4,9 @@ import { getCellMeta } from '@/utils/interaction/select-event';
 import { DataCell } from '@/cell/data-cell';
 import {
   InteractionStateName,
-  TOOLTIP_OPERATOR_MENUS,
   InterceptType,
   S2Event,
+  TOOLTIP_OPERATOR_TREND_MENU,
 } from '@/common/constant';
 import {
   CellAppendInfo,
@@ -56,13 +56,16 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
   }
 
   private getTooltipOperator(meta: ViewMeta): TooltipOperatorOptions {
-    const operator: TooltipOperatorOptions = this.spreadsheet.options.tooltip
-      .operation.trend && {
+    const trendMenu = {
+      ...TOOLTIP_OPERATOR_TREND_MENU,
       onClick: () => {
         this.spreadsheet.emit(S2Event.DATA_CELL_TREND_ICON_CLICK, meta);
         this.spreadsheet.hideTooltip();
       },
-      menus: TOOLTIP_OPERATOR_MENUS.Trend,
+    };
+    const operator: TooltipOperatorOptions = this.spreadsheet.options.tooltip
+      .operation.trend && {
+      menus: [trendMenu],
     };
 
     return operator;

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -1,6 +1,6 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { getCellMeta } from 'src/utils/interaction/select-event';
-import { concat, difference, isEmpty, isNil } from 'lodash';
+import { compact, concat, difference, isEmpty, isNil } from 'lodash';
 import {
   hideColumns,
   hideColumnsByThunkGroup,
@@ -11,11 +11,15 @@ import {
   S2Event,
   InteractionKeyboardKey,
   InteractionStateName,
-  TOOLTIP_OPERATOR_MENUS,
   InterceptType,
   CellTypes,
+  TOOLTIP_OPERATOR_HIDDEN_COLUMNS_MENU,
 } from '@/common/constant';
-import { TooltipOperation, TooltipOperatorOptions } from '@/common/interface';
+import {
+  TooltipOperation,
+  TooltipOperatorMenu,
+  TooltipOperatorOptions,
+} from '@/common/interface';
 import { Node } from '@/facet/layout/node';
 import { mergeCellInfo, getTooltipOptions } from '@/utils/tooltip';
 
@@ -155,11 +159,16 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     const enableHiddenColumnOperator =
       isColCell && isMultiColumns && cellMeta.isLeaf && operation.hiddenColumns;
 
-    const operator = enableHiddenColumnOperator && {
-      onClick: () => {
-        this.hideSelectedColumns();
-      },
-      menus: TOOLTIP_OPERATOR_MENUS.HiddenColumns,
+    const hiddenColumnsMenu: TooltipOperatorMenu =
+      enableHiddenColumnOperator && {
+        ...TOOLTIP_OPERATOR_HIDDEN_COLUMNS_MENU,
+        onClick: () => {
+          this.hideSelectedColumns();
+        },
+      };
+
+    const operator: TooltipOperatorOptions = {
+      menus: compact([hiddenColumnsMenu, ...(operation.menus || [])]),
     };
     return operator;
   }

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -168,6 +168,7 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
       };
 
     const operator: TooltipOperatorOptions = {
+      onClick: operation.onClick,
       menus: compact([hiddenColumnsMenu, ...(operation.menus || [])]),
     };
     return operator;

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -7,7 +7,7 @@ import {
   EXTRA_FIELD,
   InterceptType,
   S2Event,
-  TOOLTIP_OPERATOR_MENUS,
+  TOOLTIP_OPERATOR_SORT_MENUS,
 } from '@/common/constant';
 import {
   S2Options,
@@ -195,9 +195,9 @@ export class PivotSheet extends SpreadSheet {
     this.interaction.addIntercepts([InterceptType.HOVER]);
     const operator: TooltipOperatorOptions = {
       onClick: ({ key }) => {
-        this.groupSortByMethod(key, meta);
+        this.groupSortByMethod(key as unknown as SortMethod, meta);
       },
-      menus: TOOLTIP_OPERATOR_MENUS.Sort,
+      menus: TOOLTIP_OPERATOR_SORT_MENUS,
     };
 
     this.showTooltipWithInfo(event, [], {

--- a/packages/s2-core/src/sheet-type/table-sheet.ts
+++ b/packages/s2-core/src/sheet-type/table-sheet.ts
@@ -11,7 +11,7 @@ import {
   KEY_GROUP_PANEL_FROZEN_TRAILING_COL,
   KEY_GROUP_PANEL_FROZEN_TRAILING_ROW,
   PANEL_GROUP_FROZEN_GROUP_Z_INDEX,
-  TOOLTIP_OPERATOR_MENUS,
+  TOOLTIP_OPERATOR_TABLE_SORT_MENUS,
 } from '@/common/constant';
 import {
   S2Options,
@@ -170,7 +170,7 @@ export class TableSheet extends SpreadSheet {
         const sortParam: SortParam = {
           ...(prevSelectedSortParams || {}),
           sortFieldId: field,
-          sortMethod: key as SortParam['sortMethod'],
+          sortMethod: key as unknown as SortParam['sortMethod'],
         };
         this.setDataCfg({
           ...this.dataCfg,
@@ -178,7 +178,7 @@ export class TableSheet extends SpreadSheet {
         });
         this.render();
       },
-      menus: TOOLTIP_OPERATOR_MENUS.TableSort,
+      menus: TOOLTIP_OPERATOR_TABLE_SORT_MENUS,
     };
 
     this.showTooltipWithInfo(event, [], {

--- a/packages/s2-react/__tests__/unit/utils/options-spec.ts
+++ b/packages/s2-react/__tests__/unit/utils/options-spec.ts
@@ -18,7 +18,7 @@ describe('Options Tests', () => {
       tooltip: {
         showTooltip: true,
         autoAdjustBoundary: 'body',
-        operation: { hiddenColumns: true, trend: false, sort: true },
+        operation: { hiddenColumns: true, trend: false, sort: true, menus: [] },
       },
       interaction: {
         linkFields: [],
@@ -68,6 +68,12 @@ describe('Options Tests', () => {
         showTooltip: false,
         operation: {
           sort: false,
+          menus: [
+            {
+              key: 'custom',
+              text: 'custom',
+            },
+          ],
         },
       },
     });
@@ -83,6 +89,12 @@ describe('Options Tests', () => {
         hiddenColumns: true,
         trend: false,
         sort: false,
+        menus: [
+          {
+            key: 'custom',
+            text: 'custom',
+          },
+        ],
       },
     });
   });

--- a/packages/s2-react/src/common/constant/options.ts
+++ b/packages/s2-react/src/common/constant/options.ts
@@ -1,5 +1,5 @@
 import { S2Options, SpreadSheet } from '@antv/s2';
-import { CustomTooltip } from '../../components/tooltip/custom-tooltip';
+import { CustomTooltip } from '@/components/tooltip/custom-tooltip';
 
 export const SHEET_COMPONENT_DEFAULT_OPTIONS: Readonly<Partial<S2Options>> = {
   tooltip: {

--- a/packages/s2-react/src/common/icons/html-icon.less
+++ b/packages/s2-react/src/common/icons/html-icon.less
@@ -1,3 +1,8 @@
 .antv-s2-html-icon {
   display: inline-block;
+
+  svg {
+    width: 12px;
+    height: 12px;
+  }
 }

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -22,7 +22,7 @@ import { SheetComponentsProps } from '@/components/sheets/interface';
 
 /* *
  * 趋势分析表特性：
- * 1. 维度为空时默人为自定义目录树结构
+ * 1. 维度为空时默认为自定义目录树结构
  * 2. 单指标时数值置于列头，且隐藏指标列头
  * 3. 多指标时数值置于行头，不隐藏指标列头
  */

--- a/packages/s2-react/src/components/tooltip/components/operator/index.tsx
+++ b/packages/s2-react/src/components/tooltip/components/operator/index.tsx
@@ -1,5 +1,5 @@
 import { Menu, Dropdown } from 'antd';
-import { isEmpty, map, size } from 'lodash';
+import { isEmpty, map } from 'lodash';
 import React from 'react';
 import {
   TOOLTIP_PREFIX_CLS,
@@ -17,26 +17,30 @@ import './index.less';
  */
 
 export const TooltipOperator = (props: TooltipOperatorOptions) => {
-  const { menus, onClick, onlyMenu } = props;
+  const { menus, onlyMenu, onClick: onMenuClick } = props;
 
-  const renderTitle = (text: string, icon: Element | string) => {
+  const renderTitle = (menu: TooltipOperatorMenu) => {
     return (
-      <span>
-        <Icon icon={icon} className={`${TOOLTIP_PREFIX_CLS}-operator-icon`} />
-        {text}
+      <span onClick={menu.onClick}>
+        <Icon
+          icon={menu.icon}
+          className={`${TOOLTIP_PREFIX_CLS}-operator-icon`}
+        />
+        {menu.text}
       </span>
     );
   };
 
   const renderMenu = (menu: TooltipOperatorMenu) => {
-    const { id, icon, text, children } = menu;
+    const { key, text, children, onClick } = menu;
 
-    if (size(children)) {
+    if (!isEmpty(children)) {
       return (
         <Menu.SubMenu
-          title={renderTitle(text, icon)}
-          key={`sub-menu-${id}`}
+          title={renderTitle(menu)}
+          key={key}
           popupClassName={`${TOOLTIP_PREFIX_CLS}-operator-submenu-popup`}
+          onTitleClick={onClick}
         >
           {map(children, (subMenu: TooltipOperatorMenu) => renderMenu(subMenu))}
         </Menu.SubMenu>
@@ -44,8 +48,8 @@ export const TooltipOperator = (props: TooltipOperatorOptions) => {
     }
 
     return (
-      <Menu.Item title={text} key={id}>
-        {renderTitle(text, icon)}
+      <Menu.Item title={text} key={key}>
+        {renderTitle(menu)}
       </Menu.Item>
     );
   };
@@ -55,7 +59,7 @@ export const TooltipOperator = (props: TooltipOperatorOptions) => {
       return (
         <Menu
           className={`${TOOLTIP_PREFIX_CLS}-operator-menus`}
-          onClick={onClick}
+          onClick={onMenuClick}
         >
           {map(menus, (subMenu: TooltipOperatorMenu) => renderMenu(subMenu))}
         </Menu>
@@ -63,12 +67,12 @@ export const TooltipOperator = (props: TooltipOperatorOptions) => {
     }
 
     return map(menus, (menu: TooltipOperatorMenu) => {
-      const { id, icon, text, children } = menu;
+      const { key, children } = menu;
       const menuRender = !isEmpty(children) ? (
         <Menu
           className={`${TOOLTIP_PREFIX_CLS}-operator-menus`}
-          onClick={onClick}
-          key={id}
+          onClick={onMenuClick}
+          key={key}
         >
           {map(children, (subMenu: TooltipOperatorMenu) => renderMenu(subMenu))}
         </Menu>
@@ -77,8 +81,8 @@ export const TooltipOperator = (props: TooltipOperatorOptions) => {
       );
 
       return (
-        <Dropdown overlay={menuRender} {...(!size(children) && { onClick })}>
-          {renderTitle(text, icon)}
+        <Dropdown key={key} overlay={menuRender}>
+          {renderTitle(menu)}
         </Dropdown>
       );
     });

--- a/packages/s2-react/src/components/tooltip/components/operator/index.tsx
+++ b/packages/s2-react/src/components/tooltip/components/operator/index.tsx
@@ -1,4 +1,4 @@
-import { Menu, Dropdown } from 'antd';
+import { Menu, Dropdown, MenuProps } from 'antd';
 import { isEmpty, map } from 'lodash';
 import React from 'react';
 import {
@@ -9,6 +9,11 @@ import {
 import { Icon } from '../icon';
 import './index.less';
 
+interface TooltipOperatorProps extends Omit<TooltipOperatorOptions, 'onClick'> {
+  onlyMenu: boolean;
+  onClick: MenuProps['onClick'];
+}
+
 /**
  * tooltip menu
  *  - UI
@@ -16,7 +21,7 @@ import './index.less';
  *    delay 300ms show
  */
 
-export const TooltipOperator = (props: TooltipOperatorOptions) => {
+export const TooltipOperator = (props: TooltipOperatorProps) => {
   const { menus, onlyMenu, onClick: onMenuClick } = props;
 
   const renderTitle = (menu: TooltipOperatorMenu) => {

--- a/packages/s2-react/src/components/tooltip/components/operator/index.tsx
+++ b/packages/s2-react/src/components/tooltip/components/operator/index.tsx
@@ -9,7 +9,7 @@ import {
 import { Icon } from '../icon';
 import './index.less';
 
-interface TooltipOperatorProps extends Omit<TooltipOperatorOptions, 'onClick'> {
+interface TooltipOperatorProps extends TooltipOperatorOptions {
   onlyMenu: boolean;
   onClick: MenuProps['onClick'];
 }

--- a/packages/s2-react/src/components/tooltip/index.tsx
+++ b/packages/s2-react/src/components/tooltip/index.tsx
@@ -2,9 +2,7 @@ import { isEmpty } from 'lodash';
 import React from 'react';
 import {
   ListItem,
-  TooltipData,
   TooltipOperatorOptions,
-  TooltipOptions,
   TooltipSummaryOptions,
   TooltipNameTipsOptions,
   TooltipHeadInfo as TooltipHeadInfoType,

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -86,8 +86,8 @@ object **可选**,_default：null_ 功能描述： tooltip 操作栏配置
 
 | 参数    | 类型                                         | 必选  | 默认值 | 功能描述                                                                                   |
 | ------- | -------------------------------------------- | :---: | ------ | ------------------------------------------------------------------------------------------ |
-| menus   | [TooltipOperatorMenu](#tooltipoperatormenu)  |   ✓   |        | 操作项列表                                                                                 |
-| onClick | `({ item, key, keyPath, domEvent }) => void` |   ✓   |        | 点击事件，透传 `antd` `Menu` 组件的 [onClick](https://ant.design/components/menu-cn/#Menu) |
+| menus   | [TooltipOperatorMenu](#tooltipoperatormenu)  |     |        | 操作项列表                                                                                 |
+| onClick | `({ item, key, keyPath, domEvent }) => void` |      |        | 点击事件，透传 `antd` `Menu` 组件的 [onClick](https://ant.design/components/menu-cn/#Menu) |
 
 ##### TooltipOperatorMenu
 

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -98,5 +98,4 @@ object **必选**,_default：null_ 功能描述： tooltip 操作项列表
 | key      | `string`                                    |   ✓   |        | 唯一标识       |
 | text     | `string`                                    |       |        | 名称           |
 | icon     | `React.ReactNode`                           |       |        | 自定义图标     |
-| onClick  | `() => void`                                |       |        | 操作项点击事件 |
 | children | [TooltipOperatorMenu](#tooltipoperatormenu) |       |        | 子菜单列表     |

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -1,20 +1,20 @@
 ---
-title: 自定义Tooltip
+title: 自定义 Tooltip
 order: 5
 ---
-
 
 ## TooltipShowOptions
 
 object **必选**,_default：null_ 功能描述： tooltip 显示配置
 
-| 参数      | 类型                                | 必选  | 默认值 | 功能描述                |
-| --------- | ----------------------------------- | :---: | ------ | ----------------------- |
-| position  | [TooltipPosition](#tooltipposition) |   ✓   |        | tooltip 显示位置        |
-| data      | [TooltipData](#tooltipdata)         |       |        | tooltip 数据      |
-| cellInfos | `Record<string, any>`               |       |        | 单元格信息      |
-| options   | [TooltipOptions](#tooltipoptions)   |       |        | tooltip 部分配置        |
-| content   | `React.ReactNode`                |       |        | 自定义 tooltip 内容 |
+| 参数      | 类型                                                                        | 必选  | 默认值 | 功能描述            |
+| --------- | --------------------------------------------------------------------------- | :---: | ------ | ------------------- |
+| position  | [TooltipPosition](#tooltipposition)                                         |   ✓   |        | tooltip 显示位置    |
+| data      | [TooltipData](#tooltipdata)                                                 |       |        | tooltip 数据        |
+| cellInfos | `Record<string, any>`                                                       |       |        | 单元格信息          |
+| options   | [TooltipOptions](#tooltipoptions)                                           |       |        | tooltip 部分配置    |
+| content   | `React.ReactNode` \| `(cell, defaultTooltipShowOptions) => React.ReactNode` |       |        | 自定义 tooltip 内容 |
+| event     | `Event`                                                                     |       |        | 当前事件 Event      |
 
 ### TooltipPosition
 
@@ -84,11 +84,10 @@ object **必选**,_default：null_ 功能描述： tooltip 部分配置
 
 object **可选**,_default：null_ 功能描述： tooltip 操作栏配置
 
-| 参数          | 类型                                        | 必选  | 默认值 | 功能描述   |
-| ------------- | ------------------------------------------- | :---: | ------ | ---------- |
-| menus         | [TooltipOperatorMenu](#tooltipoperatormenu) |   ✓   |        | 操作项列表 |
-| onClick       | `() => void`                                |   ✓   |        | 点击事件   |
-| [key: string] | `boolean`                                   |       |        | 其他       |
+| 参数    | 类型                                         | 必选  | 默认值 | 功能描述                                                                                   |
+| ------- | -------------------------------------------- | :---: | ------ | ------------------------------------------------------------------------------------------ |
+| menus   | [TooltipOperatorMenu](#tooltipoperatormenu)  |   ✓   |        | 操作项列表                                                                                 |
+| onClick | `({ item, key, keyPath, domEvent }) => void` |   ✓   |        | 点击事件，透传 `antd` `Menu` 组件的 [onClick](https://ant.design/components/menu-cn/#Menu) |
 
 ##### TooltipOperatorMenu
 
@@ -96,7 +95,8 @@ object **必选**,_default：null_ 功能描述： tooltip 操作项列表
 
 | 参数     | 类型                                        | 必选  | 默认值 | 功能描述       |
 | -------- | ------------------------------------------- | :---: | ------ | -------------- |
-| id       | `string`                                    |   ✓   |        | 值             |
-| text     | `boolean`                                   |       |        | 名称           |
-| icon     | `React.ReactNode`                           |       |        | 自定义图标组件 |
+| key      | `string`                                    |   ✓   |        | 唯一标识       |
+| text     | `string`                                    |       |        | 名称           |
+| icon     | `React.ReactNode`                           |       |        | 自定义图标     |
+| onClick  | `() => void`                                |       |        | 操作项点击事件 |
 | children | [TooltipOperatorMenu](#tooltipoperatormenu) |       |        | 子菜单列表     |

--- a/s2-site/docs/common/tooltip.zh.md
+++ b/s2-site/docs/common/tooltip.zh.md
@@ -33,7 +33,7 @@ object **必选**,_default：null_ 功能描述： tooltip 操作配置项
 
 | 参数          | 说明                          | 类型      | 默认值  | 必选 |
 | ------------- | ----------------------------- | --------- | ------- | :--: |
-| hiddenColumns | 是否开启隐藏列 （明细表有效）   | `boolean` | `false`  |      |
+| hiddenColumns | 是否开启隐藏列 （叶子节点有效）   | `boolean` | `false`  |      |
 | trend         | 是否显示趋势图 icon           | `boolean` | `false` |      |
 | sort          | 是否开启组内排序              | `boolean` | `false` |      |
 | tableSort     | 是否开启明细表列头排序         | `boolean` | `false` |      |

--- a/s2-site/docs/common/tooltip.zh.md
+++ b/s2-site/docs/common/tooltip.zh.md
@@ -33,7 +33,9 @@ object **必选**,_default：null_ 功能描述： tooltip 操作配置项
 
 | 参数          | 说明                          | 类型      | 默认值  | 必选 |
 | ------------- | ----------------------------- | --------- | ------- | :--: |
-| hiddenColumns | 是否开启隐藏列 （叶子节点有效）   | `boolean` | `false`  |      |
+| hiddenColumns | 是否开启隐藏列（叶子节点有效）   | `boolean` | `false`  |      |
 | trend         | 是否显示趋势图 icon           | `boolean` | `false` |      |
 | sort          | 是否开启组内排序              | `boolean` | `false` |      |
 | tableSort     | 是否开启明细表列头排序         | `boolean` | `false` |      |
+| menus         | 自定义操作配置项         | `boolean` | `-` |      |
+| onClick       | 操作项点击回调函数         | `({ item, key, keyPath, domEvent }) => void` | `-` |      |

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -219,7 +219,7 @@ const s2Options = {
           },
         },
         {
-          key: 'custom-a',
+          key: 'custom-b',
           text: '操作 2',
           icon: 'EyeOutlined',
           onClick: () => {

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -62,7 +62,7 @@ const s2options = {
   tooltip: {
     operation: {
       trend: true, // 显示趋势图按钮
-      hiddenColumns: true, //开启隐藏列 （明细表有效）
+      hiddenColumns: true, //开启隐藏列 （叶子节点有效）
     },
   }
 };
@@ -200,6 +200,40 @@ s2.showTooltip({
 
 <img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*EwvcRZjOslMAAAAAAAAAAAAAARQnAQ" width = "600"  alt="row" />
 
+#### 自定义 Tooltip 操作项
+
+除了默认提供的操作项，还可以配置 `operation.menus` 自定义操作项，也可以监听各自的点击事件
+
+```ts
+const s2Options = {
+  tooltip: {
+    operation: {
+      trend: true,
+      menus: [
+        {
+          key: 'custom-a',
+          text: '操作 1',
+          icon: 'Trend',
+          onClick: () => {
+            console.log('操作 1 点击');
+          },
+        },
+        {
+          key: 'custom-a',
+          text: '操作 2',
+          icon: 'EyeOutlined',
+          onClick: () => {
+            console.log('操作 2 点击');
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+<playground path='react-component/tooltip/demo/custom-operation.tsx' rid='container-custom-operations' height='300'></playground>
+
 #### 自定义 Tooltip 类
 
 继承 `BaseTooltip` 基类，可重写 `显示 (show)`, `隐藏 (hide)`, `销毁 (destroy)` 等方法，结合 `this.spreadsheet` 实例，来实现满足你业务的 `tooltip`
@@ -327,10 +361,10 @@ tooltip: {
 - 显示位置 (position)
 
   ```tsx
-  instance.showTooltip = (tooltipOptions) => {
-    const { position } = tooltipOptions;
-    instance.tooltip.show({ ...tooltipOptions, position: { x: position.x + 1, y: position.y + 1 } });
-  };
+    instance.showTooltip = (tooltipOptions) => {
+      const { position } = tooltipOptions;
+      instance.tooltip.show({ ...tooltipOptions, position: { x: position.x + 1, y: position.y + 1 } });
+    };
   ```
 
 - 展示层数据 (data)
@@ -434,14 +468,17 @@ tooltip: {
     instance.showTooltip = (tooltipOptions) => {
       const { options } = tooltipOptions;
       const customOperator = {
-        onClick: () => {
-          console.log('测试');
+        onClick: ({ key }) => {
+          console.log('任意菜单项点击', key);
         },
         menus: [
           {
-            id: 'trend',
+            key: 'trend',
             icon: 'trend',
             text: '趋势',
+            onClick: () => {
+              console.log('当前菜单项点击')
+            }
           },
         ],
       };

--- a/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
+++ b/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { SheetComponent } from '@antv/s2-react';
+import '@antv/s2-react/dist/style.min.css';
+
+fetch(
+  'https://gw.alipayobjects.com/os/bmw-prod/2a5dbbc8-d0a7-4d02-b7c9-34f6ca63cff6.json',
+)
+  .then((res) => res.json())
+  .then((dataCfg) => {
+    const s2Options = {
+      width: 600,
+      height: 480,
+      tooltip: {
+        operation: {
+          menus: [
+            {
+              key: 'custom-a',
+              text: '操作1',
+              icon: 'Trend',
+              onClick: () => {
+                console.log('操作1点击');
+              },
+            },
+            {
+              key: 'custom-a',
+              text: '操作2',
+              icon: 'EyeOutlined',
+              onClick: () => {
+                console.log('操作2点击');
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    ReactDOM.render(
+      <SheetComponent
+        sheetType="pivot"
+        adaptive={false}
+        dataCfg={dataCfg}
+        options={s2Options}
+      />,
+      document.getElementById('container'),
+    );
+  });

--- a/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
+++ b/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
@@ -23,7 +23,7 @@ fetch(
               },
             },
             {
-              key: 'custom-a',
+              key: 'custom-b',
               text: '操作2',
               icon: 'EyeOutlined',
               onClick: () => {

--- a/s2-site/examples/react-component/tooltip/demo/custom-show-tooltip.tsx
+++ b/s2-site/examples/react-component/tooltip/demo/custom-show-tooltip.tsx
@@ -38,14 +38,17 @@ fetch(
               };
             });
             const customOperator = {
-              onClick: () => {
-                console.log('测试');
+              onClick: ({ key }) => {
+                console.log('任意菜单项点击', key);
               },
               menus: [
                 {
                   id: 'trend',
                   icon: 'trend',
                   text: '趋势',
+                  onClick: () => {
+                    console.log('当前菜单项点击');
+                  },
                 },
               ],
             };

--- a/s2-site/examples/react-component/tooltip/demo/meta.json
+++ b/s2-site/examples/react-component/tooltip/demo/meta.json
@@ -21,6 +21,14 @@
       "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/HRIacdrQje/4455252e-bed7-4265-8fee-90ed85a6ae11.png"
     },
     {
+      "filename": "custom-operation.tsx",
+      "title": {
+        "zh": "自定义操作项",
+        "en": "Custom Operation"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/le1o4zCn9/d5fd21d4-95bb-448e-9c10-92a1dd4495ae.png"
+    },
+    {
       "filename": "custom-content.tsx",
       "title": {
         "zh": "自定义 Tooltip 内容",


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [x] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

1. 支持自定义tooltip操作项
2. 菜单的 id 改名为 `key`, 保持和 antd 的 Menu 组件概念统一
3. tooltip 操作项配置 新增 `menus` 属性用于自定义菜单

```diff
const s2Options = {
  tooltip: {
    operation: {
      hiddenColumns: true,
+     menus: [{}]
    },
  },
};
```

3. 优化操作项点击事件处理逻辑, 之前只能在最外层监听 onClick, 根据 key 来做判断, 不是很方便

```tsx
const operation = {
  onClick({ key } ){
    if(key === '1') ...
    if(key === '2') ...
  },
  menus: [{ key: '1' }, { key: '1' }]
}
```
 
现在 `s2.showTooltip({ operation })` 和 `s2Options.tooltip.operation` 都可以对单个菜单直接监听点击事件, 更方便

```tsx
const operation = {
 onClick() {
   console.log('任意操作点击')
 },
 menus: [
  {
    key: 'custom-a',
    text: '操作1',
    icon: 'Trend',
    onClick: () => {
      console.log('操作1点击');
    },
  },
  {
    key: 'custom-b',
    text: '操作2',
    icon: 'EyeOutlined',
    onClick: () => {
      console.log('操作2点击');
    },
  },
],
}
```


4. 修复tooltip 报 react 的 key warning 错误
5. 修复 tooltip 配置未覆盖数值单元格的问题

### 🖼️ Screenshot

![image](https://user-images.githubusercontent.com/21015895/152791337-bf82e15c-a468-48c2-a208-f5a94c81fe32.png)

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
