### PR TITLE
feat: 列头滚动场景下非维度文字支持左/右对齐

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
@@ -5,7 +5,7 @@ import {
   getContentArea,
   getMaxTextWidth,
   getTextAndFollowingIconPosition,
-  getTextAndIconAreaRangeWhenHorizontalScrolling,
+  getTextAreaRange,
   getBorderPositionAndStyle,
 } from '@/utils/cell/cell';
 
@@ -415,7 +415,7 @@ describe('Horizontal Scrolling Text Position Test', () => {
   const textWidth = 20;
   test('should get center position when content is larger than viewport', () => {
     expect(
-      getTextAndIconAreaRangeWhenHorizontalScrolling(
+      getTextAreaRange(
         {
           start: 20,
           width: 50,
@@ -429,7 +429,7 @@ describe('Horizontal Scrolling Text Position Test', () => {
   test('should get center position when content is on the left of viewport', () => {
     // reset width is enough
     expect(
-      getTextAndIconAreaRangeWhenHorizontalScrolling(
+      getTextAreaRange(
         {
           start: 50,
           width: 100,
@@ -441,7 +441,7 @@ describe('Horizontal Scrolling Text Position Test', () => {
 
     // reset width isn't enough
     expect(
-      getTextAndIconAreaRangeWhenHorizontalScrolling(
+      getTextAreaRange(
         {
           start: 90,
           width: 100,
@@ -455,7 +455,7 @@ describe('Horizontal Scrolling Text Position Test', () => {
   test('should get center position when content is on the right of viewport', () => {
     // reset width is enough
     expect(
-      getTextAndIconAreaRangeWhenHorizontalScrolling(
+      getTextAreaRange(
         {
           start: -50,
           width: 100,
@@ -467,7 +467,7 @@ describe('Horizontal Scrolling Text Position Test', () => {
 
     // reset width isn't enough
     expect(
-      getTextAndIconAreaRangeWhenHorizontalScrolling(
+      getTextAreaRange(
         {
           start: -90,
           width: 100,
@@ -480,7 +480,7 @@ describe('Horizontal Scrolling Text Position Test', () => {
 
   test('should get center position when content is inside of viewport', () => {
     expect(
-      getTextAndIconAreaRangeWhenHorizontalScrolling(
+      getTextAreaRange(
         {
           start: -50,
           width: 200,

--- a/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
@@ -5,7 +5,7 @@ import {
   getContentArea,
   getMaxTextWidth,
   getTextAndFollowingIconPosition,
-  getTextAndIconPositionWhenHorizontalScrolling,
+  getTextAndIconAreaRangeWhenHorizontalScrolling,
   getBorderPositionAndStyle,
 } from '@/utils/cell/cell';
 
@@ -415,79 +415,79 @@ describe('Horizontal Scrolling Text Position Test', () => {
   const textWidth = 20;
   test('should get center position when content is larger than viewport', () => {
     expect(
-      getTextAndIconPositionWhenHorizontalScrolling(
+      getTextAndIconAreaRangeWhenHorizontalScrolling(
         {
           start: 20,
           width: 50,
         },
         content,
         textWidth,
-      ),
+      ).start,
     ).toEqual(45);
   });
 
   test('should get center position when content is on the left of viewport', () => {
     // reset width is enough
     expect(
-      getTextAndIconPositionWhenHorizontalScrolling(
+      getTextAndIconAreaRangeWhenHorizontalScrolling(
         {
           start: 50,
           width: 100,
         },
         content,
         textWidth,
-      ),
+      ).start,
     ).toEqual(75);
 
     // reset width isn't enough
     expect(
-      getTextAndIconPositionWhenHorizontalScrolling(
+      getTextAndIconAreaRangeWhenHorizontalScrolling(
         {
           start: 90,
           width: 100,
         },
         content,
         textWidth,
-      ),
+      ).start,
     ).toEqual(90);
   });
 
   test('should get center position when content is on the right of viewport', () => {
     // reset width is enough
     expect(
-      getTextAndIconPositionWhenHorizontalScrolling(
+      getTextAndIconAreaRangeWhenHorizontalScrolling(
         {
           start: -50,
           width: 100,
         },
         content,
         textWidth,
-      ),
+      ).start,
     ).toEqual(25);
 
     // reset width isn't enough
     expect(
-      getTextAndIconPositionWhenHorizontalScrolling(
+      getTextAndIconAreaRangeWhenHorizontalScrolling(
         {
           start: -90,
           width: 100,
         },
         content,
         textWidth,
-      ),
+      ).start,
     ).toEqual(10);
   });
 
   test('should get center position when content is inside of viewport', () => {
     expect(
-      getTextAndIconPositionWhenHorizontalScrolling(
+      getTextAndIconAreaRangeWhenHorizontalScrolling(
         {
           start: -50,
           width: 200,
         },
         content,
         textWidth,
-      ),
+      ).start,
     ).toEqual(50);
   });
 

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -22,7 +22,7 @@ import { ColHeaderConfig } from '@/facet/header/col';
 import {
   getBorderPositionAndStyle,
   getTextAndFollowingIconPosition,
-  getTextAndIconAreaRangeWhenHorizontalScrolling,
+  getTextAreaRange,
   adjustColHeaderScrollingViewport,
   adjustColHeaderScrollingTextPostion,
 } from '@/utils/cell/cell';
@@ -97,7 +97,7 @@ export class ColCell extends HeaderCell {
       return textStyle;
     }
 
-    // 为方便 getTextAndIconAreaRangeWhenHorizontalScrolling 计算文字位置
+    // 为方便 getTextAreaRange 计算文字位置
     // textAlign 固定为 center
     return { ...textStyle, textAlign: 'center', textBaseline: 'middle' };
   }
@@ -177,7 +177,7 @@ export class ColCell extends HeaderCell {
       this.getActionIconsWidth() -
       (iconCount ? iconStyle.margin.right : 0);
 
-    const textAreaRange = getTextAndIconAreaRangeWhenHorizontalScrolling(
+    const textAreaRange = getTextAreaRange(
       adjustedViewport,
       { start: contentBox.x, width: contentBox.width },
       textAndIconSpace, // icon position 默认为 right

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -23,6 +23,7 @@ import {
   getBorderPositionAndStyle,
   getTextAndFollowingIconPosition,
   getTextAndIconAreaRangeWhenHorizontalScrolling,
+  adjustColHeaderScrollingViewport,
   adjustColHeaderScrollingTextPostion,
 } from '@/utils/cell/cell';
 import { renderIcon, renderLine, renderRect } from '@/utils/g-renders';
@@ -147,12 +148,13 @@ export class ColCell extends HeaderCell {
     /**
      *  p(x, y)
      *  +----------------------+            x
-     *  |                    +----------------
+     *  |                    +--------------->
      *  | viewport           | |ColCell  |
      *  |                    |-|---------+
      *  +--------------------|-+
      *                       |
      *                     y |
+     *                       v
      *
      * 将 viewport 坐标(p)映射到 col header 的坐标体系中，简化计算逻辑
      *
@@ -162,6 +164,13 @@ export class ColCell extends HeaderCell {
       width: width + (scrollContainsRowHeader ? cornerWidth : 0),
     };
 
+    const { textAlign } = this.getOriginalTextStyle();
+    const adjustedViewport = adjustColHeaderScrollingViewport(
+      viewport,
+      textAlign,
+      this.getStyle().cell?.padding,
+    );
+
     const iconCount = this.getActionIconsCount();
     const textAndIconSpace =
       this.actualTextWidth +
@@ -169,7 +178,7 @@ export class ColCell extends HeaderCell {
       (iconCount ? iconStyle.margin.right : 0);
 
     const textAreaRange = getTextAndIconAreaRangeWhenHorizontalScrolling(
-      viewport,
+      adjustedViewport,
       { start: contentBox.x, width: contentBox.width },
       textAndIconSpace, // icon position 默认为 right
     );
@@ -179,7 +188,7 @@ export class ColCell extends HeaderCell {
     const startX = adjustColHeaderScrollingTextPostion(
       textAreaRange.start,
       textAreaRange.width - textAndIconSpace,
-      this.getOriginalTextStyle().textAlign,
+      textAlign,
     );
 
     const textY = contentBox.y + contentBox.height / 2;

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -36,7 +36,8 @@ import {
 export class ColCell extends HeaderCell {
   protected headerConfig: ColHeaderConfig;
 
-  protected textAndIconPositionWhenHorizontalScrolling: Point;
+  /** 文字区域（含icon）绘制起始坐标 */
+  protected textAreaPosition: Point;
 
   public get cellType() {
     return CellTypes.COL_CELL;
@@ -113,7 +114,7 @@ export class ColCell extends HeaderCell {
     if (isLeaf) {
       return super.getIconPosition(this.getActionIconsCount());
     }
-    const position = this.textAndIconPositionWhenHorizontalScrolling;
+    const position = this.textAreaPosition;
 
     const totalSpace =
       this.actualTextWidth +
@@ -192,7 +193,7 @@ export class ColCell extends HeaderCell {
     );
 
     const textY = contentBox.y + contentBox.height / 2;
-    this.textAndIconPositionWhenHorizontalScrolling = { x: startX, y: textY };
+    this.textAreaPosition = { x: startX, y: textY };
     return {
       x: startX - textAndIconSpace / 2 + this.actualTextWidth / 2,
       y: textY,

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -179,8 +179,17 @@ export const getTextPosition = (
   textCfg: TextAlignCfg,
 ) => getTextAndFollowingIconPosition(contentBox, textCfg).text;
 
-// 获取在列头水平滚动时，text坐标，使其始终在可视区域的格子中处于居中位置
-export const getTextAndIconAreaRangeWhenHorizontalScrolling = (
+/**
+ * 在给定视窗和单元格的情况下，计算单元格文字实际绘制位置
+ * 计算遵循原则：
+ * 1. 若可视范围小，尽可能多展示文字
+ * 2. 若可视范围大，居中展示文字
+ * @param viewport 视窗坐标信息
+ * @param content content 列头单元格 content 区域坐标信息
+ * @param textWidth 文字实际绘制区域宽度（含icon）
+ * @returns 文字绘制位置
+ */
+export const getTextAreaRange = (
   viewport: AreaRange,
   content: AreaRange,
   textWidth: number,

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -96,7 +96,8 @@ export const getTextAndFollowingIconPosition = (
   const { textAlign, textBaseline } = textCfg;
   const { size, margin, position: iconPosition } = normalizeIconCfg(iconCfg);
 
-  const iconSpace = iconCount * (size + margin.left) + margin.right;
+  const iconSpace =
+    iconCount * (size + margin.left) + (iconCount ? margin.right : 0);
   let textX: number;
   let iconX: number;
 
@@ -194,7 +195,7 @@ export const getTextAndIconAreaRangeWhenHorizontalScrolling = (
      *     +----------------------+
      *     |      viewport        |
      *  +--|----------------------|--+
-     *  |  |      ColCell         |  |
+     *  |  |    cellContent       |  |
      *  +--|----------------------|--+
      *     +----------------------+
      */
@@ -203,9 +204,9 @@ export const getTextAndIconAreaRangeWhenHorizontalScrolling = (
   } else if (content.start <= viewport.start) {
     /**
      *         +-------------------+
-     *  +------|----+              |
-     *  |  ColCell  |   viewport   |
-     *  +------|----+              |
+     *  +------|------+            |
+     *  | cellContent |   viewport |
+     *  +------|------+            |
      *         +-------------------+
      */
     const restWidth = content.width - (viewport.start - content.start);
@@ -217,9 +218,9 @@ export const getTextAndIconAreaRangeWhenHorizontalScrolling = (
   } else if (contentEnd >= viewportEnd) {
     /**
      *   +-------------------+
-     *   |            +------|----+
-     *   | viewport   |  ColCell  |
-     *   |            +------|----+
+     *   |            +------|------+
+     *   | viewport   | cellContent |
+     *   |            +------|------+
      *   +-------------------+
      */
     const restWidth = content.width - (contentEnd - viewportEnd);
@@ -230,11 +231,11 @@ export const getTextAndIconAreaRangeWhenHorizontalScrolling = (
     availableContentWidth = restWidth;
   } else {
     /**
-     *   +--------------------------+
-     *   |  +-----------+           |
-     *   |  |  ColCell  |  viewport |
-     *   |  +-----------+           |
-     *   +--------------------------+
+     *   +----------------------------+
+     *   |  +-------------+           |
+     *   |  | cellContent |  viewport |
+     *   |  +-------------+           |
+     *   +----------------------------+
      */
     position = content.start + content.width / 2;
     availableContentWidth = content.width;
@@ -317,6 +318,52 @@ export const getBorderPositionAndStyle = (
     },
     style: borderStyle,
   };
+};
+
+/**
+ * 根据单元格文字样式调整 viewport range，使文字在滚动时不会贴边展示
+ *
+ * 以 textAlign=left 情况为例，由大到小的矩形分别是 viewport、cellContent、cellText
+ * 左图是未调整前，滚动相交判定在 viewport 最左侧，即 colCell 滚动到 viewport 左侧后，文字会贴左边绘制
+ * 右图是调整后，range.start 提前了 padding.left 个元素，文字与 viewport 有一定间隙更加美观
+ *
+ *    range.start                                   range.start
+ *         |                                             |
+ *         |      range.width                            |  range.width
+ *         v<---------------------->                     v<------------------>
+ *
+ *         +-----------------------+                 +-----------------------+
+ *         |       viewport        |                 |       viewport        |
+ *     +-------------------+       |             +-------------------+       |
+ *     |   +---------+     |       |             |   |   +---------+ |       |
+ *     |   |  text   |     |       |             |   |   |  text   | |       |
+ *     |   +---------+     |       |             |   |   +---------+ |       |
+ *     +-------------------+       |             +-------------------+       |
+ *         +-----------------------+                 +-----------------------+
+ *
+ *                                                   <-->
+ *                                                padding.left
+ *
+ * @param viewport 原始 viewport
+ * @param textAlign 文字样式
+ * @param textPadding 单元格 padding 样式
+ * @returns viewport range
+ */
+export const adjustColHeaderScrollingViewport = (
+  viewport: AreaRange,
+  textAlign: TextAlign,
+  textPadding: Padding = { left: 0, right: 0 },
+) => {
+  const nextViewport = { ...viewport };
+
+  if (textAlign === 'left') {
+    nextViewport.start += textPadding.left;
+    nextViewport.width -= textPadding.left;
+  } else if (textAlign === 'right') {
+    nextViewport.width -= textPadding.right;
+  }
+
+  return nextViewport;
 };
 
 /**

--- a/s2-site/docs/manual/advanced/custom/cell-align.zh.md
+++ b/s2-site/docs/manual/advanced/custom/cell-align.zh.md
@@ -2,18 +2,15 @@
 title: 自定义单元格对齐方式
 order: 4
 ---
-> 在阅读本节内容前，请保持你已经阅读 [主题配置](/zh/docs/manual/basic/theme) 文档
+> 在阅读本节内容前，请确保你已经阅读 [主题配置](/zh/docs/manual/basic/theme) 文档
 
-S2 中单元格排序有两个大的原则：
-
-* 行头和列头滑动居中，保证可见性
-* 列头子节点和数据单元格对齐方式保持一致，保持整体展示的一致性
+为方便用户查看数据，S2 交叉表会在滑动过程中，保证行头和列头的最大可见性
   
 ![img](https://gw.alipayobjects.com/zos/antfincdn/avyf3tcnW/2022-02-23%25252016.38.05.gif)
 
-因此，单元格的对齐方式是有一定限制的。下面分别介绍每个类型单元格可以自定义的对齐行为。
+因此，S2 对单元格的对齐方式有一定限制。下面分别介绍每个类型单元格可以自定义的对齐行为。
 
-## 角头对齐
+## 角头对齐方式
 
 * 行头单元格（红色部分）对齐方式受 [bolderText](/zh/docs/api/general/S2Theme#defaultcelltheme) 控制
 * 列头单元格（蓝色部分）对齐方式受 [text](/zh/docs/api/general/S2Theme#defaultcelltheme) 控制
@@ -82,7 +79,7 @@ cornerCell: {
   </tbody>
 </table>
 
-## 行头对齐
+## 行头对齐方式
 
 * 非叶子节点和小计总计单元格（红色部分）对齐方式受 [bolderText](/zh/docs/api/general/S2Theme#defaultcelltheme) 控制
 * 叶子节点单元格（蓝色部分）对齐方式受 [text](/zh/docs/api/general/S2Theme#defaultcelltheme) 控制
@@ -153,7 +150,74 @@ rowCell: {
 
 ## 列头对齐方式
 
-由于滑动居中的特性，列头非叶子节点单元格的 `textBaseline` 被内部规定为 `top`，`textAlign` 被内部规定为 `center`；叶子节点单元格对齐方式和数据单元格保持一致，所以无法为其自定义对齐方式。
+为保证滑动下最大可见的特性，列头非叶子节点单元格的 `textBaseline` 被内部规定为 `middle`，`textAlign` 不受限制可按需要自定义。
+
+* 指标单元格（红色部分）对齐方式受 [bolderText](/zh/docs/api/general/S2Theme#defaultcelltheme) 控制
+* 其他维度单元格（蓝色部分）对齐方式受 [text](/zh/docs/api/general/S2Theme#defaultcelltheme) 控制
+
+<image alt="col cell align desc" src="https://gw.alipayobjects.com/zos/antfincdn/Jr7Gv9LQ9/1969f010-2bae-4b38-b06f-2935b2c69d1d.png" width="400" />
+
+列头单元格的三种对齐方式效果如下：
+
+<table style="width: 100%; outline: none; border-collapse: collapse;">
+  <colgroup>
+    <col width="20%"/>
+    <col width="80%" />
+  </colgroup>
+  <tbody>
+    <tr>
+      <td style="text-align: center;">
+        <pre class="language-js">
+colCell: {
+  text: {
+    textAlign: 'left',
+  },
+  bolderText: {
+    textAlign: 'left',
+  }
+}
+        </pre>
+      </td>
+      <td>
+        <img height="180" alt="left" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/nioLivnuF/CleanShot%2525202022-03-03%252520at%25252017.53.49.gif">
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align: center;">
+         <pre class="language-js">
+colCell: {
+  text: {
+    textAlign: 'center',
+  },
+  bolderText: {
+    textAlign: 'center',
+  }
+}
+        </pre>
+      </td>
+      <td>
+        <img height="180" alt="center" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/kn9Y4FGAb/CleanShot%2525202022-03-03%252520at%25252018.00.06.gif">
+      </td>
+    </tr>
+    <tr>
+      <td style="text-align: center;">
+               <pre class="language-js">
+colCell: {
+  text: {
+    textAlign: 'right',
+  },
+  bolderText: {
+    textAlign: 'right',
+  }
+}
+        </pre>
+      </td>
+      <td>
+        <img height="180" alt="right" style="max-height: unset;" src="https://gw.alipayobjects.com/zos/antfincdn/LAv2EKaGS/CleanShot%2525202022-03-03%252520at%25252018.01.33.gif">
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## 数据单元格对齐方式
 


### PR DESCRIPTION
### 👀 PR includes

✨ Feature

- [x] New feature

### 📝 Description
- 列头值维度 textStyle
  - before：取数据格 dataCell 的 textStyle
  - after：取列头 colCell 的 textStyle
- 列头非叶子节点支持滚动情况下始终居中
  - before：只支持 center 居中
  - after：新支持 left 和 right

### 🖼️ Screenshot

#### Before
- colCell.textAlign 不支持 left、right 
- dataCell.textAlign 会影响 colCell 指标 align

| 表格紧凑不滚动时效果 | 表格宽松滚动时效果 |
| ------ | ----- |
|    ![CleanShot 2022-03-02 at 17 47 30](https://user-images.githubusercontent.com/6716092/156337178-8cbdda78-0968-4157-ba50-a0c4d1873cb6.gif)    | ![CleanShot 2022-03-02 at 17 46 07](https://user-images.githubusercontent.com/6716092/156336969-3c19f065-a24e-4c98-a8a6-478b44768c0d.gif)   |

#### After
为方便对比效果，colCell.cell.padding 设置为 `left=10`、`right: 30`

| 表格紧凑不滚动时效果 | 表格宽松滚动时效果（textAlign 各取 left、center、right） |
| ------ | ----- |
|  ![CleanShot 2022-03-03 at 15 58 29](https://user-images.githubusercontent.com/6716092/156521581-0bbc92b9-c26f-43da-89b8-94ee2f31ed31.gif)   |  ![CleanShot 2022-03-03 at 15 54 33](https://user-images.githubusercontent.com/6716092/156521009-8204524b-c802-4b03-9b43-0b8d4bf1a69f.gif)  |
|   无  |  ![CleanShot 2022-03-03 at 15 55 59](https://user-images.githubusercontent.com/6716092/156521192-dd549207-6621-4f22-9c0f-c78e735d9308.gif)  |
|   无  |  ![CleanShot 2022-03-03 at 15 57 02](https://user-images.githubusercontent.com/6716092/156521344-c51781bf-1b49-4f36-b3ff-82a69ee5345b.gif)  |


### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
