### PR TITLE
feat: 维度切换组件增加allowEmpty配置 close #533

### DIFF
--- a/packages/s2-react/src/components/switcher/dimension/index.tsx
+++ b/packages/s2-react/src/components/switcher/dimension/index.tsx
@@ -22,6 +22,7 @@ export const Dimension: FC<DimensionProps> = ({
   crossRows,
   expandable,
   expandText,
+  allowEmpty,
   items,
   droppableType,
   ...rest
@@ -31,6 +32,9 @@ export const Dimension: FC<DimensionProps> = ({
   const onUpdateExpand = (event: CheckboxChangeEvent) => {
     setExpandChildren(event.target.checked);
   };
+
+  // 开启不允许为空后，如果当前有且仅有一个item时，需要禁用拖动
+  const isDragDisabled = !allowEmpty && items.length === 1;
 
   const { text, icon: Icon } = SWITCHER_CONFIG[fieldType];
   return (
@@ -71,6 +75,7 @@ export const Dimension: FC<DimensionProps> = ({
                 item={item}
                 expandable={expandable}
                 expandChildren={expandChildren}
+                isDragDisabled={isDragDisabled}
                 {...rest}
               />
             ))}
@@ -83,6 +88,7 @@ export const Dimension: FC<DimensionProps> = ({
 };
 
 Dimension.defaultProps = {
+  allowEmpty: true,
   crossRows: false,
   expandable: false,
   expandText: i18n('展开子项'),

--- a/packages/s2-react/src/components/switcher/interface.ts
+++ b/packages/s2-react/src/components/switcher/interface.ts
@@ -16,6 +16,7 @@ export interface SwitcherState {
 }
 
 export interface SwitcherField {
+  allowEmpty?: boolean;
   expandable?: boolean;
   expandText?: string;
   selectable?: boolean;

--- a/packages/s2-react/src/components/switcher/item/index.less
+++ b/packages/s2-react/src/components/switcher/item/index.less
@@ -58,8 +58,12 @@
     margin-top: @normal-span;
   }
 
-  &.list-dragging {
+  &.dragging {
     box-shadow: 0 0 2px 1px rgba(0, 0, 0, 0.1);
+  }
+
+  &.disable-dragging {
+    cursor: not-allowed;
   }
 
   .child-items {

--- a/packages/s2-react/src/components/switcher/item/index.tsx
+++ b/packages/s2-react/src/components/switcher/item/index.tsx
@@ -24,6 +24,7 @@ export type DimensionItemProps = DimensionCommonProps & {
   index: number;
   item: SwitcherItem;
   expandChildren: boolean;
+  isDragDisabled: boolean;
 };
 
 export const DimensionItem: FC<DimensionItemProps> = ({
@@ -31,13 +32,14 @@ export const DimensionItem: FC<DimensionItemProps> = ({
   item: { id, displayName, checked = true, children = [] },
   expandable,
   expandChildren,
+  isDragDisabled,
   selectable,
   index,
   draggingItemId,
   onVisibleItemChange,
 }) => {
   return (
-    <Draggable draggableId={id} index={index}>
+    <Draggable draggableId={id} index={index} isDragDisabled={isDragDisabled}>
       {(provided, snapshot) => (
         <div
           {...provided.draggableProps}
@@ -45,7 +47,8 @@ export const DimensionItem: FC<DimensionItemProps> = ({
           className={cx(
             getSwitcherClassName(selectable ? 'checkable-list' : 'normal-list'),
             {
-              'list-dragging': snapshot.isDragging,
+              dragging: snapshot.isDragging,
+              'disable-dragging': isDragDisabled,
             },
           )}
         >

--- a/s2-site/docs/api/components/switcher.zh.md
+++ b/s2-site/docs/api/components/switcher.zh.md
@@ -27,6 +27,7 @@ order: 3
 | expandable | 是否打开展开子项的 checkbox 用于控制展开和隐藏子项 | `boolean`                         | `false`    |      |
 | expandText | 展开子项的 checkbox 对应的文字                     | `string`                          | `展开子项` |      |
 | selectable | 是否打开字段的 checkbox 用于控制显隐               | `boolean`                         | `false`    |      |
+| allowEmpty | 当前维度是否可以将全部子项拖出               | `boolean`                         | `true`    |      |
 
 ## SwitcherItem
 

--- a/s2-site/docs/manual/basic/analysis/switcher.zh.md
+++ b/s2-site/docs/manual/basic/analysis/switcher.zh.md
@@ -16,6 +16,7 @@ S2 提供开箱即用的维度切换组件 `Switcher` 。借助它，你可以�
 const switcherFields = {
   rows: {
     items: [{ id: "province" }, { id: "city" }],
+    allowEmpty: false,
   },
   columns: {
     items: [{ id: "type" }],
@@ -107,6 +108,17 @@ const field = {
 const field = {
   expandable: true,
   expandText: "展开同环比", // 默认：展开子项
+  items: [
+    /*...*/
+  ],
+};
+```
+
+* 如果当前维度在移动交互中需要至少保留一个子项不能被拖拽出去，可以设置 `allowEmpty:false`, 该属性用于控制维度是否可以将全部子项拖出到其他维度：
+
+```js
+const field = {
+  allowEmpty: false, // 默认：true
   items: [
     /*...*/
   ],

--- a/s2-site/docs/manual/basic/analysis/switcher.zh.md
+++ b/s2-site/docs/manual/basic/analysis/switcher.zh.md
@@ -125,6 +125,8 @@ const field = {
 };
 ```
 
+![allowEmpty](https://gw.alipayobjects.com/zos/antfincdn/rUmA%26o3J%26/2022-02-24%25252017.31.46.gif)
+
 ### 提交修改
 
  `Switcher` 组件在弹窗关闭后会触发 `onSubmit` 回调，且此回调会接收一个 [SwitcherResult](/zh/docs/api/components/switcher#switcherresult) 类型的参数，你可以通过该回调拿到修改后的结果。

--- a/s2-site/examples/react-component/switcher/demo/pure-switcher.tsx
+++ b/s2-site/examples/react-component/switcher/demo/pure-switcher.tsx
@@ -5,6 +5,7 @@ import { Switcher } from '@antv/s2-react';
 const switcherFields = {
   rows: {
     items: [{ id: 'province' }, { id: 'city' }],
+    allowEmpty: false,
   },
   columns: {
     items: [{ id: 'type' }],


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] 维度切换组件增加allowEmpty配置, close #533 

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [x] Switcher组件文档更新
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
通过`allowEmpty`控制当前维度最后一个子项拖拽行为：
```js
const switcherFields = {
  rows: {
    items: [{ id: 'province' }, { id: 'city' }],
    allowEmpty: false // 行头不能为空
  },
  columns: {
    items: [{ id: 'type' }],
    allowEmpty: true  // 行头可以为空
  },
  values: {
    selectable: true,
    items: [{ id: 'price' }, { id: 'cost' }],
  },
};

```
![2022-02-24 17 31 46](https://user-images.githubusercontent.com/17964556/155497473-64dd02e8-92d5-4f32-9f54-4d4be8a93830.gif)

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
