### PR TITLE
fix(tooltip): 修复不同类型的单元格配置合并问题

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -406,7 +406,7 @@ export abstract class BaseFacet {
   };
 
   clearAllGroup = () => {
-    const children = this.panelGroup.cfg.children;
+    const children = this.panelGroup.getChildren() || [];
     for (let i = children.length - 1; i >= 0; i--) {
       const child = children[i];
       if (child instanceof Group) {

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -26,6 +26,7 @@ import * as CSS from 'csstype';
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { handleDataItem } from './cell/data-cell';
 import { isMultiDataItem } from './data-item-type-checker';
+import { customMerge } from './merge';
 import { AutoAdjustPositionOptions, ListItem } from '@/common/interface';
 import { LayoutResult } from '@/common/interface/basic';
 import {
@@ -494,7 +495,7 @@ export const getTooltipOptionsByCellType = (
   cellType: CellTypes,
 ): Tooltip => {
   const getOptionsByCell = (cellConfig: BaseTooltipConfig) => {
-    return { ...cellTooltipConfig, ...cellConfig };
+    return customMerge(cellTooltipConfig, cellConfig);
   };
 
   const { col, row, data, corner } = cellTooltipConfig;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

修复配置不同类型单元格 tooltip 配置时, 没有 merge 父级配置, 造成配置丢失的问题

由于使用的是 {...}, 当有相同 key 时, 配置会被覆盖掉而不是继承

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
