### PR TITLE
feat: :sparkles: 允许用户自定义行头单元格宽度

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/layout/row-node-width-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/row-node-width-spec.ts
@@ -1,0 +1,46 @@
+import * as mockDataConfig from 'tests/data/data-issue-372.json';
+import { getContainer } from 'tests/util/helpers';
+import { PivotSheet } from '@/sheet-type';
+import { S2Options } from '@/common';
+
+const s2options: S2Options = {
+  width: 800,
+  height: 600,
+};
+
+describe('Row width Test in grid mode', () => {
+  let s2: PivotSheet;
+  beforeEach(() => {
+    s2 = new PivotSheet(getContainer(), mockDataConfig, s2options);
+    s2.render();
+  });
+
+  test('get the correct custom width of row nodes when the layoutWidthType equals adaptive', () => {
+    const { rowNodes } = s2.facet.layoutResult;
+    expect(Math.round(rowNodes[0].width)).toBe(267);
+  });
+
+  test('get the correct custom width of row nodes when the layoutWidthType equals colAdaptive', () => {
+    s2.setOptions({
+      style: {
+        layoutWidthType: 'compact',
+        rowCfg: { width: 50 },
+      },
+    });
+    s2.render();
+    const { rowNodes } = s2.facet.layoutResult;
+    expect(rowNodes[0].width).toBe(50);
+  });
+
+  test('get the correct custom width of row nodes when the layoutWidthType equals compact', () => {
+    s2.setOptions({
+      style: {
+        layoutWidthType: 'compact',
+        rowCfg: { width: 20 },
+      },
+    });
+    s2.render();
+    const { rowNodes } = s2.facet.layoutResult;
+    expect(rowNodes[0].width).toBe(20);
+  });
+});

--- a/packages/s2-core/src/common/constant/options.ts
+++ b/packages/s2-core/src/common/constant/options.ts
@@ -22,7 +22,7 @@ export const DEFAULT_STYLE: Readonly<Style> = {
     height: 30,
   },
   rowCfg: {
-    width: 96,
+    width: null,
     widthByField: {},
     heightByField: {},
   },

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -14,12 +14,7 @@ import { getIndexRangeWithOffsets } from 'src/utils/facet';
 import { CellTypes } from 'src/common/constant/interaction';
 import { HeaderActionIcon } from 'src/common/interface/basic';
 import { shouldShowActionIcons } from 'src/utils/cell/header-cell';
-import {
-  EXTRA_FIELD,
-  LayoutWidthTypes,
-  S2Event,
-  VALUE_FIELD,
-} from '@/common/constant';
+import { EXTRA_FIELD, LayoutWidthTypes, VALUE_FIELD } from '@/common/constant';
 import { DebuggerUtil } from '@/common/debug';
 import { LayoutResult, ViewMeta } from '@/common/interface';
 import { buildHeaderHierarchy } from '@/facet/layout/build-header-hierarchy';
@@ -572,9 +567,15 @@ export class PivotFacet extends BaseFacet {
     const { rowCfg, spreadsheet } = this.cfg;
 
     const userDragWidth = get(rowCfg, `widthByField.${node.key}`);
+    const userCustomWidth = get(rowCfg, 'width');
     if (userDragWidth) {
       return userDragWidth;
     }
+
+    if (userCustomWidth) {
+      return userCustomWidth;
+    }
+
     if (spreadsheet.getLayoutWidthType() !== LayoutWidthTypes.Adaptive) {
       // compact or colAdaptive
       return this.getCompactGridRowWidth(node);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description
* 允许用户自定义平铺模式下当的行头单元格宽度（`layoutWithType` 为 `adaptive` 时除外）
* 补充单测
<!-- close #0 -->
close #1093 
