### PR TITLE
fix: corner 事件监听失效

### DIFF
--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -187,9 +187,10 @@ export class CornerCell extends HeaderCell {
   }
 
   private drawBackgroundShape() {
-    const { backgroundColorOpacity } = this.getStyle().cell;
+    const { backgroundColorOpacity, backgroundColor } = this.getStyle().cell;
     const attrs: ShapeAttrs = {
       ...this.getCellArea(),
+      fill: backgroundColor,
       opacity: backgroundColorOpacity,
     };
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [X] Solve the issue and close #0


### 📝 Description
fix: corner 事件监听失效 (S2Event.CORNER_CELL_CLICK)
没有填充 fill 的时候， 只有点击 Corner cell 的Text 才能触发 S2Event.CORNER_CELL_CLICK 事件。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|![corner事件触发-error](https://user-images.githubusercontent.com/20497176/155467663-99eeae58-3095-41b9-9156-93e21a024835.gif)|![corner事件触发-right](https://user-images.githubusercontent.com/20497176/155467674-14e212f8-a1ce-4d0a-a83a-14f771360181.gif)|




### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
