### PR TITLE
ci: 新增官网部署通知

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -16,8 +16,8 @@ jobs:
           inactive-day: 15
           body: |
             由于该 issue 被标记为需要复现，却 15 天未收到回应。现关闭 issue，若有任何问题，可评论回复。
-            
-            Since the issue was labeled as "need reproduce" but no response was received for 15 days. Now close the issue. If you have any questions, feel free to comment.
+
+            Since the issue was labeled as "🤔 Need Reproduce" but no response was received for 15 days. Now close the issue. If you have any questions, feel free to comment.
 
       - name: Needs more info
         uses: actions-cool/issues-helper@main
@@ -26,6 +26,6 @@ jobs:
           labels: '👀 need more info'
           inactive-day: 15
           body: |
-            由于该 issue 被标记为需要复现，却 15 天未收到回应。现关闭 issue，若有任何问题，可评论回复。
-            
-            Since the issue was labeled as "need reproduce" but no response was received for 15 days. Now close the issue. If you have any questions, feel free to comment.
+            由于该 issue 被标记为需要更多信息，却 15 天未收到回应。现关闭 issue，若有任何问题，可评论回复。
+
+            Since the issue was labeled as "👀 need more info" but no response was received for 15 days. Now close the issue. If you have any questions, feel free to comment.

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -29,9 +29,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
-            你好 @${{ github.event.issue.user.login }}，你所提供的信息不足于我们排查问题, 请完善 issue 描述, 提供 gif, 截图等方式, 详细说明复现步骤, 感谢配合, 谢谢!
+            你好 @${{ github.event.issue.user.login }}，你所提供的信息不足于我们排查问题, 请按照 issue 模板填写相关信息, 提供 gif, 截图, d代码片段, 配置信息, 可复现链接等方式, 详细说明复现步骤, 感谢配合, 谢谢! 15 天内未回复issue自动关闭。
 
-            Hello, @${{ github.event.issue.user.login }}, the information you provided is not enough for us to troubleshoot the problem. Please complete the issue description, provide gifs, screenshots, etc. And explain the reproduction steps in detail. Thanks so much for your cooperation!
+            Hello, @${{ github.event.issue.user.login }}, the information you provided is not enough for us to troubleshoot the problem. Please complete the issue description, provide gifs, screenshots, etc. And explain the reproduction steps in detail. Thanks so much for your cooperation! The issue will be closed without any replay within 15 days.
 
       - name: Invalid
         if: github.event.label.name == '⛔ invalid'

--- a/.github/workflows/site-build-notify.yml
+++ b/.github/workflows/site-build-notify.yml
@@ -1,0 +1,24 @@
+name: 🚀 Site Build Notify
+on:
+  page_build
+
+jobs:
+  site-build-notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Site Build Success Notify
+        uses: zcong1993/actions-ding@master
+        with:
+          dingToken: ${{ secrets.DING_TALK_ACCESS_TOKEN }}
+          ignoreError: true
+          body: |
+            {
+              "msgtype": "link",
+              "link": {
+                "title": "🚀 官网部署成功",
+                "text": "点击访问",
+                "messageUrl": "https://s2.antv.vision",
+                "picUrl": "https://gw.alipayobjects.com/zos/antfincdn/ISzgBCtgR/2c5c4aaa-4f40-46f7-8f6b-427fa9ff07bb.png"
+              }
+            }

--- a/.github/workflows/sync-site-lock-changelog-with-pr.yml
+++ b/.github/workflows/sync-site-lock-changelog-with-pr.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Git bootstrap
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name 'Jinke Li'
+          git config --global user.email 'a1231236677287@163.com'
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.JINKE_GITHUB_TOKEN }}
 
       - name: Checkout branch
         run: |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [x] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

1. 增加 github pages 部署通知
2. 修复一些自动回复的文案和错误描述
3. 修复自动同步changelog 机器人无法触发 lint 和 test ci 的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
