### PR TITLE
fix: 修复头部cell错误使用meta中formatter的问题，close #1014

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1014-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1014-spec.ts
@@ -1,0 +1,111 @@
+/**
+ * @description spec for issue #1014
+ * https://github.com/antvis/S2/issues/1014
+ * Column should not be formatted
+ *
+ */
+import { getContainer } from 'tests/util/helpers';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { filter, get } from 'lodash';
+import { PivotSheet, SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+import { CornerCell } from '@/cell';
+
+const s2options: S2Options = {
+  // 让被测试的单元格在首屏显示出来
+  width: 300,
+  height: 200,
+  style: {
+    colCfg: {
+      height: 60,
+    },
+    cellCfg: {
+      width: 100,
+      height: 50,
+    },
+  },
+};
+
+const dataCfg = {
+  ...mockDataConfig,
+  fields: {
+    rows: ['province'],
+    columns: ['city'],
+    values: ['price'],
+    valueInCols: true,
+  },
+  meta: [
+    {
+      field: 'province',
+      name: '省份',
+      formatter: (v) => `province: ${v}`,
+    },
+    {
+      field: 'city',
+      name: '城市',
+      formatter: (v) => `city: ${v}`,
+    },
+    {
+      field: 'price',
+      name: '价格',
+      formatter: (v) => `price:${v}`,
+    },
+  ],
+};
+
+describe('Formatter Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    s2 = new PivotSheet(getContainer(), dataCfg, s2options);
+    s2.render();
+  });
+
+  test('corner should not be formatted', () => {
+    const cornerNodes = filter(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      s2.facet.getCornerHeader().getChildren(),
+      (node) => node instanceof CornerCell,
+    ) as unknown[] as CornerCell[];
+
+    const provinceCornerNode = cornerNodes.find(
+      (cell) => get(cell, 'meta.field') === 'province',
+    );
+
+    const cityCornerNode = cornerNodes.find(
+      (cell) => get(cell, 'meta.field') === 'city',
+    );
+
+    expect(get(provinceCornerNode, 'meta.value')).toStrictEqual('省份');
+    expect(get(provinceCornerNode, 'meta.label')).toStrictEqual('省份');
+    expect(get(cityCornerNode, 'meta.value')).toStrictEqual('城市');
+    expect(get(cityCornerNode, 'meta.label')).toStrictEqual('城市');
+  });
+
+  test('row should not be formatted', () => {
+    const rowNodes = s2.getRowNodes();
+    const provinceRowNode = rowNodes.find(({ field }) => field === 'province');
+
+    expect(provinceRowNode.label).toStrictEqual('浙江');
+    expect(provinceRowNode.value).toStrictEqual('浙江');
+  });
+
+  test('column should not be formatted', () => {
+    const colNodes = s2.getColumnNodes();
+
+    const cityColNode = colNodes.find(({ field }) => field === 'city');
+
+    expect(cityColNode.label).toStrictEqual('义乌');
+    expect(cityColNode.value).toStrictEqual('义乌');
+  });
+
+  test('data cell should render formatted value', () => {
+    const priceDataCells = s2.interaction.getPanelGroupAllDataCells();
+
+    expect(priceDataCells).not.toHaveLength(0);
+    expect(priceDataCells).toSatisfyAll(
+      (cell) => cell.getActualText() === 'price:1',
+    );
+  });
+});

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -101,16 +101,6 @@ export class ColCell extends HeaderCell {
     return { ...textStyle, textAlign, textBaseline };
   }
 
-  protected getFormattedFieldValue(): FormatResult {
-    const { label, key } = this.meta;
-    const formatter = this.headerConfig.formatter(key);
-    const content = formatter(label);
-    return {
-      formattedValue: content,
-      value: label,
-    };
-  }
-
   protected getMaxTextWidth(): number {
     const { width } = this.getContentArea();
     return width - this.getActionIconsWidth();

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -349,10 +349,6 @@ export class CornerCell extends HeaderCell {
     };
   }
 
-  protected getFormattedFieldValue(): FormatResult {
-    return { formattedValue: this.meta.label, value: this.meta.label };
-  }
-
   protected getMaxTextWidth(): number {
     const { width } = this.getContentArea();
     return width - this.getTreeIconWidth() - this.getActionIconsWidth();

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -1,6 +1,7 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { first, map, includes, find, isEqual, get, forEach } from 'lodash';
 import { shouldShowActionIcons } from 'src/utils/cell/header-cell';
+import { EXTRA_FIELD } from '@/common/constant/basic';
 import { BaseCell } from '@/cell/base-cell';
 import { InteractionStateName } from '@/common/constant/interaction';
 import { GuiIcon } from '@/common/icons';
@@ -49,11 +50,21 @@ export abstract class HeaderCell extends BaseCell<Node> {
     this.actionIcons = [];
   }
 
-  // 头部cell都不需要使用formatter进行格式化，formatter只针对于data cell
+  // 头部cell不需要使用formatter进行格式化，formatter只针对于data cell
   protected getFormattedFieldValue(): FormatResult {
-    const { label } = this.meta;
+    const { label, field } = this.meta;
+
+    if (!isEqual(field, EXTRA_FIELD)) {
+      return {
+        formattedValue: label,
+        value: label,
+      };
+    }
+
+    const fieldName = this.spreadsheet.dataSet.getFieldName(label);
+
     return {
-      formattedValue: label,
+      formattedValue: fieldName || label,
       value: label,
     };
   }

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -8,6 +8,7 @@ import {
   HeaderActionIcon,
   HeaderActionIconProps,
   CellMeta,
+  FormatResult,
 } from '@/common/interface';
 import { BaseHeaderConfig } from '@/facet/header/base';
 import { Node } from '@/facet/layout/node';
@@ -46,6 +47,15 @@ export abstract class HeaderCell extends BaseCell<Node> {
 
   protected initCell() {
     this.actionIcons = [];
+  }
+
+  // 头部cell都不需要使用formatter进行格式化，formatter只针对于data cell
+  protected getFormattedFieldValue(): FormatResult {
+    const { label } = this.meta;
+    return {
+      formattedValue: label,
+      value: label,
+    };
   }
 
   protected showActionIcons(actionIconCfg: HeaderActionIcon) {

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -303,21 +303,6 @@ export class RowCell extends HeaderCell {
     };
   }
 
-  protected getFormattedFieldValue(): FormatResult {
-    const { label } = this.meta;
-    let content = label;
-    const formatter = this.spreadsheet.dataSet.getFieldFormatter(
-      this.meta.field,
-    );
-    if (formatter) {
-      content = formatter(label);
-    }
-    return {
-      formattedValue: content,
-      value: label,
-    };
-  }
-
   protected getIconPosition() {
     const { x, y, textAlign } = this.textShape.cfg.attrs;
 

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -90,15 +90,6 @@ export class TableColCell extends ColCell {
     return `${HORIZONTAL_RESIZE_AREA_KEY_PRE}${'table-col-cell'}`;
   }
 
-  // 明细表列头不应该格式化 https://github.com/antvis/S2/issues/840
-  protected getFormattedFieldValue(): FormatResult {
-    const { label } = this.meta;
-    return {
-      formattedValue: label,
-      value: label,
-    };
-  }
-
   protected drawBackgroundShape() {
     const { backgroundColor } = this.getStyle().cell;
     this.backgroundShape = renderRect(this, {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1126,8 +1126,6 @@ export abstract class BaseFacet {
         data: this.layoutResult.colNodes,
         scrollContainsRowHeader:
           this.cfg.spreadsheet.isScrollContainsRowHeader(),
-        formatter: (field: string): Formatter =>
-          this.cfg.dataSet.getFieldFormatter(field),
         sortParam: this.cfg.spreadsheet.store.get('sortParam'),
         spreadsheet: this.spreadsheet,
       });

--- a/packages/s2-core/src/facet/header/col.ts
+++ b/packages/s2-core/src/facet/header/col.ts
@@ -7,14 +7,11 @@ import {
   FRONT_GROUND_GROUP_COL_SCROLL_Z_INDEX,
 } from '@/common/constant';
 import { ColCell } from '@/cell';
-import { Formatter } from '@/common/interface';
 import { Node } from '@/facet/layout/node';
 
 import { SpreadSheet } from '@/sheet-type/index';
 
 export interface ColHeaderConfig extends BaseHeaderConfig {
-  // format field value
-  formatter: (field: string) => Formatter;
   // corner width used when scroll {@link ColHeader#onColScroll}
   cornerWidth?: number;
   scrollContainsRowHeader?: boolean;

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -807,9 +807,6 @@ export class TableFacet extends BaseFacet {
         data: this.layoutResult.colNodes,
         scrollContainsRowHeader:
           this.cfg.spreadsheet.isScrollContainsRowHeader(),
-        formatter: (field) => {
-          return this.cfg.dataSet.getFieldFormatter(field);
-        },
         sortParam: this.cfg.spreadsheet.store.get('sortParam'),
         spreadsheet: this.spreadsheet,
       });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [x] 移除 col header中冗余的 `formatter`属性
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x]  修复头部cell错误使用meta中formatter的问题

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

```js
  meta: [
    {
      field: 'number',
      name: '数量',
    },
    {
      field: 'province',
      name: '省份',
      formatter: () => 'province',
    },
    {
      field: 'city',
      name: '城市',
      formatter: () => 'city',
    },
    {
      field: 'type',
      name: '类别',
      formatter: () => 'type',
    },
    {
      field: 'sub_type',
      name: '子类别',
    },
  ],
```

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/155101431-a6e978d8-dbee-469a-a707-067e3ab8e139.png)    | ![image](https://user-images.githubusercontent.com/17964556/155101302-71269786-c5e6-4a15-aedf-b8d7c8e36bbf.png)   |

### 🔗 Related issue link

<!-- close #0 -->
close #1014 
### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
