### PR TITLE
fix: 当不同父节点下存在相同子节点时高级排序出错 close #1065

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
+++ b/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
@@ -1,4 +1,4 @@
-import { sortAction } from '@/utils/sort-action';
+import { sortAction, sortByCustom } from '@/utils/sort-action';
 
 describe('Sort Action Test', () => {
   describe('Sort Action', () => {
@@ -86,6 +86,78 @@ describe('Sort Action Test', () => {
       expect(sortAction([{ a: '' }, { a: '3' }, { a: 2 }], 'ASC', 'a')).toEqual(
         [{ a: '' }, { a: 2 }, { a: '3' }],
       );
+    });
+  });
+});
+
+describe('Sort By Custom Test', () => {
+  describe('Sort By Custom', () => {
+    test('sort by custom with equal sub node', () => {
+      const params = {
+        originValues: [
+          'Monday[&]noon',
+          'Monday[&]afternoon',
+          'Monday[&]morning',
+          'Tuesday[&]afternoon',
+          'Tuesday[&]noon',
+          'Tuesday[&]morning',
+        ],
+        sortByValues: ['morning', 'noon', 'afternoon'],
+      };
+      expect(sortByCustom(params)).toEqual([
+        'Monday[&]morning',
+        'Monday[&]noon',
+        'Monday[&]afternoon',
+        'Tuesday[&]morning',
+        'Tuesday[&]noon',
+        'Tuesday[&]afternoon',
+      ]);
+    });
+    test('sort by custom with repeated sub node', () => {
+      const params = {
+        originValues: [
+          'Monday[&]noon',
+          'Monday[&]afternoon',
+          'Tuesday[&]afternoon',
+          'Tuesday[&]noon',
+          'Tuesday[&]morning',
+          'Wednesday[&]afternoon',
+          'Wednesday[&]morning',
+        ],
+        sortByValues: ['morning', 'noon', 'afternoon'],
+      };
+      expect(sortByCustom(params)).toEqual([
+        'Monday[&]noon',
+        'Monday[&]afternoon',
+        'Tuesday[&]morning',
+        'Tuesday[&]noon',
+        'Tuesday[&]afternoon',
+        'Wednesday[&]morning',
+        'Wednesday[&]afternoon',
+      ]);
+    });
+    test('sort by custom with unordered node', () => {
+      const params = {
+        originValues: [
+          'Monday[&]afternoon',
+          'Tuesday[&]afternoon',
+          'Wednesday[&]afternoon',
+          'Monday[&]noon',
+          'Tuesday[&]noon',
+          'Wednesday[&]morning',
+          'Tuesday[&]morning',
+        ],
+        sortByValues: ['morning', 'noon', 'afternoon'],
+      };
+      expect(sortByCustom(params)).toEqual([
+        'Monday[&]noon',
+        'Monday[&]afternoon',
+        'Tuesday[&]morning',
+        'Tuesday[&]noon',
+        'Tuesday[&]afternoon',
+        'Wednesday[&]morning',
+        'Wednesday[&]afternoon',
+      ]);
     });
   });
 });

--- a/packages/s2-core/src/utils/sort-action.ts
+++ b/packages/s2-core/src/utils/sort-action.ts
@@ -1,7 +1,7 @@
 import { keys, has, map, toUpper, endsWith, uniq } from 'lodash';
 import { SortMethod, SortParam } from '@/common/interface';
 import { DataType, SortActionParams } from '@/data-set/interface';
-import { EXTRA_FIELD, TOTAL_VALUE } from '@/common/constant';
+import { EXTRA_FIELD, ID_SEPARATOR, TOTAL_VALUE } from '@/common/constant';
 import { sortByItems, getListBySorted } from '@/utils/data-set-operate';
 import { getDimensionsWithParentPath } from '@/utils/dataset/pivot-data-set';
 
@@ -71,10 +71,43 @@ export const sortByFunc = (params: SortActionParams): string[] => {
 
 export const sortByCustom = (params: SortActionParams): string[] => {
   const { sortByValues, originValues } = params;
-  const sortedListWithPre = sortByValues.map(
-    (item) => originValues?.find((i) => endsWith(i, item)) || item,
+
+  // 从 originValues 中过滤出所有包含 sortByValue 的 id
+  const idWithPre = originValues.filter((originItem) =>
+    sortByValues.find((value) => endsWith(originItem, value)),
   );
-  return getListBySorted(originValues, sortedListWithPre);
+  // 将 id 拆分为父节点和目标节点
+  const idListWithPre = idWithPre.map((idStr) => {
+    const ids = idStr.split(ID_SEPARATOR);
+    if (ids.length > 1) {
+      const parentId = ids.slice(0, ids.length - 1).join(ID_SEPARATOR);
+      return [parentId, ids[ids.length - 1]];
+    }
+    return ids;
+  });
+  // 获取父节点顺序
+  const parentOrder = Array.from(new Set(idListWithPre.map((id) => id[0])));
+  // 排序
+  idListWithPre.sort((a: string[], b: string[]) => {
+    const aParent = a.slice(0, a.length - 1);
+    const bParent = b.slice(0, b.length - 1);
+    // 父节点不同时，按 parentOrder 排序
+    if (aParent.join() !== bParent.join()) {
+      const aParentIndex = parentOrder.indexOf(aParent[0]);
+      const bParentIndex = parentOrder.indexOf(bParent[0]);
+      return aParentIndex - bParentIndex;
+    }
+    // 父节点相同时，按 sortByValues 排序
+    const aIndex = sortByValues.indexOf(a[a.length - 1]);
+    const bIndex = sortByValues.indexOf(b[b.length - 1]);
+    return aIndex - bIndex;
+  });
+  // 拼接 id
+  const sortedIdWithPre = idListWithPre.map((idArr) =>
+    idArr.join(ID_SEPARATOR),
+  );
+
+  return getListBySorted(originValues, sortedIdWithPre);
 };
 
 export const sortByMethod = (params: SortActionParams): string[] => {

--- a/packages/s2-react/src/components/advanced-sort/index.tsx
+++ b/packages/s2-react/src/components/advanced-sort/index.tsx
@@ -10,6 +10,7 @@ import {
   forEach,
   filter,
   find,
+  uniq,
 } from 'lodash';
 import cx from 'classnames';
 import { SpreadSheet, SortParam, SortMethod, TOTAL_VALUE } from '@antv/s2';
@@ -105,11 +106,13 @@ export const AdvancedSort: React.FC<AdvancedSortProps> = ({
     handleCustom();
     setCurrentDimension(dimension);
     if (splitOrders) {
-      setSortBy(splitOrders);
+      setSortBy(uniq(splitOrders));
     } else {
       setSortBy(
-        find(manualDimensionList, (item) => item.field === dimension.field)
-          ?.list || [],
+        uniq(
+          find(manualDimensionList, (item) => item.field === dimension.field)
+            ?.list || [],
+        ),
       );
     }
   };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1065 

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
见 bug 描述

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| 见 bug 描述|请等待下方 gif 加载，可点击查看更流畅~|

[![uw7xj-kcgl8.gif](https://i.postimg.cc/Nfkf2qMf/uw7xj-kcgl8.gif)](https://postimg.cc/bsdj45kK)

### 🔗 Related issue link
https://github.com/antvis/S2/issues/1065

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
