### PR TITLE
feat(tooltip): tooltip 操作项支持动态显示

### DIFF
--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -10,7 +10,8 @@ export interface TooltipOperatorMenu {
   icon?: Element | string;
   text?: string;
   onClick?: () => void;
-  children?: TooltipOperatorMenu[]; // subMenu
+  visible?: boolean | ((cell: S2CellType) => boolean);
+  children?: TooltipOperatorMenu[];
 }
 
 export interface TooltipOperatorOptions {

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -1,6 +1,9 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
-import { compact, get } from 'lodash';
-import { getTooltipOptions } from '../../../utils/tooltip';
+import { get } from 'lodash';
+import {
+  getTooltipOptions,
+  getTooltipVisibleOperator,
+} from '../../../utils/tooltip';
 import { getCellMeta } from '@/utils/interaction/select-event';
 import { DataCell } from '@/cell/data-cell';
 import {
@@ -60,6 +63,7 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
     event: CanvasEvent,
     meta: ViewMeta,
   ): TooltipOperatorOptions {
+    const cell = this.spreadsheet.getCell(event.target);
     const { operation } = getTooltipOptions(this.spreadsheet, event);
     const trendMenu = operation.trend && {
       ...TOOLTIP_OPERATOR_TREND_MENU,
@@ -69,12 +73,10 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
       },
     };
 
-    const operator: TooltipOperatorOptions = {
-      onClick: operation.onClick,
-      menus: compact([trendMenu, ...(operation.menus || [])]),
-    };
-
-    return operator;
+    return getTooltipVisibleOperator(operation, {
+      defaultMenus: [trendMenu],
+      cell,
+    });
   }
 
   private showTooltip(event: CanvasEvent, meta: ViewMeta) {

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -1,6 +1,6 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { getCellMeta } from 'src/utils/interaction/select-event';
-import { compact, concat, difference, isEmpty, isNil } from 'lodash';
+import { concat, difference, isEmpty, isNil } from 'lodash';
 import {
   hideColumns,
   hideColumnsByThunkGroup,
@@ -21,7 +21,11 @@ import {
   TooltipOperatorOptions,
 } from '@/common/interface';
 import { Node } from '@/facet/layout/node';
-import { mergeCellInfo, getTooltipOptions } from '@/utils/tooltip';
+import {
+  mergeCellInfo,
+  getTooltipOptions,
+  getTooltipVisibleOperator,
+} from '@/utils/tooltip';
 
 export class RowColumnClick extends BaseEvent implements BaseEventImplement {
   private isMultiSelection = false;
@@ -167,11 +171,10 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
         },
       };
 
-    const operator: TooltipOperatorOptions = {
-      onClick: operation.onClick,
-      menus: compact([hiddenColumnsMenu, ...(operation.menus || [])]),
-    };
-    return operator;
+    return getTooltipVisibleOperator(operation, {
+      defaultMenus: [hiddenColumnsMenu],
+      cell,
+    });
   }
 
   private bindTableColExpand() {

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -138,14 +138,14 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
     const s2DataCfg = React.useMemo<S2DataConfig>(() => {
       const defaultFields = {
         fields: {
-          valueInCols: !(size(dataCfg?.fields?.values) > 1), // 多指标数值挂行头，单指标挂列头
+          valueInCols: size(dataCfg?.fields?.values) <= 1, // 多指标数值挂行头，单指标挂列头
         },
       };
-      return customMerge({}, dataCfg, defaultFields);
+      return customMerge(dataCfg, defaultFields);
     }, [dataCfg]);
 
     const s2Options = React.useMemo<S2Options>(() => {
-      return customMerge({}, options, strategySheetOptions);
+      return customMerge(options, strategySheetOptions);
     }, [options, strategySheetOptions]);
 
     return (

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -13,7 +13,7 @@ object **必选**,_default：null_ 功能描述： tooltip 显示配置
 | data      | [TooltipData](#tooltipdata)                                                 |       |        | tooltip 数据        |
 | cellInfos | `Record<string, any>`                                                       |       |        | 单元格信息          |
 | options   | [TooltipOptions](#tooltipoptions)                                           |       |        | tooltip 部分配置    |
-| content   | `React.ReactNode` \| `(cell, defaultTooltipShowOptions) => React.ReactNode` |       |        | 自定义 tooltip 内容 |
+| content   | `React.ReactNode | string` \| `(cell, defaultTooltipShowOptions) => React.ReactNode | string` |       |        | 自定义 tooltip 内容 |
 | event     | `Event`                                                                     |       |        | 当前事件 Event      |
 
 ### TooltipPosition
@@ -86,7 +86,7 @@ object **可选**,_default：null_ 功能描述： tooltip 操作栏配置
 
 | 参数    | 类型                                         | 必选  | 默认值 | 功能描述                                                                                   |
 | ------- | -------------------------------------------- | :---: | ------ | ------------------------------------------------------------------------------------------ |
-| menus   | [TooltipOperatorMenu](#tooltipoperatormenu)  |     |        | 操作项列表                                                                                 |
+| menus   | [TooltipOperatorMenu[]](#tooltipoperatormenu)  |     |        | 操作项列表  |
 | onClick | `({ item, key, keyPath, domEvent }) => void` |      |        | 点击事件，透传 `antd` `Menu` 组件的 [onClick](https://ant.design/components/menu-cn/#Menu) |
 
 ##### TooltipOperatorMenu
@@ -96,6 +96,8 @@ object **必选**,_default：null_ 功能描述： tooltip 操作项列表
 | 参数     | 类型                                        | 必选  | 默认值 | 功能描述       |
 | -------- | ------------------------------------------- | :---: | ------ | -------------- |
 | key      | `string`                                    |   ✓   |        | 唯一标识       |
-| text     | `string`                                    |       |        | 名称           |
-| icon     | `React.ReactNode`                           |       |        | 自定义图标     |
+| text     | `string`   |       |        | 名称           |
+| icon     | `React.ReactNode \| string`   |       |        | 自定义图标     |
+| visible  | `boolean \| (cell) => boolean`                           |      |   `true`      | 操作项是否显示，可传入一个函数根据当前单元格信息动态显示     |
+| onClick  | `() => void`                           |       |        | 点击事件回调     |
 | children | [TooltipOperatorMenu](#tooltipoperatormenu) |       |        | 子菜单列表     |

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -202,7 +202,7 @@ s2.showTooltip({
 
 #### 自定义 Tooltip 操作项
 
-除了默认提供的操作项，还可以配置 `operation.menus` 自定义操作项，也可以监听各自的点击事件
+除了默认提供的操作项，还可以配置 `operation.menus` 自定义操作项，支持嵌套，也可以监听各自的点击事件
 
 ```ts
 const s2Options = {
@@ -217,6 +217,14 @@ const s2Options = {
           onClick: () => {
             console.log('操作 1 点击');
           },
+          children: [{
+            key: 'custom-a-a',
+            text: '操作 1-1',
+            icon: 'Trend',
+            onClick: () => {
+              console.log('操作 1-1 点击');
+            },
+          }]
         },
         {
           key: 'custom-b',
@@ -224,6 +232,35 @@ const s2Options = {
           icon: 'EyeOutlined',
           onClick: () => {
             console.log('操作 2 点击');
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+还可以通过 `visible` 参数控制当前操作项是否显示，支持传入一个回调，可以根据当前 [单元格信息](/zh/docs/api/basic-class/base-cell) 动态显示
+
+```ts
+const s2Options = {
+  tooltip: {
+    operation: {
+      menus: [
+        {
+          key: 'custom-a',
+          text: '操作 1',
+          icon: 'Trend',
+          visible: false,
+        },
+        {
+          key: 'custom-b',
+          text: '操作 2',
+          icon: 'EyeOutlined',
+          visible: (cell) => {
+            // 叶子节点不显示
+            const meta = cell.getMeta()
+            return meta.isLeaf
           },
         },
       ],

--- a/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
+++ b/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
@@ -21,6 +21,16 @@ fetch(
               onClick: () => {
                 console.log('操作1点击');
               },
+              children: [
+                {
+                  key: 'custom-a-a',
+                  text: '操作 1-1',
+                  icon: 'Trend',
+                  onClick: () => {
+                    console.log('操作 1-1 点击');
+                  },
+                },
+              ],
             },
             {
               key: 'custom-b',
@@ -28,6 +38,28 @@ fetch(
               icon: 'EyeOutlined',
               onClick: () => {
                 console.log('操作2点击');
+              },
+            },
+            {
+              key: 'custom-c',
+              text: '操作3',
+              icon: 'EyeOutlined',
+              visible: false,
+              onClick: () => {
+                console.log('操作3点击');
+              },
+            },
+            {
+              key: 'custom-c',
+              text: '操作4',
+              icon: 'EyeOutlined',
+              visible: (cell) => {
+                // 叶子节点才显示
+                const meta = cell.getMeta();
+                return meta.isLeaf;
+              },
+              onClick: () => {
+                console.log('操作4点击');
               },
             },
           ],


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [x] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

tooltip 自定义操作项新增 `visible: boolean | (cell) => boolean` 属性, 支持嵌套, 用于根据单元格信息动态显示的场景

```ts
const s2Options = {
  tooltip: {
    operation: {
      menus: [
        {
          key: 'custom-a',
          text: '操作 1',
          icon: 'Trend',
          visible: false,
        },
        {
          key: 'custom-b',
          text: '操作 2',
          icon: 'EyeOutlined',
          visible: (cell) => {
            // 叶子节点不显示
            const meta = cell.getMeta()
            return meta.isLeaf
          },
        },
      ],
    },
  },
};
```

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
