### PR TITLE
feat(pivot): 新增组内排序时触发回调事件

### DIFF
--- a/packages/s2-core/src/common/constant/events/basic.ts
+++ b/packages/s2-core/src/common/constant/events/basic.ts
@@ -42,7 +42,7 @@ export enum S2Event {
   MERGED_CELLS_DOUBLE_CLICK = 'merged-cells:double-click',
   MERGED_CELLS_MOUSE_DOWN = 'merged-cells:mouse-down',
 
-  /** ================ Table Sort ================  */
+  /** ================ Sort ================  */
   RANGE_SORT = 'sort:range-sort',
   RANGE_SORTED = 'sort:range-sorted',
 

--- a/packages/s2-core/src/common/interface/emitter.ts
+++ b/packages/s2-core/src/common/interface/emitter.ts
@@ -1,7 +1,7 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { ResizeInfo } from './resize';
 import { Data, DataItem } from '@/common/interface/s2DataConfig';
-import { FilterParam, Style } from '@/common/interface/basic';
+import { FilterParam, SortParams, Style } from '@/common/interface/basic';
 import {
   HiddenColumnsInfo,
   S2CellType,
@@ -20,7 +20,7 @@ type CollapsedRowsType = {
   };
 };
 
-type SortParams = {
+export type TableSortParams = {
   sortKey: string;
   sortMethod: SortMethodType;
   sortBy?: (data: Data) => DataItem;
@@ -42,6 +42,7 @@ type ResizeHandler = (data: {
   seriesNumberWidth?: number;
 }) => void;
 type SelectedHandler = (cells: S2CellType[]) => void;
+type SortedHandler = (rangeData: Data[]) => any;
 
 export interface EmitterType {
   /** ================ Global ================  */
@@ -60,8 +61,8 @@ export interface EmitterType {
   [S2Event.GLOBAL_SELECTED]: SelectedHandler;
 
   /** ================ Sort ================  */
-  [S2Event.RANGE_SORT]: (info: SortParams) => void;
-  [S2Event.RANGE_SORTED]: (rangeData: Data[]) => any;
+  [S2Event.RANGE_SORT]: (info: TableSortParams | SortParams) => void;
+  [S2Event.RANGE_SORTED]: SortedHandler | CanvasEventHandler;
 
   /** ================ Filter ================  */
   [S2Event.RANGE_FILTER]: (info: FilterParam) => void;

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -19,6 +19,7 @@ import {
   KEY_GROUP_FROZEN_ROW_RESIZE_AREA,
   SeriesNumberHeader,
   TableRowCell,
+  TableSortParams,
 } from '..';
 import {
   calculateFrozenCornerCells,
@@ -59,7 +60,8 @@ export class TableFacet extends BaseFacet {
     super(cfg);
 
     const s2 = this.spreadsheet;
-    s2.on(S2Event.RANGE_SORT, ({ sortKey, sortMethod, sortBy }) => {
+    s2.on(S2Event.RANGE_SORT, (sortParams) => {
+      const { sortKey, sortMethod, sortBy } = sortParams as TableSortParams;
       set(s2.dataCfg, 'sortParams', [
         {
           sortFieldId: sortKey,

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -182,6 +182,8 @@ export class PivotSheet extends SpreadSheet {
     const prevSortParams = this.dataCfg.sortParams.filter(
       (item) => item?.sortFieldId !== sortFieldId,
     );
+    // 触发排序事件
+    this.emit(S2Event.RANGE_SORT, [...prevSortParams, sortParam]);
     this.setDataCfg({
       ...this.dataCfg,
       sortParams: [...prevSortParams, sortParam],
@@ -195,6 +197,8 @@ export class PivotSheet extends SpreadSheet {
     const operator: TooltipOperatorOptions = {
       onClick: ({ key }) => {
         this.groupSortByMethod(key as unknown as SortMethod, meta);
+        // 排序事件完成触发
+        this.emit(S2Event.RANGE_SORTED, event);
       },
       menus: TOOLTIP_OPERATOR_SORT_MENUS,
     };

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -327,9 +327,6 @@ export abstract class SpreadSheet extends EE {
   public setDataCfg(dataCfg: S2DataConfig) {
     this.store.set('originalDataCfg', dataCfg);
     const newDataCfg = clone(dataCfg);
-    const lastSortParam = this.store.get('sortParam');
-    const { sortParams } = newDataCfg;
-    newDataCfg.sortParams = [].concat(lastSortParam || [], sortParams || []);
     this.dataCfg = getSafetyDataConfig(newDataCfg);
     // clear value ranger after each updated data cfg
     clearValueRangeState(this);

--- a/packages/s2-react/src/components/sheets/interface.ts
+++ b/packages/s2-react/src/components/sheets/interface.ts
@@ -5,13 +5,14 @@ import {
   TargetCellInfo,
   LayoutCol,
   LayoutRow,
-  ListSortParams,
   S2Constructor,
   Node,
   SpreadSheet,
   ThemeCfg,
   ViewMeta,
   LayoutResult,
+  TableSortParams,
+  SortParams,
 } from '@antv/s2';
 import React from 'react';
 import { DrillDownProps } from '@/components/drill-down';
@@ -97,7 +98,7 @@ export interface BaseSheetComponentProps {
   header?: HeaderCfgProps;
   onLoad?: () => void;
   onDestroy?: () => void;
-  onListSort?: (params: ListSortParams) => void;
+  onListSortChange?: (params: TableSortParams | SortParams) => void;
   onRowColLayout?: (rows: LayoutRow[], cols: LayoutCol[]) => void;
   onAfterHeaderLayout?: (layoutResult: LayoutResult) => void;
   onCollapseRows?: (collapsedRows: Record<string, boolean>) => void;

--- a/packages/s2-react/src/components/sheets/interface.ts
+++ b/packages/s2-react/src/components/sheets/interface.ts
@@ -11,7 +11,6 @@ import {
   ThemeCfg,
   ViewMeta,
   LayoutResult,
-  TableSortParams,
   SortParams,
 } from '@antv/s2';
 import React from 'react';
@@ -98,7 +97,7 @@ export interface BaseSheetComponentProps {
   header?: HeaderCfgProps;
   onLoad?: () => void;
   onDestroy?: () => void;
-  onListSortChange?: (params: TableSortParams | SortParams) => void;
+  onSortChange?: (params: SortParams) => void;
   onRowColLayout?: (rows: LayoutRow[], cols: LayoutCol[]) => void;
   onAfterHeaderLayout?: (layoutResult: LayoutResult) => void;
   onCollapseRows?: (collapsedRows: Record<string, boolean>) => void;

--- a/packages/s2-react/src/components/sheets/interface.ts
+++ b/packages/s2-react/src/components/sheets/interface.ts
@@ -57,25 +57,6 @@ export interface PartDrillDown {
   displayCondition?: (meta: Node) => boolean;
 }
 
-// 用于和下钻组件进行交互联动
-export interface PartDrillDownDataCache {
-  // 执行下钻的行头id
-  rowId: string;
-  // 下钻的行头level
-  drillLevel: number;
-  // 下钻的维度
-  drillField: string;
-  // 下钻的数据
-  drillData: Record<string, string | number>[];
-}
-
-export interface PartDrillDownFieldInLevel {
-  // 下钻的维度
-  drillField: string;
-  // 下钻的层级
-  drillLevel: number;
-}
-
 // 是否开启自适应宽高，并指定容器
 export type Adaptive =
   | boolean

--- a/packages/s2-react/src/hooks/useEvents.ts
+++ b/packages/s2-react/src/hooks/useEvents.ts
@@ -107,8 +107,8 @@ export function useEvents(props: BaseSheetComponentProps) {
         },
 
         // ============== sort ====================
-        [S2Event.RANGE_SORT]: (value: TableSortParams | SortParams) => {
-          props.onListSortChange?.(value);
+        [S2Event.RANGE_SORT]: (value: SortParams) => {
+          props.onSortChange?.(value);
         },
       };
 

--- a/packages/s2-react/src/hooks/useEvents.ts
+++ b/packages/s2-react/src/hooks/useEvents.ts
@@ -3,7 +3,6 @@ import {
   S2Event,
   getBaseCellData,
   CellScrollPosition,
-  TableSortParams,
   SortParams,
   EmitterType,
   ViewMeta,

--- a/packages/s2-react/src/hooks/useEvents.ts
+++ b/packages/s2-react/src/hooks/useEvents.ts
@@ -3,7 +3,8 @@ import {
   S2Event,
   getBaseCellData,
   CellScrollPosition,
-  ListSortParams,
+  TableSortParams,
+  SortParams,
   EmitterType,
   ViewMeta,
   LayoutResult,
@@ -106,8 +107,8 @@ export function useEvents(props: BaseSheetComponentProps) {
         },
 
         // ============== sort ====================
-        [S2Event.RANGE_SORT]: (value: ListSortParams) => {
-          props.onListSort?.(value);
+        [S2Event.RANGE_SORT]: (value: TableSortParams | SortParams) => {
+          props.onListSortChange?.(value);
         },
       };
 

--- a/packages/s2-react/src/utils/drill-down.ts
+++ b/packages/s2-react/src/utils/drill-down.ts
@@ -8,10 +8,10 @@ import {
   Node,
   PivotDataSet,
   HeaderActionIcon,
+  PartDrillDownDataCache,
 } from '@antv/s2';
 import React from 'react';
 import { PartDrillDownInfo, SheetComponentsProps } from '@/components';
-import { PartDrillDownDataCache } from '@/components/sheets/interface';
 import { i18n } from '@/common/i18n';
 
 export interface DrillDownParams {

--- a/s2-site/docs/api/components/sheet-component.zh.md
+++ b/s2-site/docs/api/components/sheet-component.zh.md
@@ -7,45 +7,36 @@ order: 0
 
 功能描述： 基于 `core` 层封装的 `react` 版开箱即用的组件。
 
-| 参数 | 说明                                                         | 类型 | 默认值  | 必选 |
-| :--- | :--- | :--- | :--- | :---: |
-| sheetType |  表格类型：<br/> 1. `pivot`: 透视表 <br/> 2. `table`: 明细表 <br> 3. `gridAnalysis`: 网格分析表 <br/> 4. `strategy`: 趋势分析表 | `pivot | table | gridAnalysis | strategy` | `pivot` | |
-| spreadsheet | 自定义表 | (...args: [S2Constructor](/zh/docs/api/basic-class/spreadsheet#s2constructor)) => [SpreadSheet](/zh/docs/api/basic-class/spreadsheet) | |  |
-| dataCfg |  透视表数据映射相关配置项 | [S2DataConfig](/zh/docs/api/general/S2DataConfig) | | ✓ |
-| options | 透视表属性配置项 | [S2Options](/zh/docs/api/general/S2Options) | | ✓ |
-| partDrillDown |  维度下钻相关属性 | [PartDrillDown](/zh/docs/api/components/drill-down) | |  |
-| adaptive | 是否根据窗口大小自适应 | `boolean | { width?: boolean, height?: boolean, getContainer: () => HTMLElement }` | `false` | |
-| showPagination | 是否显示默认分页<br>（只有在 `options` 配置过 `pagination`  属性才会生效） | `boolean` | `true` | |
-| themeCfg | 自定义透视表主题样式 | [ThemeCfg](/zh/docs/api/general/S2Theme) | |  |
-| loading | 控制表格的加载状态 | `boolean` | | |
-| header | 表头配置项 | [HeaderCfgProps](/zh/docs/api/components/header) | | |
-| getSpreadSheet | 获取表实例 [详情](/zh/docs/manual/advanced/get-instance) | (spreadsheet: [SpreadSheet](/zh/docs/api/basic-class/spreadsheet)) => void; | | |
-| onListSort | 排序回调，用于做自定义排序 |  (params: [ListSortParams](#listsortparams) ) => void; | |  |
-| onRowCellClick | 行头鼠标单击事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onRowCellHover | 行头鼠标悬停事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onRowCellDoubleClick | 行头鼠标双击事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onColCellClick | 列头鼠标单击事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onColCellHover | 列头鼠标悬停事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onColCellDoubleClick | 列头鼠标双击事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onCornerCellClick | 角头鼠标单击事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onCornerCellHover | 角头鼠标悬停事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onCornerCellDoubleClick | 角头鼠标双击事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onDataCellClick | 数值单元格鼠标点击事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onDataCellHover | 数值单元格鼠标悬停事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onDataCellDoubleClick | 数值单元格双击事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onMergedCellHover | 合并单元格鼠标悬停事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onMergedCellClick | 合并单元格鼠标点击事件 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onMergedCellDoubleClick | 合并单元格鼠标双击事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-| onContextMenu | 右键单元格单击事件| (data: [TargetCellInfo](#targetcellinfo)) => void | | |
-
-### ListSortParams
-
-功能描述：排序回调函数的返回的信息。
-
-| 参数 | 说明                      | 类型 | 默认值  | 必选 |
-| :--- | :--- | :--- | :--- | :---: |
-| sortFieldId | 当前排序的维度或度量的 id | `string` | | ✓ |
-| sortMethod | 当前排序方式 | `string` | | ✓ |
+| 参数 | 说明                                                                                                        | 类型 | 默认值  | 必选 |
+| :--- |:----------------------------------------------------------------------------------------------------------| :--- | :--- | :---: |
+| sheetType | 表格类型：<br/> 1. `pivot`: 透视表 <br/> 2. `table`: 明细表 <br> 3. `gridAnalysis`: 网格分析表 <br/> 4. `strategy`: 趋势分析表 | `pivot | table | gridAnalysis | strategy` | `pivot` | |
+| spreadsheet | 自定义表                                                                                                      | (...args: [S2Constructor](/zh/docs/api/basic-class/spreadsheet#s2constructor)) => [SpreadSheet](/zh/docs/api/basic-class/spreadsheet) | |  |
+| dataCfg | 透视表数据映射相关配置项                                                                                              | [S2DataConfig](/zh/docs/api/general/S2DataConfig) | | ✓ |
+| options | 透视表属性配置项                                                                                                  | [S2Options](/zh/docs/api/general/S2Options) | | ✓ |
+| partDrillDown | 维度下钻相关属性                                                                                                  | [PartDrillDown](/zh/docs/api/components/drill-down) | |  |
+| adaptive | 是否根据窗口大小自适应                                                                                               | `boolean | { width?: boolean, height?: boolean, getContainer: () => HTMLElement }` | `false` | |
+| showPagination | 是否显示默认分页<br>（只有在 `options` 配置过 `pagination`  属性才会生效）                                                      | `boolean` | `true` | |
+| themeCfg | 自定义透视表主题样式                                                                                                | [ThemeCfg](/zh/docs/api/general/S2Theme) | |  |
+| loading | 控制表格的加载状态                                                                                                 | `boolean` | | |
+| header | 表头配置项                                                                                                     | [HeaderCfgProps](/zh/docs/api/components/header) | | |
+| getSpreadSheet | 获取表实例 [详情](/zh/docs/manual/advanced/get-instance)                                                         | (spreadsheet: [SpreadSheet](/zh/docs/api/basic-class/spreadsheet)) => void; | | |
+| onSortChange | 组内排序时触发回调事件（暂只支持透视表）                                                                                      |  (params: [SortParams](#sortparams) ) => void; | |  |
+| onRowCellClick | 行头鼠标单击事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onRowCellHover | 行头鼠标悬停事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onRowCellDoubleClick | 行头鼠标双击事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onColCellClick | 列头鼠标单击事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onColCellHover | 列头鼠标悬停事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onColCellDoubleClick | 列头鼠标双击事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onCornerCellClick | 角头鼠标单击事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onCornerCellHover | 角头鼠标悬停事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onCornerCellDoubleClick | 角头鼠标双击事件                                                                                                  | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onDataCellClick | 数值单元格鼠标点击事件                                                                                               | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onDataCellHover | 数值单元格鼠标悬停事件                                                                                               | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onDataCellDoubleClick | 数值单元格双击事件                                                                                                 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onMergedCellHover | 合并单元格鼠标悬停事件                                                                                               | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onMergedCellClick | 合并单元格鼠标点击事件                                                                                               | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onMergedCellDoubleClick | 合并单元格鼠标双击事件                                                                                               | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
+| onContextMenu | 右键单元格单击事件                                                                                                 | (data: [TargetCellInfo](#targetcellinfo)) => void | | |
 
 ### TargetCellInfo
 
@@ -56,3 +47,5 @@ order: 0
 | target | 交互作用对象 | [S2CellType](/zh/docs/api/basic-class/base-cell) | |  |
 | event | 事件 | [Event](#) | |  |
 | viewMeta | 当前节点信息 | [Node](/zh/docs/api/basic-class/node) | |  |
+
+`markdown:docs/common/sort-params.zh.md`


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature
feat(pivot): 新增组内排序时触发回调事件 [onSortChange 事件]
[feat: pivot 添加 S2Event.RANGE_SORT 和 S2Event.RANGE_SORTED 事件](https://github.com/antvis/S2/commit/f9ebdd116ed187c71a6db003ccc15ad0746b9680)
[fix: 删除从 store 中获取 params，历史遗留](https://github.com/antvis/S2/commit/fcf2086a0705a6d87e2e6cf9227045ec9fe967aa)

提交说明：
1. 以前向外抛出的 onListSort（排序回调，用于做自定义排序） 事件没有生效，因为 [sortParams. sortFunc](https://s2.antv.vision/zh/docs/api/general/S2DataConfig#sortfuncparam) 具有相同功能，估不重复定义。现向外抛出  onSortChange（组内排序时触发回调事件） 事件，用户可拿到每次排序的规则。
2. 待明细表参数统一后抛出 onSortChange。
- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #287 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
