### PR TITLE
feat: Meta内formatter增加入参提供完整数据 close #994

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/data-cell.spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell.spec.ts
@@ -1,6 +1,6 @@
-import { doc } from 'prettier';
+import { get } from 'lodash';
 import { EXTRA_FIELD, VALUE_FIELD } from '@/common/constant/basic';
-import { ViewMeta } from '@/common';
+import { Formatter, ViewMeta } from '@/common';
 import { PivotDataSet } from '@/data-set';
 import { SpreadSheet, PivotSheet } from '@/sheet-type';
 import { DataCell } from '@/cell';
@@ -37,5 +37,16 @@ describe('data cell formatter test', () => {
       [VALUE_FIELD]: 'value',
       [EXTRA_FIELD]: 12,
     });
+  });
+
+  test('should return correct formatted value', () => {
+    const formatter: Formatter = (value, data) => `${get(data, 'value') * 10}`;
+    jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+
+    const dataCell = new DataCell(meta, s2);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(dataCell.textShape.attr('text')).toEqual('120');
   });
 });

--- a/packages/s2-core/__tests__/unit/cell/data-cell.spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell.spec.ts
@@ -1,0 +1,41 @@
+import { doc } from 'prettier';
+import { EXTRA_FIELD, VALUE_FIELD } from '@/common/constant/basic';
+import { ViewMeta } from '@/common';
+import { PivotDataSet } from '@/data-set';
+import { SpreadSheet, PivotSheet } from '@/sheet-type';
+import { DataCell } from '@/cell';
+
+const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
+const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
+describe('data cell formatter test', () => {
+  const meta = {
+    data: {
+      city: 'chengdu',
+      value: 12,
+      [VALUE_FIELD]: 'value',
+      [EXTRA_FIELD]: 12,
+    },
+  } as unknown as ViewMeta;
+
+  let s2: SpreadSheet;
+  beforeEach(() => {
+    const container = document.createElement('div');
+
+    s2 = new MockPivotSheet(container);
+    const dataSet: PivotDataSet = new MockPivotDataSet(s2);
+    s2.dataSet = dataSet;
+  });
+  test('should pass complete data into formater', () => {
+    const formatter = jest.fn();
+    jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+
+    const dataCell = new DataCell(meta, s2);
+
+    expect(formatter).toHaveBeenCalledWith(undefined, {
+      city: 'chengdu',
+      value: 12,
+      [VALUE_FIELD]: 'value',
+      [EXTRA_FIELD]: 12,
+    });
+  });
+});

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -194,21 +194,19 @@ export class DataCell extends BaseCell<ViewMeta> {
   }
 
   protected getFormattedFieldValue(): FormatResult {
-    const rowField = this.meta.rowId;
-    const rowMeta = this.spreadsheet.dataSet.getFieldMeta(rowField);
+    const { rowId, valueField, fieldValue, data } = this.meta;
+    const rowMeta = this.spreadsheet.dataSet.getFieldMeta(rowId);
     let formatter: Formatter;
     if (rowMeta) {
       // format by row field
-      formatter = this.spreadsheet.dataSet.getFieldFormatter(rowField);
+      formatter = this.spreadsheet.dataSet.getFieldFormatter(rowId);
     } else {
       // format by value field
-      formatter = this.spreadsheet.dataSet.getFieldFormatter(
-        this.meta.valueField,
-      );
+      formatter = this.spreadsheet.dataSet.getFieldFormatter(valueField);
     }
-    const formattedValue = formatter(this.meta.fieldValue);
+    const formattedValue = formatter(fieldValue, data);
     return {
-      value: this.meta.fieldValue,
+      value: fieldValue,
       formattedValue,
     };
   }

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -157,17 +157,6 @@ export class RowCell extends HeaderCell {
     }
   }
 
-  protected getFormattedValue(value: string): string {
-    let content = value;
-    const formatter = this.spreadsheet.dataSet.getFieldFormatter(
-      this.meta.field,
-    );
-    if (formatter) {
-      content = formatter(value);
-    }
-    return content;
-  }
-
   // draw text
   protected drawTextShape() {
     super.drawTextShape();

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -2,7 +2,12 @@ import { Event, ShapeAttrs } from '@antv/g-canvas';
 import { S2CellType } from './interaction';
 import { DataItem, S2DataConfig } from './s2DataConfig';
 import { BaseHeaderConfig } from '@/facet/header/base';
-import { Condition, CustomTreeItem, ResizeInfo } from '@/common/interface';
+import {
+  Condition,
+  CustomTreeItem,
+  Data,
+  ResizeInfo,
+} from '@/common/interface';
 import { S2BasicOptions } from '@/common/interface/s2Options';
 import { BaseDataSet, DataType } from '@/data-set';
 import { Frame } from '@/facet/header';
@@ -13,7 +18,11 @@ import { Node } from '@/facet/layout/node';
 import { SpreadSheet } from '@/sheet-type';
 import { S2Options, S2TableSheetOptions } from '@/common/interface/s2Options';
 
-export type Formatter = (v: unknown) => string;
+// 第二个参数在以下情况会传入：
+// 1. data cell 格式化
+// 2. copy/export
+// 3. tooltip, 且仅在选择多个单元格时，data 类型为数组
+export type Formatter = (v: unknown, data?: Data | Data[]) => string;
 
 export interface FormatResult {
   formattedValue: string;

--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -108,7 +108,7 @@ const processValueInDetail = (
     } else {
       tempRows = columns.map((v: string) => {
         const mainFormatter = sheetInstance.dataSet.getFieldFormatter(v);
-        return getCsvString(mainFormatter(record[v]));
+        return getCsvString(mainFormatter(record[v], record));
       });
     }
     if (sheetInstance.options.showSeriesNumber) {
@@ -130,7 +130,7 @@ const processValueInCol = (
     // If the meta equals null, replacing it with blank line.
     return '';
   }
-  const { fieldValue, valueField } = viewMeta;
+  const { fieldValue, valueField, data } = viewMeta;
 
   if (isObject(fieldValue)) {
     return processObjectValueInCol(fieldValue);
@@ -140,7 +140,7 @@ const processValueInCol = (
     return `${fieldValue}`;
   }
   const mainFormatter = sheetInstance.dataSet.getFieldFormatter(valueField);
-  return mainFormatter(fieldValue);
+  return mainFormatter(fieldValue, data);
 };
 
 /* Process the data when the value position is on the rows. */
@@ -152,7 +152,7 @@ const processValueInRow = (
   let tempCells = [];
 
   if (viewMeta) {
-    const { fieldValue, valueField } = viewMeta;
+    const { fieldValue, valueField, data } = viewMeta;
     if (isObject(fieldValue)) {
       tempCells = processObjectValueInRow(fieldValue, isFormat);
       return tempCells;
@@ -162,7 +162,7 @@ const processValueInRow = (
       tempCells.push(fieldValue);
     } else {
       const mainFormatter = sheetInstance.dataSet.getFieldFormatter(valueField);
-      tempCells.push(mainFormatter(fieldValue));
+      tempCells.push(mainFormatter(fieldValue, data));
     }
   } else {
     // If the meta equals null then it will be replaced by '-'.

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -29,7 +29,7 @@ import { Event as CanvasEvent } from '@antv/g-canvas';
 import { handleDataItem } from './cell/data-cell';
 import { isMultiDataItem } from './data-item-type-checker';
 import { customMerge } from './merge';
-import { AutoAdjustPositionOptions, ListItem } from '@/common/interface';
+import { AutoAdjustPositionOptions, Data, ListItem } from '@/common/interface';
 import { LayoutResult } from '@/common/interface/basic';
 import {
   SummaryParam,
@@ -167,8 +167,8 @@ export const getFriendlyVal = (val: any): number | string => {
 export const getFieldFormatter = (spreadsheet: SpreadSheet, field: string) => {
   const formatter = spreadsheet?.dataSet?.getFieldFormatter(field);
 
-  return (v: any) => {
-    return getFriendlyVal(formatter(v));
+  return (v: unknown, data?: Data) => {
+    return getFriendlyVal(formatter(v, data));
   };
 };
 
@@ -184,7 +184,7 @@ export const getListItem = (
   const dataValue = isObject(data[field])
     ? JSON.stringify(data[field])
     : data[field];
-  const value = formatter(valueField || dataValue);
+  const value = formatter(valueField || dataValue, data);
 
   return {
     name,
@@ -405,7 +405,7 @@ export const getSummaries = (params: SummaryParam): TooltipSummaryOptions[] => {
       const dataSum = getDataSumByField(selected, VALUE_FIELD);
       value = parseFloat(dataSum.toPrecision(PRECISION)); // solve accuracy problems
       if (currentFormatter) {
-        value = currentFormatter(dataSum);
+        value = currentFormatter(dataSum, selected);
       }
     }
     summaries.push({

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -174,10 +174,17 @@ export const getFieldFormatter = (spreadsheet: SpreadSheet, field: string) => {
 
 export const getListItem = (
   spreadsheet: SpreadSheet,
-  data: TooltipDataItem,
-  field: string,
-  valueField?: string,
-  useCompleteDataForFormatter = true,
+  {
+    data,
+    field,
+    valueField,
+    useCompleteDataForFormatter = true,
+  }: {
+    data: TooltipDataItem;
+    field: string;
+    valueField?: string;
+    useCompleteDataForFormatter?: boolean;
+  },
 ): ListItem => {
   const name = spreadsheet?.dataSet?.getFieldName(field);
   const formatter = getFieldFormatter(spreadsheet, field);
@@ -206,7 +213,11 @@ export const getFieldList = (
     (field) => field !== EXTRA_FIELD && activeData[field],
   );
   const fieldList = map(currFields, (field: string): ListItem => {
-    return getListItem(spreadsheet, activeData, field, undefined, false);
+    return getListItem(spreadsheet, {
+      data: activeData,
+      field,
+      useCompleteDataForFormatter: false,
+    });
   });
   return fieldList;
 };
@@ -258,12 +269,11 @@ export const getDetailList = (
     if (isTotals) {
       // total/subtotal
       valItem.push(
-        getListItem(
-          spreadsheet,
-          activeData,
+        getListItem(spreadsheet, {
+          data: activeData,
           field,
-          get(activeData, VALUE_FIELD),
-        ),
+          valueField: get(activeData, VALUE_FIELD),
+        }),
       );
     }
     // the value hangs at the head of the column, match the displayed fields according to the metric itself
@@ -281,10 +291,12 @@ export const getDetailList = (
       ) as Record<string, string | number>;
 
       forEach(mappedResult, (_, key) => {
-        valItem.push(getListItem(spreadsheet, mappedResult, key));
+        valItem.push(
+          getListItem(spreadsheet, { data: mappedResult, field: key }),
+        );
       });
     } else {
-      valItem.push(getListItem(spreadsheet, activeData, field));
+      valItem.push(getListItem(spreadsheet, { data: activeData, field }));
     }
 
     return valItem;

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -177,6 +177,7 @@ export const getListItem = (
   data: TooltipDataItem,
   field: string,
   valueField?: string,
+  useCompleteDataForFormatter = true,
 ): ListItem => {
   const name = spreadsheet?.dataSet?.getFieldName(field);
   const formatter = getFieldFormatter(spreadsheet, field);
@@ -184,7 +185,10 @@ export const getListItem = (
   const dataValue = isObject(data[field])
     ? JSON.stringify(data[field])
     : data[field];
-  const value = formatter(valueField || dataValue, data);
+  const value = formatter(
+    valueField || dataValue,
+    useCompleteDataForFormatter ? data : undefined,
+  );
 
   return {
     name,
@@ -202,7 +206,7 @@ export const getFieldList = (
     (field) => field !== EXTRA_FIELD && activeData[field],
   );
   const fieldList = map(currFields, (field: string): ListItem => {
-    return getListItem(spreadsheet, activeData, field);
+    return getListItem(spreadsheet, activeData, field, undefined, false);
   });
   return fieldList;
 };

--- a/s2-site/docs/api/general/S2DataConfig.zh.md
+++ b/s2-site/docs/api/general/S2DataConfig.zh.md
@@ -68,7 +68,7 @@ array object **必选**,_default：null_
 | field  | 字段 id | `string` | |    |
 | name | 字段名称 | `string`|  |   |
 | description | 字段描述 | `string`|  |   |
-| formatter | 格式化 <br/>数值字段：一般用于格式化数字单位<br/>文本字段：一般用于做字段枚举值的别名 | `(value: unknown) => string` | | |
+| formatter | 格式化 <br/>数值字段：一般用于格式化数字单位<br/>文本字段：一般用于做字段枚举值的别名<br/> 第二个参数在以下情况会传入：data cell 格式化，复制/导出，tooltip 展示（**且仅在选择多个单元格时，data 类型为数组**） | `(value: unknown, data?: Data | Data[]) => string` | | |
 
 `markdown:docs/common/sort-params.zh.md`
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] meta提供第二个参数用于提供单元格对应的完整数据

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->
close #994 
### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
