### PR TITLE
feat(tooltip): 支持自定义挂载节点

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/interaction-tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-tooltip-spec.ts
@@ -30,15 +30,19 @@ describe('Interaction Tooltip Tests', () => {
   });
 
   test('should display tooltip when data cell clicked', () => {
-    const showTooltipWithInfoSpy = jest
-      .spyOn(s2, 'showTooltipWithInfo')
-      .mockImplementation(() => {});
+    const isContains = () => {
+      return s2.tooltip.container?.classList?.contains(
+        'antv-s2-tooltip-container-show',
+      );
+    };
+
+    expect(isContains()).toBeFalsy();
 
     s2.emit(S2Event.DATA_CELL_CLICK, {
       stopPropagation() {},
     } as unknown as GEvent);
 
-    expect(showTooltipWithInfoSpy).toHaveBeenCalledTimes(1);
+    expect(isContains()).toBeTruthy();
     expect(s2.tooltip.container.style.display).not.toEqual('none');
     expect(s2.tooltip.container.style.visibility).not.toEqual('hidden');
   });

--- a/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
@@ -19,7 +19,7 @@ describe('Tooltip Tests', () => {
       .mockImplementation(() => createMockCellInfo('testId').mockCell as any);
   });
 
-  test('should render custom tooltip mount container12', async () => {
+  test('should not render tooltip in default container if disable tooltip', async () => {
     const s2 = new PivotSheet(getContainer(), mockDataConfig, {
       ...s2Options,
       tooltip: {
@@ -35,7 +35,7 @@ describe('Tooltip Tests', () => {
     s2.destroy();
   });
 
-  test('should render default tooltip container', async () => {
+  test('should render tooltip in default container', async () => {
     const s2 = new PivotSheet(getContainer(), mockDataConfig, {
       ...s2Options,
       tooltip: {
@@ -53,7 +53,7 @@ describe('Tooltip Tests', () => {
     s2.destroy();
   });
 
-  test('should render custom tooltip mount container', async () => {
+  test('should render tooltip in custom container', async () => {
     const container = document.createElement('div');
     container.id = 'custom-container';
     document.body.appendChild(container);

--- a/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
@@ -1,8 +1,6 @@
 import * as mockDataConfig from 'tests/data/simple-data.json';
-import { createMockCellInfo, getContainer } from 'tests/util/helpers';
-import { Event as CanvasEvent } from '@antv/g-canvas';
-import { S2Event } from '@/common/constant/events/basic';
-import { PivotSheet, SpreadSheet } from '@/sheet-type';
+import { getContainer } from 'tests/util/helpers';
+import { PivotSheet } from '@/sheet-type';
 import { S2Options } from '@/common/interface';
 
 const s2Options: S2Options = {
@@ -13,19 +11,15 @@ const s2Options: S2Options = {
 const CONTAINER_CLASS_NAME = 'antv-s2-tooltip-container';
 
 describe('Tooltip Tests', () => {
-  beforeEach(() => {
-    jest
-      .spyOn(SpreadSheet.prototype, 'getCell')
-      .mockImplementation(() => createMockCellInfo('testId').mockCell as any);
-  });
+  const createS2 = (tooltipOptions: S2Options['tooltip']) => {
+    return new PivotSheet(getContainer(), mockDataConfig, {
+      ...s2Options,
+      tooltip: tooltipOptions,
+    });
+  };
 
   test('should not render tooltip in default container if disable tooltip', async () => {
-    const s2 = new PivotSheet(getContainer(), mockDataConfig, {
-      ...s2Options,
-      tooltip: {
-        showTooltip: false,
-      },
-    });
+    const s2 = createS2({ showTooltip: false });
     s2.render();
 
     expect(
@@ -35,16 +29,24 @@ describe('Tooltip Tests', () => {
     s2.destroy();
   });
 
-  test('should render tooltip in default container', async () => {
-    const s2 = new PivotSheet(getContainer(), mockDataConfig, {
-      ...s2Options,
-      tooltip: {
-        showTooltip: true,
-      },
-    });
+  test('should not render tooltip in default container when hide tooltip if disable tooltip', async () => {
+    const s2 = createS2({ showTooltip: false });
     s2.render();
 
-    s2.emit(S2Event.ROW_CELL_HOVER, {} as CanvasEvent);
+    s2.hideTooltip();
+
+    expect(
+      document.querySelector(`body > .${CONTAINER_CLASS_NAME}`),
+    ).toBeFalsy();
+
+    s2.destroy();
+  });
+
+  test('should render tooltip in default container', async () => {
+    const s2 = createS2({ showTooltip: true });
+    s2.render();
+
+    s2.showTooltip({ position: { x: 0, y: 0 } });
 
     expect(
       document.querySelector(`body > div[class^="${CONTAINER_CLASS_NAME}"]`),
@@ -58,16 +60,14 @@ describe('Tooltip Tests', () => {
     container.id = 'custom-container';
     document.body.appendChild(container);
 
-    const s2 = new PivotSheet(getContainer(), mockDataConfig, {
-      ...s2Options,
-      tooltip: {
-        showTooltip: true,
-        getContainer: () => container,
-      },
+    const s2 = createS2({
+      showTooltip: true,
+      getContainer: () => container,
     });
+
     s2.render();
 
-    s2.emit(S2Event.ROW_CELL_HOVER, {} as CanvasEvent);
+    s2.showTooltip({ position: { x: 0, y: 0 } });
 
     expect(
       document.querySelector(`body > .${CONTAINER_CLASS_NAME}`),

--- a/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
@@ -1,0 +1,78 @@
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { createMockCellInfo, getContainer } from 'tests/util/helpers';
+import { Event as CanvasEvent } from '@antv/g-canvas';
+import { S2Event } from '@/common/constant/events/basic';
+import { PivotSheet, SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+
+const s2Options: S2Options = {
+  width: 300,
+  height: 200,
+};
+
+const CONTAINER_CLASS_NAME = 'antv-s2-tooltip-container';
+
+describe('Tooltip Tests', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(SpreadSheet.prototype, 'getCell')
+      .mockImplementation(() => createMockCellInfo('testId').mockCell as any);
+  });
+
+  test('should render custom tooltip mount container12', async () => {
+    const s2 = new PivotSheet(getContainer(), mockDataConfig, {
+      ...s2Options,
+      tooltip: {
+        showTooltip: false,
+      },
+    });
+    s2.render();
+
+    expect(
+      document.querySelector(`body > .${CONTAINER_CLASS_NAME}`),
+    ).toBeFalsy();
+  });
+
+  test('should render default tooltip container', async () => {
+    const s2 = new PivotSheet(getContainer(), mockDataConfig, {
+      ...s2Options,
+      tooltip: {
+        showTooltip: true,
+      },
+    });
+    s2.render();
+
+    s2.emit(S2Event.ROW_CELL_HOVER, {} as CanvasEvent);
+
+    expect(
+      document.querySelector(`body > div[class^="${CONTAINER_CLASS_NAME}"]`),
+    ).toBeTruthy();
+  });
+
+  test('should render custom tooltip mount container', async () => {
+    const container = document.createElement('div');
+    container.id = 'custom-container';
+    document.body.appendChild(container);
+
+    const s2 = new PivotSheet(getContainer(), mockDataConfig, {
+      ...s2Options,
+      tooltip: {
+        showTooltip: true,
+        getContainer: () => container,
+      },
+    });
+    s2.render();
+
+    s2.emit(S2Event.ROW_CELL_HOVER, {} as CanvasEvent);
+
+    expect(
+      document.querySelector(`body > .${CONTAINER_CLASS_NAME}`),
+    ).toBeFalsy();
+
+    expect(
+      document.querySelector(
+        `#custom-container > div[class^="${CONTAINER_CLASS_NAME}"]`,
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/tooltip-spec.ts
@@ -31,6 +31,8 @@ describe('Tooltip Tests', () => {
     expect(
       document.querySelector(`body > .${CONTAINER_CLASS_NAME}`),
     ).toBeFalsy();
+
+    s2.destroy();
   });
 
   test('should render default tooltip container', async () => {
@@ -47,6 +49,8 @@ describe('Tooltip Tests', () => {
     expect(
       document.querySelector(`body > div[class^="${CONTAINER_CLASS_NAME}"]`),
     ).toBeTruthy();
+
+    s2.destroy();
   });
 
   test('should render custom tooltip mount container', async () => {
@@ -74,5 +78,7 @@ describe('Tooltip Tests', () => {
         `#custom-container > div[class^="${CONTAINER_CLASS_NAME}"]`,
       ),
     ).toBeTruthy();
+
+    s2.destroy();
   });
 });

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line max-classes-per-file
-import { getContainer, sleep } from 'tests/util/helpers';
+import { getContainer } from 'tests/util/helpers';
 import * as dataCfg from 'tests/data/simple-data.json';
 import { Canvas, Event as GEvent } from '@antv/g-canvas';
 import { cloneDeep } from 'lodash';

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -749,11 +749,11 @@ describe('PivotSheet Tests', () => {
   test('should destroy sheet', () => {
     const facetDestroySpy = jest
       .spyOn(s2.facet, 'destroy')
-      .mockImplementation(() => {});
+      .mockImplementationOnce(() => {});
 
     const hdAdapterDestroySpy = jest
       .spyOn(s2.hdAdapter, 'destroy')
-      .mockImplementation(() => {});
+      .mockImplementationOnce(() => {});
 
     s2.render(false);
 

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -181,6 +181,8 @@ describe('PivotSheet Tests', () => {
       sheet.showTooltipWithInfo({ clientX: 0, clientY: 0 } as MouseEvent, []);
 
       expect(sheet.tooltip.container.innerHTML).toEqual(tooltipContent);
+
+      sheet.destroy();
     });
 
     test.each([
@@ -214,6 +216,8 @@ describe('PivotSheet Tests', () => {
         sheet.showTooltipWithInfo({ clientX: 0, clientY: 0 } as MouseEvent, []);
 
         expect(sheet.tooltip.container.innerHTML).toEqual(tooltipContent);
+
+        sheet.destroy();
       },
     );
 
@@ -279,6 +283,8 @@ describe('PivotSheet Tests', () => {
         expect(
           sheet.tooltip.container.contains(defaultTooltipContent),
         ).toBeFalsy();
+
+        sheet.destroy();
       },
     );
 
@@ -314,6 +320,8 @@ describe('PivotSheet Tests', () => {
         expect(
           sheet.tooltip.container.contains(methodTooltipContent),
         ).toBeTruthy();
+
+        sheet.destroy();
       },
     );
 

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -251,6 +251,8 @@ describe('PivotSheet Tests', () => {
         });
 
         expect(sheet.tooltip.container.innerHTML).toEqual(methodTooltipContent);
+
+        sheet.destroy();
       },
     );
 
@@ -369,6 +371,8 @@ describe('PivotSheet Tests', () => {
       expect(customShow).toHaveBeenCalled();
       expect(customHide).toHaveBeenCalled();
       expect(customDestroy).toHaveBeenCalled();
+
+      sheet.destroy();
     });
 
     test('should show invalid custom tooltip warning', () => {
@@ -396,6 +400,8 @@ describe('PivotSheet Tests', () => {
           sheet.tooltip as unknown
         )?.constructor?.toString()} should be extends from BaseTooltip`,
       );
+
+      sheet.destroy();
     });
   });
 

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -117,6 +117,9 @@ export const createMockCellInfo = (
   const mockCell = {
     ...mockCellViewMeta,
     getMeta: () => mockCellViewMeta,
+    update: jest.fn(),
+    getActualText: jest.fn(),
+    getFieldValue: jest.fn(),
     hideInteractionShape: jest.fn(),
   };
 

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -154,6 +154,8 @@ export interface BaseTooltipConfig<T = TooltipContentType> {
   readonly operation?: TooltipOperation;
   readonly autoAdjustBoundary?: TooltipAutoAdjustBoundary;
   readonly renderTooltip?: (spreadsheet: SpreadSheet) => BaseTooltip;
+  // Custom tooltip mount container
+  readonly getContainer?: () => HTMLElement;
 }
 
 export interface Tooltip<T = TooltipContentType> extends BaseTooltipConfig<T> {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -352,13 +352,13 @@ export abstract class SpreadSheet extends EE {
 
   public destroy() {
     this.emit(S2Event.LAYOUT_DESTROY);
-    this.facet.destroy();
+    this.facet?.destroy();
     this.hdAdapter?.destroy();
-    this.interaction.destroy();
-    this.store.clear();
+    this.interaction?.destroy();
+    this.store?.clear();
     this.destroyTooltip();
     this.clearCanvasEvent();
-    this.container.destroy();
+    this.container?.destroy();
   }
 
   /**

--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -143,8 +143,11 @@ export class BaseTooltip {
    */
   protected getContainer(): HTMLElement {
     if (!this.container) {
+      const rootContainer =
+        this.spreadsheet.options.tooltip.getContainer?.() || document.body;
       const container = document.createElement('div');
-      document.body.appendChild(container);
+
+      rootContainer.appendChild(container);
       this.container = container;
       return this.container;
     }

--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -73,6 +73,9 @@ export class BaseTooltip {
   }
 
   public hide() {
+    if (!this.container) {
+      return;
+    }
     const container = this.getContainer();
     setContainerStyle(container, {
       style: {
@@ -87,7 +90,7 @@ export class BaseTooltip {
     const container = this.getContainer();
     if (container) {
       this.resetPosition();
-      container?.remove();
+      container.remove?.();
     }
   }
 
@@ -145,11 +148,11 @@ export class BaseTooltip {
     if (!this.container) {
       const rootContainer =
         this.spreadsheet.options.tooltip.getContainer?.() || document.body;
-      const container = document.createElement('div');
 
+      const container = document.createElement('div');
       rootContainer.appendChild(container);
+
       this.container = container;
-      return this.container;
     }
     this.container.className = `${TOOLTIP_PREFIX_CLS}-container`;
     return this.container;

--- a/packages/s2-react/__tests__/spreadsheet/tooltip-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/tooltip-spec.tsx
@@ -40,7 +40,6 @@ function MainLayout() {
 describe('SheetComponent Tooltip Tests', () => {
   beforeEach(() => {
     s2?.destroy();
-    s2 = null;
   });
 
   beforeEach(() => {

--- a/s2-site/docs/common/tooltip.zh.md
+++ b/s2-site/docs/common/tooltip.zh.md
@@ -18,6 +18,7 @@ object **必选**,_default：null_ 功能描述： tooltip 配置
 | renderTooltip      | 自定义整个 tooltip, 可以继承 BaseTooltip 自己重写一些方法    | [RenderTooltip](#rendertooltip)         | -      |      |
 | content   | 自定义 tooltip 内容                                      | `React.ReactNode | Element | string |` 或者 `(cell, defaultTooltipShowOptions) => React.ReactNode | Element | string`                         | -      |      |
 | autoAdjustBoundary | 当 tooltip 超过边界时自动调整显示位置，container: 图表区域，body: 整个浏览器窗口，设置为 `null` 可关闭此功能 | `container` \| `body`                   | `body` |      |
+| getContainer | 自定义 tooltip 挂载容器，| `() => HTMLElement`                   | `document.body` |      |
 
 ### BaseTooltipConfig
 

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -55,7 +55,7 @@ const s2Options = {
 
 ### 操作配置项
 
-通过配置 `operation` 字段在 `Tooltip` 上增加操作项
+通过配置 `operation` 字段在 `Tooltip` 上增加 [操作项](/zh/docs/api/general/S2Options#tooltipoperation), 支持 [自定义](#自定义-tooltip-操作项).
 
 ```ts
 const s2Options = {
@@ -270,6 +270,22 @@ const s2Options = {
 ```
 
 <playground path='react-component/tooltip/demo/custom-operation.tsx' rid='container-custom-operations' height='300'></playground>
+
+#### 自定义 Tooltip 挂载节点
+
+默认挂载在 `body` 上，可自定义挂载位置
+
+```html
+<div class="container" />
+```
+
+```ts
+const s2Options = {
+  tooltip: {
+    getContainer: () => document.querySelector('.container')
+  }
+}
+```
 
 #### 自定义 Tooltip 类
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

1. tooltip 支持自定义挂载节点

```html
<div class="container" />
```

```ts
const s2Options = {
  tooltip: {
    getContainer: () => document.querySelector('.container')
  }
}
```

2. 修复未开启 tooltip `showTooltip: false` 时, 还是会渲染节点的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/155691511-37bd90c0-11fd-45c6-88c4-c606254880b0.png)| ![image](https://user-images.githubusercontent.com/21015895/155691481-e5fcea80-37e8-4180-9cae-5b2bf5db0bbc.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
