### PR TITLE
fix: 初始化后更新dataCfg不触发分页total变化

### DIFF
--- a/packages/s2-react/src/hooks/usePagination.ts
+++ b/packages/s2-react/src/hooks/usePagination.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SpreadSheet } from '@antv/s2';
+import { S2Event, SpreadSheet } from '@antv/s2';
 import { isEmpty } from 'lodash';
 import { BaseSheetComponentProps } from '../components';
 
@@ -41,7 +41,12 @@ export const usePagination = (
     if (!s2 || isEmpty(options.pagination)) {
       return;
     }
-    setTotal(s2.facet.viewCellHeights.getTotalLength());
+
+    const totalUpdateCallback = (data) => setTotal(data.total);
+    s2.on(S2Event.LAYOUT_PAGINATION, totalUpdateCallback);
+    return () => {
+      s2.off(S2Event.LAYOUT_PAGINATION, totalUpdateCallback);
+    };
   }, [options.pagination, dataCfg, s2]);
 
   return {


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
使用表格 react 组件时，当异步获取数据更新 props.dataCfg 后，pagination 组件 total 未更新，导致分页功能 BUG。

### 🖼️ Screenshot

- 初始化无数据，点击 get data 后会载入 3 条数据
- 明细表也进行了同种测试

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-02-15 at 11 30 11](https://user-images.githubusercontent.com/6716092/153987396-dee36b24-3a76-4800-b6a8-b5ca1ffdb7a7.gif)      |  ![CleanShot 2022-02-15 at 11 29 19](https://user-images.githubusercontent.com/6716092/153987328-b3c5774f-fdb7-449f-9d6c-e4633860b630.gif)    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
