### PR TITLE
feat(tooltip): tooltip 自定义操作项点击事件透出 cell 信息 close #1106

### DIFF
--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -9,7 +9,7 @@ export interface TooltipOperatorMenu {
   key: string;
   icon?: Element | string;
   text?: string;
-  onClick?: () => void;
+  onClick?: (cell: S2CellType) => void;
   visible?: boolean | ((cell: S2CellType) => boolean);
   children?: TooltipOperatorMenu[];
 }

--- a/packages/s2-react/src/components/tooltip/components/operator/index.tsx
+++ b/packages/s2-react/src/components/tooltip/components/operator/index.tsx
@@ -5,6 +5,7 @@ import {
   TOOLTIP_PREFIX_CLS,
   TooltipOperatorMenu,
   TooltipOperatorOptions,
+  S2CellType,
 } from '@antv/s2';
 import { Icon } from '../icon';
 import './index.less';
@@ -12,6 +13,7 @@ import './index.less';
 interface TooltipOperatorProps extends TooltipOperatorOptions {
   onlyMenu: boolean;
   onClick: MenuProps['onClick'];
+  cell: S2CellType;
 }
 
 /**
@@ -22,11 +24,11 @@ interface TooltipOperatorProps extends TooltipOperatorOptions {
  */
 
 export const TooltipOperator = (props: TooltipOperatorProps) => {
-  const { menus, onlyMenu, onClick: onMenuClick } = props;
+  const { menus, onlyMenu, onClick: onMenuClick, cell } = props;
 
   const renderTitle = (menu: TooltipOperatorMenu) => {
     return (
-      <span onClick={menu.onClick}>
+      <span onClick={() => menu.onClick?.(cell)}>
         <Icon
           icon={menu.icon}
           className={`${TOOLTIP_PREFIX_CLS}-operator-icon`}
@@ -45,7 +47,7 @@ export const TooltipOperator = (props: TooltipOperatorProps) => {
           title={renderTitle(menu)}
           key={key}
           popupClassName={`${TOOLTIP_PREFIX_CLS}-operator-submenu-popup`}
-          onTitleClick={onClick}
+          onTitleClick={() => onClick?.(cell)}
         >
           {map(children, (subMenu: TooltipOperatorMenu) => renderMenu(subMenu))}
         </Menu.SubMenu>

--- a/packages/s2-react/src/components/tooltip/custom-tooltip.tsx
+++ b/packages/s2-react/src/components/tooltip/custom-tooltip.tsx
@@ -14,8 +14,10 @@ export class CustomTooltip extends BaseTooltip {
     const { content: contentFromOptions } = this.spreadsheet.options.tooltip;
     // 方法级 s2.showTooltip({ content: '' })
     const showOptions = this.options;
+    const cell = this.spreadsheet.getCell(showOptions.event?.target);
     const tooltipProps: TooltipRenderProps = {
       ...showOptions,
+      cell,
     };
     // 优先级: 方法级 > 配置级, 兼容 content 为空字符串的场景
     const content = showOptions.content ?? contentFromOptions;

--- a/packages/s2-react/src/components/tooltip/index.tsx
+++ b/packages/s2-react/src/components/tooltip/index.tsx
@@ -22,7 +22,7 @@ import { TooltipRenderProps } from './interface';
 import './index.less';
 
 export const TooltipComponent: React.FC<TooltipRenderProps> = (props) => {
-  const { data, options, content } = props;
+  const { data, options, content, cell } = props;
 
   const renderDivider = () => {
     return <Divider />;
@@ -38,6 +38,7 @@ export const TooltipComponent: React.FC<TooltipRenderProps> = (props) => {
           onClick={operator.onClick}
           menus={operator.menus}
           onlyMenu={onlyMenu}
+          cell={cell}
         />
       )
     );

--- a/packages/s2-react/src/components/tooltip/interface.ts
+++ b/packages/s2-react/src/components/tooltip/interface.ts
@@ -1,8 +1,9 @@
-import { TooltipShowOptions } from '@antv/s2';
+import type { S2CellType, TooltipShowOptions } from '@antv/s2';
 
 export interface TooltipRenderProps<T = React.ReactNode>
   extends TooltipShowOptions<T> {
   readonly content?: T;
+  readonly cell: S2CellType;
 }
 
 export type TooltipInfosProps = {

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -99,5 +99,5 @@ object **必选**,_default：null_ 功能描述： tooltip 操作项列表
 | text     | `string`   |       |        | 名称           |
 | icon     | `React.ReactNode \| string`   |       |        | 自定义图标     |
 | visible  | `boolean \| (cell) => boolean`                           |      |   `true`      | 操作项是否显示，可传入一个函数根据当前单元格信息动态显示     |
-| onClick  | `() => void`                           |       |        | 点击事件回调     |
+| onClick  | (`cell`: [S2CellType](/zh/docs/api/basic-class/base-cell): ) => void                           |       |        | 点击事件回调  (cell 为当前 tooltip 对应的单元格）   |
 | children | [TooltipOperatorMenu](#tooltipoperatormenu) |       |        | 子菜单列表     |

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -202,26 +202,26 @@ s2.showTooltip({
 
 #### 自定义 Tooltip 操作项
 
-除了默认提供的操作项，还可以配置 `operation.menus` 自定义操作项，支持嵌套，也可以监听各自的点击事件
+除了默认提供的操作项，还可以配置 `operation.menus` 自定义操作项，支持嵌套，也可以监听各自的 `onClick` 点击事件，可以拿到 当前 `tooltip` 对应的 [单元格信息](/zh/docs/api/basic-class/base-cell)
 
 ```ts
 const s2Options = {
   tooltip: {
     operation: {
-      trend: true,
       menus: [
         {
           key: 'custom-a',
           text: '操作 1',
           icon: 'Trend',
-          onClick: () => {
+          onClick: (cell) => {
             console.log('操作 1 点击');
+            console.log('tooltip 对应的单元格：', cell)
           },
           children: [{
             key: 'custom-a-a',
             text: '操作 1-1',
             icon: 'Trend',
-            onClick: () => {
+            onClick: (cell) => {
               console.log('操作 1-1 点击');
             },
           }]
@@ -230,7 +230,7 @@ const s2Options = {
           key: 'custom-b',
           text: '操作 2',
           icon: 'EyeOutlined',
-          onClick: () => {
+          onClick: (cell) => {
             console.log('操作 2 点击');
           },
         },

--- a/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
+++ b/s2-site/examples/react-component/tooltip/demo/custom-operation.tsx
@@ -18,8 +18,8 @@ fetch(
               key: 'custom-a',
               text: '操作1',
               icon: 'Trend',
-              onClick: () => {
-                console.log('操作1点击');
+              onClick: (cell) => {
+                console.log('操作1点击', cell);
               },
               children: [
                 {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

menu 的 onClick 事件增加 cell 参数, 方便拿到当前 tooltip 对应的单元格信息

```ts
 tooltip: {
    operation: {
      menus: [
        {
          key: '操作1',
          text: '操作1',
          onClick(cell) {
            console.log(cell);
          },
          children: [
            {
              key: '操作2',
              text: '操作2',
              onClick(cell) {
                console.log(cell);
              },
            },
          ],
        },
      ],
    },
  },
```

### 🖼️ Screenshot

![Kapture 2022-02-18 at 17 35 54](https://user-images.githubusercontent.com/21015895/154656727-0fce71ef-3fb2-4523-8aeb-bc57078d960a.gif)


### 🔗 Related issue link

<!-- close #0 -->

close #1106

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
