### PR TITLE
fix(interaction): 修复开启复制后, 无法复制表格外的文字

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -4,6 +4,7 @@ import { createFakeSpreadSheet } from 'tests/util/helpers';
 import { EmitterType } from '@/common/interface/emitter';
 import {
   CellTypes,
+  InteractionKeyboardKey,
   InteractionStateName,
   InterceptType,
   OriginEventType,
@@ -15,10 +16,20 @@ import { RootInteraction } from '@/interaction/root';
 import { CellMeta, S2Options } from '@/common/interface';
 import { BaseFacet } from '@/facet';
 
+const MOCK_COPY_DATA = 'data';
+
 jest.mock('@/interaction/brush-selection');
 jest.mock('@/interaction/base-interaction/click/row-column-click');
 jest.mock('@/interaction/base-interaction/click/data-cell-click');
 jest.mock('@/interaction/base-interaction/hover');
+jest.mock('@/utils/export/copy', () => {
+  const originalModule = jest.requireActual('@/utils/export/copy');
+  return {
+    __esModule: true,
+    ...originalModule,
+    getSelectedData: jest.fn(() => MOCK_COPY_DATA),
+  };
+});
 
 const s2Options: S2Options = {
   width: 200,
@@ -94,6 +105,9 @@ describe('Interaction Event Controller Tests', () => {
     eventController = new EventController(
       spreadsheet as unknown as SpreadSheet,
     );
+    Object.defineProperty(eventController, 'isCanvasEffect', {
+      value: true,
+    });
   });
 
   afterEach(() => {
@@ -321,12 +335,65 @@ describe('Interaction Event Controller Tests', () => {
     expect(keyboardDown).toHaveBeenCalled();
   });
 
+  test('should copy data', () => {
+    const copied = jest.fn();
+    spreadsheet.on(S2Event.GLOBAL_COPIED, copied);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: InteractionKeyboardKey.ARROW_UP,
+        metaKey: true,
+      }),
+    );
+    expect(copied).not.toHaveBeenCalled();
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: InteractionKeyboardKey.COPY,
+        metaKey: true,
+      }),
+    );
+    expect(copied).toHaveBeenCalledWith(MOCK_COPY_DATA);
+  });
+
+  test("should dont't trigger sheet copy event", () => {
+    window.dispatchEvent(new Event('click', {}));
+
+    const copied = jest.fn();
+    spreadsheet.on(S2Event.GLOBAL_COPIED, copied);
+
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: InteractionKeyboardKey.COPY,
+        metaKey: true,
+      }),
+    );
+    expect(copied).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    { type: OriginEventType.KEY_DOWN, event: S2Event.GLOBAL_KEYBOARD_DOWN },
+    { type: OriginEventType.KEY_UP, event: S2Event.GLOBAL_KEYBOARD_DOWN },
+  ])(
+    "should dont't trigger sheet %o if not click the canvas container",
+    ({ type, event }) => {
+      // 模拟点击的不是表格区域
+      window.dispatchEvent(new Event('click', {}));
+
+      const handler = jest.fn();
+      spreadsheet.on(event, handler);
+
+      window.dispatchEvent(new KeyboardEvent(type, {}));
+      expect(handler).not.toHaveBeenCalled();
+    },
+  );
+
   test("should dont't reset if current interaction has brush selection", () => {
     spreadsheet.interaction.addIntercepts([InterceptType.BRUSH_SELECTION]);
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    document.dispatchEvent(new Event('click', {}));
+    window.dispatchEvent(new Event('click', {}));
 
     expect(spreadsheet.interaction.removeIntercepts).toHaveBeenCalled();
     expect(reset).not.toHaveBeenCalled();
@@ -340,7 +407,7 @@ describe('Interaction Event Controller Tests', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    document.dispatchEvent(
+    window.dispatchEvent(
       new MouseEvent('click', {
         clientX: 100,
         clientY: 100,
@@ -356,7 +423,7 @@ describe('Interaction Event Controller Tests', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    document.dispatchEvent(
+    window.dispatchEvent(
       new MouseEvent('click', {
         clientX: 300,
         clientY: 300,
@@ -377,7 +444,7 @@ describe('Interaction Event Controller Tests', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    document.dispatchEvent(
+    window.dispatchEvent(
       new MouseEvent('click', {
         clientX: 120,
         clientY: 120,
@@ -398,7 +465,9 @@ describe('Interaction Event Controller Tests', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: InteractionKeyboardKey.ESC }),
+    );
 
     expect(reset).toHaveBeenCalled();
     expect(spreadsheet.interaction.reset).toHaveBeenCalled();
@@ -415,7 +484,7 @@ describe('Interaction Event Controller Tests', () => {
         height: 200,
       } as DOMRect);
 
-    document.dispatchEvent(
+    window.dispatchEvent(
       new MouseEvent('click', {
         clientX: 300,
         clientY: 300,
@@ -436,7 +505,7 @@ describe('Interaction Event Controller Tests', () => {
       },
     });
 
-    document.dispatchEvent(
+    window.dispatchEvent(
       new MouseEvent('click', {
         clientX: 100,
         clientY: 100,
@@ -462,7 +531,7 @@ describe('Interaction Event Controller Tests', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    document.dispatchEvent(
+    window.dispatchEvent(
       new MouseEvent('click', {
         clientX: 120,
         clientY: 120,

--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -356,7 +356,7 @@ describe('Interaction Event Controller Tests', () => {
     expect(copied).toHaveBeenCalledWith(MOCK_COPY_DATA);
   });
 
-  test("should dont't trigger sheet copy event", () => {
+  test('should not trigger sheet copy event if outside the canvas container', () => {
     window.dispatchEvent(new Event('click', {}));
 
     const copied = jest.fn();
@@ -375,7 +375,7 @@ describe('Interaction Event Controller Tests', () => {
     { type: OriginEventType.KEY_DOWN, event: S2Event.GLOBAL_KEYBOARD_DOWN },
     { type: OriginEventType.KEY_UP, event: S2Event.GLOBAL_KEYBOARD_DOWN },
   ])(
-    "should dont't trigger sheet %o if not click the canvas container",
+    'should not trigger sheet %o if outside the canvas container',
     ({ type, event }) => {
       // 模拟点击的不是表格区域
       window.dispatchEvent(new Event('click', {}));
@@ -388,7 +388,7 @@ describe('Interaction Event Controller Tests', () => {
     },
   );
 
-  test("should dont't reset if current interaction has brush selection", () => {
+  test('should not reset if current interaction has brush selection', () => {
     spreadsheet.interaction.addIntercepts([InterceptType.BRUSH_SELECTION]);
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
@@ -399,7 +399,7 @@ describe('Interaction Event Controller Tests', () => {
     expect(reset).not.toHaveBeenCalled();
   });
 
-  test("should dont't reset if current mouse on the canvas container", () => {
+  test('should not reset if current mouse on the canvas container', () => {
     const containsMock = jest
       .spyOn(HTMLElement.prototype, 'contains')
       .mockImplementation(() => true);
@@ -473,7 +473,7 @@ describe('Interaction Event Controller Tests', () => {
     expect(spreadsheet.interaction.reset).toHaveBeenCalled();
   });
 
-  test("should dont't reset if current mouse on the tooltip and outside the canvas container", () => {
+  test('should not reset if current mouse on the tooltip and outside the canvas container', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
     spreadsheet.tooltip.container.getBoundingClientRect = () =>

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -48,6 +48,8 @@ export class EventController {
 
   public domEventListeners: EventListener[] = [];
 
+  private isCanvasEffect = false;
+
   constructor(spreadsheet: SpreadSheet) {
     this.spreadsheet = spreadsheet;
     this.bindEvents();
@@ -80,16 +82,20 @@ export class EventController {
 
     // dom events
     this.addDomEventListener(
-      document,
+      window,
       OriginEventType.CLICK,
       (event: MouseEvent) => {
         this.resetSheetStyle(event);
+        this.isCanvasEffect = this.isMouseOnTheCanvasContainer(event);
       },
     );
     this.addDomEventListener(
       window,
       OriginEventType.KEY_DOWN,
       (event: KeyboardEvent) => {
+        if (!this.isCanvasEffect) {
+          return;
+        }
         this.onKeyboardCopy(event);
         this.onKeyboardEsc(event);
         this.spreadsheet.emit(S2Event.GLOBAL_KEYBOARD_DOWN, event);
@@ -99,6 +105,9 @@ export class EventController {
       window,
       OriginEventType.KEY_UP,
       (event: KeyboardEvent) => {
+        if (!this.isCanvasEffect) {
+          return;
+        }
         this.spreadsheet.emit(S2Event.GLOBAL_KEYBOARD_UP, event);
       },
     );

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -224,9 +224,7 @@ function MainLayout() {
   const logHandler =
     (name: string) =>
     (...args: unknown[]) => {
-      if (options.debug) {
-        console.debug(name, ...args);
-      }
+      console.log(name, ...args);
     };
 
   const onColCellClick = (cellInfo: TargetCellInfo) => {
@@ -621,42 +619,48 @@ function MainLayout() {
             </Collapse.Panel>
             <Collapse.Panel header="交互配置" key="interaction">
               <Space>
-                <Switch
-                  checkedChildren="选中聚光灯开"
-                  unCheckedChildren="选中聚光灯关"
-                  checked={mergedOptions.interaction.selectedCellsSpotlight}
-                  onChange={(checked) => {
-                    updateOptions({
-                      interaction: {
-                        selectedCellsSpotlight: checked,
-                      },
-                    });
-                  }}
-                />
-                <Switch
-                  checkedChildren="hover十字器开"
-                  unCheckedChildren="hover十字器关"
-                  checked={mergedOptions.interaction.hoverHighlight}
-                  onChange={(checked) => {
-                    updateOptions({
-                      interaction: {
-                        hoverHighlight: checked,
-                      },
-                    });
-                  }}
-                />
-                <Switch
-                  checkedChildren="hover聚焦开"
-                  unCheckedChildren="hover聚焦关"
-                  checked={mergedOptions.interaction.hoverFocus}
-                  onChange={(checked) => {
-                    updateOptions({
-                      interaction: {
-                        hoverFocus: checked,
-                      },
-                    });
-                  }}
-                />
+                <Tooltip title="高亮选中单元格">
+                  <Switch
+                    checkedChildren="选中聚光灯开"
+                    unCheckedChildren="选中聚光灯关"
+                    checked={mergedOptions.interaction.selectedCellsSpotlight}
+                    onChange={(checked) => {
+                      updateOptions({
+                        interaction: {
+                          selectedCellsSpotlight: checked,
+                        },
+                      });
+                    }}
+                  />
+                </Tooltip>
+                <Tooltip title="高亮当前行列单元格">
+                  <Switch
+                    checkedChildren="hover十字器开"
+                    unCheckedChildren="hover十字器关"
+                    checked={mergedOptions.interaction.hoverHighlight}
+                    onChange={(checked) => {
+                      updateOptions({
+                        interaction: {
+                          hoverHighlight: checked,
+                        },
+                      });
+                    }}
+                  />
+                </Tooltip>
+                <Tooltip title="在数值单元格悬停800ms,显示tooltip">
+                  <Switch
+                    checkedChildren="hover聚焦开"
+                    unCheckedChildren="hover聚焦关"
+                    checked={mergedOptions.interaction.hoverFocus}
+                    onChange={(checked) => {
+                      updateOptions({
+                        interaction: {
+                          hoverFocus: checked,
+                        },
+                      });
+                    }}
+                  />
+                </Tooltip>
                 <Tooltip title="开启后,点击空白处,按下ESC键, 取消高亮, 清空选中单元格, 等交互样式">
                   <Switch
                     checkedChildren="自动重置交互样式开"
@@ -712,7 +716,6 @@ function MainLayout() {
           </Collapse>
           {render && (
             <SheetComponent
-              key="basic"
               dataCfg={dataCfg as S2DataConfig}
               options={mergedOptions as S2Options}
               sheetType={sheetType}
@@ -751,6 +754,7 @@ function MainLayout() {
               onCopied={logHandler('onCopied')}
               onLayoutColsHidden={logHandler('onLayoutColsHidden')}
               onLayoutColsExpanded={logHandler('onLayoutColsExpanded')}
+              onSelected={logHandler('onSelected')}
             />
           )}
         </TabPane>

--- a/s2-site/examples/case/data-preview/demo/index.tsx
+++ b/s2-site/examples/case/data-preview/demo/index.tsx
@@ -247,20 +247,18 @@ const App = ({ data }) => {
     interaction: {
       enableCopy: true,
       autoResetSheetStyle: false,
+      hoverFocus: false,
     },
     colCell: (item, spreadsheet, headerConfig) => {
-      let cell;
       if (item.colIndex === 0) {
-        cell = new CustomCornerCell(item, spreadsheet, headerConfig);
-      } else {
-        cell = new CustomTableColCell(
-          item,
-          spreadsheet,
-          headerConfig,
-          onIconClick,
-        );
+        return new CustomCornerCell(item, spreadsheet, headerConfig);
       }
-      return cell;
+      return new CustomTableColCell(
+        item,
+        spreadsheet,
+        headerConfig,
+        onIconClick,
+      );
     },
     customSVGIcons: [
       {
@@ -299,13 +297,6 @@ const App = ({ data }) => {
     }));
     s2Ref.current.render(true);
   }, [columns.length]);
-
-  useEffect(() => {
-    s2Ref.current.on(S2Event.GLOBAL_COPIED, (data) => {
-      message.success('复制成功');
-    });
-    return () => s2Ref.current.off(S2Event.GLOBAL_COPIED);
-  }, []);
 
   const [searchKey, setSearchKey] = useState('');
   const [searchResult, setSearchResult] = useState([]);
@@ -419,10 +410,11 @@ const App = ({ data }) => {
         onColCellClick={(e) => {
           // 最左侧列的格子点击后全选
           if (e.viewMeta.colIndex === 0) {
-            s2Ref.current?.interaction.changeState({
-              stateName: InteractionStateName.ALL_SELECTED,
-            });
+            s2Ref.current?.interaction.selectAll();
           }
+        }}
+        onCopied={() => {
+          message.success('复制成功');
         }}
       />
       <Modal

--- a/s2-site/examples/case/data-preview/index.zh.md
+++ b/s2-site/examples/case/data-preview/index.zh.md
@@ -45,7 +45,7 @@ order: 5
 
 ### 复制
 
-利用 S2 的 `S2Event.GLOBAL_COPIED` 事件，我们在用户复制成功时添加了 message 提示用户。
+监听 S2 的 `S2Event.GLOBAL_COPIED` 或者 `onCopied` 事件，在用户复制成功时进行提示。
 
 ### 列隐藏
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

只在焦点在表格区域时才触发 keydown 和 keyup 事件

1. 修复复制表格外任意文字, 依然触发表格复制事件, 导致无法复制文字的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-02-24 at 15 40 15](https://user-images.githubusercontent.com/21015895/155479792-70f679b0-b290-4979-a0ab-c169a896b544.gif) | ![Kapture 2022-02-24 at 15 38 11](https://user-images.githubusercontent.com/21015895/155479483-c6586b0e-c60b-4352-b8e1-4d81fbdfb0fa.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
