### PR TITLE
fix: 明细表锁行/列时分割线阴影显隐逻辑

### DIFF
--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -34,6 +34,7 @@ export const KEY_GROUP_PANEL_FROZEN_TOP = 'frozenTopGroup';
 export const KEY_GROUP_PANEL_FROZEN_BOTTOM = 'frozenBottomGroup';
 export const KEY_GROUP_ROW_RESIZE_AREA = 'rowResizeAreaGroup';
 export const KEY_GROUP_FROZEN_ROW_RESIZE_AREA = 'rowFrozenResizeAreaGroup';
+export const KEY_GROUP_FROZEN_SPLIT_LINE = 'frozenSplitLine';
 export const KEY_GROUP_ROW_INDEX_RESIZE_AREA = 'rowIndexResizeAreaGroup';
 export const KEY_GROUP_CORNER_RESIZE_AREA = 'cornerResizeAreaGroup';
 export const KEY_GROUP_COL_RESIZE_AREA = 'colResizeAreaGroup';

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -548,11 +548,16 @@ export class TableFacet extends BaseFacet {
       dataLength,
     );
 
+    // 在分页条件下需要额外处理 Y 轴滚动值
+    const relativeScrollY = Math.floor(scrollY - this.getPaginationScrollY());
+
     // scroll boundary
     const maxScrollX = Math.max(0, last(this.viewCellWidths) - viewportWidth);
     const maxScrollY = Math.max(
       0,
-      this.viewCellHeights.getTotalHeight() - viewportHeight,
+      this.viewCellHeights.getCellOffsetY(cellRange.end + 1) -
+        this.viewCellHeights.getCellOffsetY(cellRange.start) -
+        viewportHeight,
     );
 
     // remove previous splitline group
@@ -633,7 +638,7 @@ export class TableFacet extends BaseFacet {
         },
       );
 
-      if (style.showShadow && scrollY > 0) {
+      if (style.showShadow && relativeScrollY > 0) {
         splitLineGroup.addShape('rect', {
           attrs: {
             x: 0,
@@ -703,7 +708,7 @@ export class TableFacet extends BaseFacet {
         },
       );
 
-      if (style.showShadow && Math.floor(scrollY) < Math.floor(maxScrollY)) {
+      if (style.showShadow && relativeScrollY < Math.floor(maxScrollY)) {
         splitLineGroup.addShape('rect', {
           attrs: {
             x: 0,


### PR DESCRIPTION
### 👀 PR includes

- [x] Solve the issue and close #945  
### 📝 Description

修复明细表阴影逻辑，与交叉表一致 #898 遵循 ant-design 阴影逻辑。并将单次 render 分割线，改为滚动后 render，便于重绘。

### 🖼️ Screenshot

```
{
  frozenRowCount: 1,
  frozenTrailingRowCount: 1,
  frozenColCount: 1,
  frozenTrailingColCount: 1,
}
```

| Before | After |
| ------ | ----- |
|     ![CleanShot 2022-02-22 at 21 11 51](https://user-images.githubusercontent.com/6716092/155139225-fa066f9c-57ee-4d3e-86b9-632da3d5b0a6.gif)   |    ![CleanShot 2022-02-22 at 21 09 48](https://user-images.githubusercontent.com/6716092/155138947-64a3f5be-f655-4e02-b7f7-187353dc3464.gif)   |


### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
