### PR TITLE
feat: adaptive 的 container 自适应包含 header 和 page

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -193,7 +193,7 @@ describe('Scroll By Group Tests', () => {
     'should disable scroll if no scroll bar and scroll over the panel viewport by %o',
     async ({ offset }) => {
       // hide scroll bar
-      s2.changeSize(1000, 300);
+      s2.changeSheetSize(1000, 300);
       s2.render(false);
 
       const showHorizontalScrollBarSpy = jest
@@ -298,12 +298,12 @@ describe('Scroll By Group Tests', () => {
         layoutWidthType: 'compact',
       },
     });
-    s2.changeSize(100, 1000); // 横向滚动条
+    s2.changeSheetSize(100, 1000); // 横向滚动条
     s2.render(false);
     expect(s2.facet.hScrollBar.getCanvasBBox().y).toBe(220);
     expect(s2.facet.hRowScrollBar.getCanvasBBox().y).toBe(220);
 
-    s2.changeSize(1000, 150); // 纵向滚动条
+    s2.changeSheetSize(1000, 150); // 纵向滚动条
     s2.render(false);
     expect(s2.facet.vScrollBar.getCanvasBBox().x).toBe(189);
 
@@ -312,12 +312,12 @@ describe('Scroll By Group Tests', () => {
         scrollbarPosition: ScrollbarPositionType.CANVAS,
       },
     });
-    s2.changeSize(100, 1000); // 横向滚动条
+    s2.changeSheetSize(100, 1000); // 横向滚动条
     s2.render(false);
     expect(s2.facet.hScrollBar.getCanvasBBox().y).toBe(994);
     expect(s2.facet.hRowScrollBar.getCanvasBBox().y).toBe(994);
 
-    s2.changeSize(1000, 200); // 纵向滚动条
+    s2.changeSheetSize(1000, 200); // 纵向滚动条
     s2.render(false);
     expect(s2.facet.vScrollBar.getCanvasBBox().x).toBe(994);
   });

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -480,7 +480,7 @@ describe('PivotSheet Tests', () => {
   });
 
   test('should change sheet size', () => {
-    s2.changeSize(1000, 500);
+    s2.changeSheetSize(1000, 500);
 
     expect(s2.options.width).toEqual(1000);
     expect(s2.options.height).toEqual(500);

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -197,7 +197,7 @@ export abstract class BaseFacet {
   /**
    * 在每次render, 校验scroll offset是否在合法范围中
    * 比如在滚动条已经滚动到100%的状态的前提下：（ maxAvailableScrollOffsetX = colsHierarchy.width - viewportBBox.width ）
-   *     此时changeSize，sheet从 small width 变为 big width
+   *     此时changeSheetSize，sheet从 small width 变为 big width
    *     导致后者 viewport 区域更大，其结果就是后者的 maxAvailableScrollOffsetX 更小
    *     此时就需要重置 scrollOffsetX，否则就会导致滚动过多，出现空白区域
    */

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -397,6 +397,18 @@ export abstract class SpreadSheet extends EE {
   }
 
   /**
+   * @param width
+   * @param height
+   * @deprecated 该方法将会在2.0被移除
+   */
+  public changeSize(
+    width: number = this.options.width,
+    height: number = this.options.height,
+  ) {
+    this.changeSheetSize(width, height);
+  }
+
+  /**
    * 修改表格画布大小，不用重新加载数据
    * @param width
    * @param height

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -401,7 +401,7 @@ export abstract class SpreadSheet extends EE {
    * @param width
    * @param height
    */
-  public changeSize(
+  public changeSheetSize(
     width: number = this.options.width,
     height: number = this.options.height,
   ) {

--- a/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
@@ -13,9 +13,11 @@ const s2Options: S2Options = {
 describe('useResize tests', () => {
   let s2: SpreadSheet;
   let container: HTMLDivElement;
+  let wrapper: HTMLDivElement;
 
   beforeEach(() => {
     container = getContainer();
+    wrapper = getContainer();
     s2 = new PivotSheet(container, mockDataConfig, s2Options);
     s2.render();
     jest.spyOn(s2, 'buildFacet' as any).mockImplementation(() => {});
@@ -24,12 +26,13 @@ describe('useResize tests', () => {
   test('should rerender when option width or height changed and adaptive disable', () => {
     const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
     const changeSizeSpy = jest
-      .spyOn(s2, 'changeSize')
+      .spyOn(s2, 'changeSheetSize')
       .mockImplementation(() => {});
 
     const { rerender } = renderHook(() =>
       useResize({
         container,
+        wrapper,
         s2,
         adaptive: false,
       }),
@@ -61,12 +64,13 @@ describe('useResize tests', () => {
   test('should cannot change table size when width or height updated and enable adaptive', () => {
     const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
     const changeSizeSpy = jest
-      .spyOn(s2, 'changeSize')
+      .spyOn(s2, 'changeSheetSize')
       .mockImplementation(() => {});
 
     const { rerender } = renderHook(() =>
       useResize({
         container,
+        wrapper,
         s2,
         adaptive: true,
       }),

--- a/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
@@ -25,9 +25,6 @@ describe('useResize tests', () => {
 
   test('should rerender when option width or height changed and adaptive disable', () => {
     const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
-    const changeSizeSpy = jest
-      .spyOn(s2, 'changeSheetSize')
-      .mockImplementation(() => {});
 
     const { rerender } = renderHook(() =>
       useResize({
@@ -55,10 +52,8 @@ describe('useResize tests', () => {
     expect(canvas.style.height).toEqual(`200px`);
 
     expect(renderSpy).toHaveBeenCalled();
-    expect(changeSizeSpy).toHaveBeenCalled();
 
     renderSpy.mockRestore();
-    changeSizeSpy.mockRestore();
   });
 
   test('should cannot change table size when width or height updated and enable adaptive', () => {

--- a/packages/s2-react/src/components/sheets/base-sheet/index.less
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.less
@@ -1,6 +1,11 @@
 @preCls: antv-s2;
 
 .@{preCls} {
+  &-div {
+    padding: 0;
+    margin: 0;
+  }
+
   &-container {
     overflow: auto;
 

--- a/packages/s2-react/src/components/sheets/base-sheet/index.less
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.less
@@ -1,13 +1,25 @@
 @preCls: antv-s2;
 
+.ant-spin-nested-loading,
+.ant-spin-container {
+  height: 100%;
+}
+
 .@{preCls} {
   &-div {
     padding: 0;
     margin: 0;
   }
 
+  &-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
   &-container {
     overflow: auto;
+    flex: 1 1 auto;
 
     canvas {
       display: block;

--- a/packages/s2-react/src/components/sheets/base-sheet/index.less
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.less
@@ -6,12 +6,9 @@
 }
 
 .@{preCls} {
-  &-div {
+  &-wrapper {
     padding: 0;
     margin: 0;
-  }
-
-  &-wrapper {
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -17,7 +17,15 @@ import './index.less';
 export const BaseSheet = React.forwardRef(
   (props: SheetComponentsProps, ref: React.MutableRefObject<SpreadSheet>) => {
     const { dataCfg, options, header, showPagination, sheetType } = props;
-    const { s2Ref, loading, containerRef, pagination } = useSpreadSheet(props, {
+    const {
+      s2Ref,
+      loading,
+      containerRef,
+      pagination,
+      wrapRef,
+      headerRef,
+      footRef,
+    } = useSpreadSheet(props, {
       sheetType,
     });
 
@@ -37,21 +45,27 @@ export const BaseSheet = React.forwardRef(
 
     return (
       <React.StrictMode>
-        <Spin spinning={loading}>
-          {header && (
-            <Header
-              {...header}
-              sheet={s2Ref.current}
-              width={options.width}
-              dataCfg={getSafetyDataConfig(dataCfg)}
-              options={getSheetComponentOptions(options)}
-            />
-          )}
-          <div ref={containerRef} className={`${S2_PREFIX_CLS}-container`} />
-          {showPagination && (
-            <S2Pagination {...pagination} pagination={options.pagination} />
-          )}
-        </Spin>
+        <div ref={wrapRef} className={`${S2_PREFIX_CLS}-div`}>
+          <Spin spinning={loading}>
+            {header && (
+              <div ref={headerRef} className={`${S2_PREFIX_CLS}-div`}>
+                <Header
+                  {...header}
+                  sheet={s2Ref.current}
+                  width={options.width}
+                  dataCfg={getSafetyDataConfig(dataCfg)}
+                  options={getSheetComponentOptions(options)}
+                />
+              </div>
+            )}
+            <div ref={containerRef} className={`${S2_PREFIX_CLS}-container`} />
+            {showPagination && (
+              <div ref={footRef} className={`${S2_PREFIX_CLS}-div`}>
+                <S2Pagination {...pagination} pagination={options.pagination} />
+              </div>
+            )}
+          </Spin>
+        </div>
       </React.StrictMode>
     );
   },

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -39,10 +39,7 @@ export const BaseSheet = React.forwardRef(
     return (
       <React.StrictMode>
         <Spin spinning={loading}>
-          <div
-            ref={wrapRef}
-            className={`${S2_PREFIX_CLS}-div ${S2_PREFIX_CLS}-wrapper`}
-          >
+          <div ref={wrapRef} className={`${S2_PREFIX_CLS}-wrapper`}>
             {header && (
               <Header
                 {...header}

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -17,17 +17,10 @@ import './index.less';
 export const BaseSheet = React.forwardRef(
   (props: SheetComponentsProps, ref: React.MutableRefObject<SpreadSheet>) => {
     const { dataCfg, options, header, showPagination, sheetType } = props;
-    const {
-      s2Ref,
-      loading,
-      containerRef,
-      pagination,
-      wrapRef,
-      headerRef,
-      footRef,
-    } = useSpreadSheet(props, {
-      sheetType,
-    });
+    const { s2Ref, loading, containerRef, pagination, wrapRef } =
+      useSpreadSheet(props, {
+        sheetType,
+      });
 
     // 同步实例
     React.useEffect(() => {
@@ -45,27 +38,26 @@ export const BaseSheet = React.forwardRef(
 
     return (
       <React.StrictMode>
-        <div ref={wrapRef} className={`${S2_PREFIX_CLS}-div`}>
-          <Spin spinning={loading}>
+        <Spin spinning={loading}>
+          <div
+            ref={wrapRef}
+            className={`${S2_PREFIX_CLS}-div ${S2_PREFIX_CLS}-wrapper`}
+          >
             {header && (
-              <div ref={headerRef} className={`${S2_PREFIX_CLS}-div`}>
-                <Header
-                  {...header}
-                  sheet={s2Ref.current}
-                  width={options.width}
-                  dataCfg={getSafetyDataConfig(dataCfg)}
-                  options={getSheetComponentOptions(options)}
-                />
-              </div>
+              <Header
+                {...header}
+                sheet={s2Ref.current}
+                width={options.width}
+                dataCfg={getSafetyDataConfig(dataCfg)}
+                options={getSheetComponentOptions(options)}
+              />
             )}
             <div ref={containerRef} className={`${S2_PREFIX_CLS}-container`} />
             {showPagination && (
-              <div ref={footRef} className={`${S2_PREFIX_CLS}-div`}>
-                <S2Pagination {...pagination} pagination={options.pagination} />
-              </div>
+              <S2Pagination {...pagination} pagination={options.pagination} />
             )}
-          </Spin>
-        </div>
+          </div>
+        </Spin>
       </React.StrictMode>
     );
   },

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -67,7 +67,7 @@ export const useResize = (params: UseResizeEffectParams) => {
           ? round(size?.inlineSize)
           : s2?.options.width;
         const height = adaptiveHeight
-          ? container.getBoundingClientRect().height // 去除 header 和 page 后才是 sheet 真正的高度
+          ? round(container?.getBoundingClientRect().height) // 去除 header 和 page 后才是 sheet 真正的高度
           : s2?.options.height;
         if (!adaptiveWidth && !adaptiveHeight) {
           return;

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -38,7 +38,7 @@ export const useResize = (params: UseResizeEffectParams) => {
 
   const render = useCallback(
     (width: number, height: number) => {
-      s2.changeSize(width, height);
+      s2.changeSheetSize(width, height);
       s2.render(false);
       isFirstRender.current = false;
     },
@@ -50,7 +50,6 @@ export const useResize = (params: UseResizeEffectParams) => {
   // rerender by option
   React.useEffect(() => {
     if (!adaptive && s2) {
-      s2.changeSize(s2?.options.width, s2?.options.height);
       s2.render(false);
     }
   }, [s2?.options.width, s2?.options.height, adaptive, s2]);

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -7,8 +7,6 @@ import { Adaptive } from '@/components';
 export interface UseResizeEffectParams {
   container: HTMLElement; // 只包含了 sheet 容器
   wrapper: HTMLElement; // 包含了 sheet + foot(page) + header
-  header: HTMLElement;
-  foot: HTMLElement;
   s2: SpreadSheet;
   adaptive: Adaptive;
 }
@@ -28,7 +26,7 @@ function analyzeAdaptive(paramsContainer: HTMLElement, adaptive: Adaptive) {
 }
 
 export const useResize = (params: UseResizeEffectParams) => {
-  const { s2, adaptive, container, foot, header } = params;
+  const { s2, adaptive, container } = params;
   const {
     container: wrapper,
     adaptiveWidth,
@@ -70,21 +68,16 @@ export const useResize = (params: UseResizeEffectParams) => {
           ? round(size?.inlineSize)
           : s2?.options.width;
         const height = adaptiveHeight
-          ? round(size?.blockSize)
+          ? container.getBoundingClientRect().height // 去除 header 和 page 后才是 sheet 真正的高度
           : s2?.options.height;
         if (!adaptiveWidth && !adaptiveHeight) {
           return;
         }
-        const containHeight =
-          height -
-          foot.getBoundingClientRect().height -
-          header.getBoundingClientRect().height -
-          16; // padding
         if (isFirstRender.current) {
-          render(width, containHeight);
+          render(width, height);
           return;
         }
-        debounceRender(width, containHeight);
+        debounceRender(width, height);
       }
     });
 
@@ -98,8 +91,6 @@ export const useResize = (params: UseResizeEffectParams) => {
   }, [
     wrapper,
     container,
-    foot,
-    header,
     adaptiveWidth,
     adaptiveHeight,
     s2?.options.width,

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -28,8 +28,6 @@ export function useSpreadSheet(
   const s2Ref = React.useRef<SpreadSheet>();
   const containerRef = React.useRef<HTMLDivElement>();
   const wrapRef = React.useRef<HTMLDivElement>();
-  const headerRef = React.useRef<HTMLDivElement>();
-  const footRef = React.useRef<HTMLDivElement>();
 
   const { spreadsheet: customSpreadSheet, dataCfg, options, themeCfg } = props;
   const { loading, setLoading } = useLoading(s2Ref.current, props.loading);
@@ -106,8 +104,6 @@ export function useSpreadSheet(
     s2: s2Ref.current,
     container: containerRef.current,
     wrapper: wrapRef.current,
-    header: headerRef.current,
-    foot: footRef.current,
     adaptive: props.adaptive,
   });
 
@@ -115,8 +111,6 @@ export function useSpreadSheet(
     s2Ref,
     containerRef,
     wrapRef,
-    headerRef,
-    footRef,
     loading,
     setLoading,
     pagination,

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -27,6 +27,9 @@ export function useSpreadSheet(
   const forceUpdate = useUpdate();
   const s2Ref = React.useRef<SpreadSheet>();
   const containerRef = React.useRef<HTMLDivElement>();
+  const wrapRef = React.useRef<HTMLDivElement>();
+  const headerRef = React.useRef<HTMLDivElement>();
+  const footRef = React.useRef<HTMLDivElement>();
 
   const { spreadsheet: customSpreadSheet, dataCfg, options, themeCfg } = props;
   const { loading, setLoading } = useLoading(s2Ref.current, props.loading);
@@ -102,12 +105,18 @@ export function useSpreadSheet(
   useResize({
     s2: s2Ref.current,
     container: containerRef.current,
+    wrapper: wrapRef.current,
+    header: headerRef.current,
+    foot: footRef.current,
     adaptive: props.adaptive,
   });
 
   return {
     s2Ref,
     containerRef,
+    wrapRef,
+    headerRef,
+    footRef,
     loading,
     setLoading,
     pagination,

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -50,7 +50,7 @@ order: 1
 | setThemeCfg | 更新主题配置 | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme)) => void |
 | updatePagination | 更新分页 | (pagination: [Pagination](/zh/docs/api/general/S2Options#pagination)) => void |
 | getContentHeight | 获取当前表格实际内容高度 | `() => number` |
-| changeSheetSize | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |
+| changeSheetSize (别名：changeSize) | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |
 | getLayoutWidthType | 获取单元格宽度布局类型（LayoutWidthType: `adaptive（自适应）` \| `colAdaptive（列自适应）` \| `compact（紧凑）`） | () => `LayoutWidthType`|
 | getRowNodes | 获取行头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |
 | getColumnNodes | 获取列头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -50,7 +50,7 @@ order: 1
 | setThemeCfg | 更新主题配置 | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme)) => void |
 | updatePagination | 更新分页 | (pagination: [Pagination](/zh/docs/api/general/S2Options#pagination)) => void |
 | getContentHeight | 获取当前表格实际内容高度 | `() => number` |
-| changeSize | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |
+| changeSheetSize | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |
 | getLayoutWidthType | 获取单元格宽度布局类型（LayoutWidthType: `adaptive（自适应）` \| `colAdaptive（列自适应）` \| `compact（紧凑）`） | () => `LayoutWidthType`|
 | getRowNodes | 获取行头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |
 | getColumnNodes | 获取列头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |

--- a/s2-site/docs/manual/advanced/adaptive.zh.md
+++ b/s2-site/docs/manual/advanced/adaptive.zh.md
@@ -34,7 +34,7 @@ import { debounce } from 'lodash'
 const s2 = new PivotSheet(...)
 
 const debounceRender = debounce((width, height) => {
-  s2.changeSize(width, height)
+  s2.changeSheetSize(width, height)
   s2.render(false) // 不重新加载数据
 }, 200)
 
@@ -60,7 +60,7 @@ const s2 = new PivotSheet(...)
 const parent = /* 你的容器节点 */
 
 const debounceRender = debounce((width, height) => {
-  s2.changeSize(width, height)
+  s2.changeSheetSize(width, height)
   s2.render(false) // 不重新加载数据
 }, 200)
 

--- a/s2-site/docs/manual/advanced/hd-adapter.zh.md
+++ b/s2-site/docs/manual/advanced/hd-adapter.zh.md
@@ -43,7 +43,7 @@ const renderByDevicePixelRatio = (ratio = window.devicePixelRatio) => {
   const newHeight = Math.floor(height * ratio);
 
   // 内部的更新容器大小方法
-  changeSize(newWidth, newHeight);
+  changeSheetSize(newWidth, newHeight);
 };
 ```
 
@@ -83,7 +83,7 @@ const renderByZoomScale = debounce((e) => {
     const newHeight = Math.floor(height * ratio);
 
     // 内部的更新容器大小方法
-    changeSize(newWidth, newHeight);
+    changeSheetSize(newWidth, newHeight);
   }
 }, 350);
 ```

--- a/s2-site/docs/manual/faq.zh.md
+++ b/s2-site/docs/manual/faq.zh.md
@@ -75,11 +75,11 @@ const s2Options = {
 }
 ```
 
-也可以手动调用 `s2.changeSize` 根据缩放比改变图表大小，使图表和父元素缩放比保持一致
+也可以手动调用 `s2.changeSheetSize` 根据缩放比改变图表大小，使图表和父元素缩放比保持一致
 
 ```ts
 const scale = 0.8
-s2.changeSize(width * scale, height * scale)
+s2.changeSheetSize(width * scale, height * scale)
 s2.render(false)
 ```
 
@@ -138,7 +138,7 @@ const pivotSheet = new PivotSheet('#container > div[title="xx"]', dataCfg, optio
 表格不感知变化，需要更新完配置后调用一次 `render` 方法触发更新
 
 ```ts
-s2.changeSize(200, 200)
+s2.changeSheetSize(200, 200)
 s2.render(false)
 ```
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🐛 Bugfix

- [X] Solve the issue and close #1122 


### 📝 Description
1.  原本 adaptive 以下配置时，sheetComponent 自适应不包含 header 和 page， 现将 header 和 page 包含其中。

```js
 adaptive = {true} 

 adaptive={{
      width: true,
      height: false,
      getContainer: () => adaptiveRef.current // 或者使用 document.getElementById(containerId)
    }
```

2. 将 changeSize 更改为 changeSheetSize。因为 G 的 container 和 S 的 container 上都存在 changeSize 方法，在调用时，IDE会错误识别，跑单测时，引用方法出现错误的问题。（但这样是不是 break change 了 👀
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|<img width="1336" alt="image" src="https://user-images.githubusercontent.com/20497176/155474195-ec205e96-710e-4a23-b261-1d4adf7af556.png"> | <img width="1388" alt="image" src="https://user-images.githubusercontent.com/20497176/155473358-16af1ccb-a2c9-427d-aefc-1cd28be40688.png">|

### 🔗 Related issue link

<!-- close #0 -->

close #1133 

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
