### PR TITLE
feat: 全量展示小计项

### DIFF
--- a/packages/s2-core/src/utils/layout/add-totals.ts
+++ b/packages/s2-core/src/utils/layout/add-totals.ts
@@ -1,4 +1,3 @@
-import { size } from 'lodash';
 import { TotalParams } from '@/facet/layout/interface';
 import { TotalClass } from '@/facet/layout/total-class';
 import { EXTRA_FIELD } from '@/common/constant';
@@ -11,17 +10,13 @@ export const addTotals = (params: TotalParams) => {
   );
   let action: 'unshift' | 'push';
   let totalValue: TotalClass;
-  if (isFirstField) {
+  if (totalsConfig?.showGrandTotals && isFirstField) {
     // check to see if grand total is added
-    if (totalsConfig.showGrandTotals) {
-      action = totalsConfig.reverseLayout ? 'unshift' : 'push';
-      totalValue = new TotalClass(totalsConfig.label, false, true);
-    }
-  } else if (totalsConfig?.showSubTotals && size(fieldValues) > 1) {
-    if (currentField !== EXTRA_FIELD) {
-      action = totalsConfig.reverseSubLayout ? 'unshift' : 'push';
-      totalValue = new TotalClass(totalsConfig.subLabel, true);
-    }
+    action = totalsConfig.reverseLayout ? 'unshift' : 'push';
+    totalValue = new TotalClass(totalsConfig.label, false, true);
+  } else if (totalsConfig?.showSubTotals && currentField !== EXTRA_FIELD) {
+    action = totalsConfig.reverseSubLayout ? 'unshift' : 'push';
+    totalValue = new TotalClass(totalsConfig.subLabel, true);
   }
 
   fieldValues[action]?.(totalValue);


### PR DESCRIPTION
### 👀 PR includes

✨ Feature

- [x] New feature

### 📝 Description
当用户配置了小计后，无论小计维度有几个子维度值，始终展示小计项。

### 🖼️ Screenshot
字段配置
```
fields: {
  rows: ['province', 'city', 'area'],
  columns: ['type', 'subType'],
  values: ['count'],
}
```

总、小计配置
```
totals: {
    row: {
      reverseLayout: true,
      reverseSubLayout: true,
      showGrandTotals: true,
      showSubTotals: true,
      subTotalsDimensions: ['province', 'city'],
    },
    col: {
      reverseLayout: true,
      reverseSubLayout: true,
      showGrandTotals: true,
      showSubTotals: true,
      subTotalsDimensions: ['type'],
    },
  }
```

- row: `四川` 下只有 `成都` 一个子维度
- col: `休闲` 下只有 `公园` 一个子维度

| Before | After |
| ------ | ----- |
|  <img width="600" alt="CleanShot 2022-02-14 at 14 48 03@2x" src="https://user-images.githubusercontent.com/6716092/153813826-2296aa16-79dc-40c7-b8fa-de7310f85fbc.png">     |  <img width="604" alt="CleanShot 2022-02-14 at 14 46 48@2x" src="https://user-images.githubusercontent.com/6716092/153813680-3da89958-0680-4148-8876-ddafe79801b3.png">    |

### 🔗 Related issue link

close #1078 

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
