### PR TITLE
fix: 开启 adaptive 时，options 更改后, 宽高不跟随 wrapperRef 的宽高改变

### DIFF
--- a/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
@@ -23,6 +23,41 @@ describe('useResize tests', () => {
     jest.spyOn(s2, 'buildFacet' as any).mockImplementation(() => {});
   });
 
+  test('should rerender when option width or height changed and adaptive disable', () => {
+    const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
+
+    const { rerender } = renderHook(() =>
+      useResize({
+        container,
+        wrapper,
+        s2,
+        adaptive: false,
+        optionWidth: s2Options.width,
+        optionHeight: s2Options.height,
+      }),
+    );
+
+    expect(s2.options.width).toEqual(s2Options.width);
+    expect(s2.options.height).toEqual(s2Options.height);
+
+    act(() => {
+      s2.setOptions({ width: 300, height: 400 });
+    });
+
+    rerender();
+
+    const canvas = s2.container.get('el') as HTMLCanvasElement;
+    expect(s2.options.width).toEqual(300);
+    expect(s2.options.height).toEqual(400);
+
+    expect(canvas.style.width).toEqual(`200px`);
+    expect(canvas.style.height).toEqual(`200px`);
+
+    expect(renderSpy).toHaveBeenCalled();
+
+    renderSpy.mockRestore();
+  });
+
   test('should cannot change table size when width or height updated and enable adaptive', () => {
     const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
     const changeSizeSpy = jest
@@ -35,6 +70,8 @@ describe('useResize tests', () => {
         wrapper,
         s2,
         adaptive: true,
+        optionWidth: s2Options.width,
+        optionHeight: s2Options.height,
       }),
     );
 

--- a/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
@@ -45,7 +45,7 @@ describe('useResize tests', () => {
     });
 
     rerender();
-
+    // adaptive 为 false 时，options.width、 options.height 修改, 不会触发 useResize 中的 render
     const canvas = s2.container.get('el') as HTMLCanvasElement;
     expect(s2.options.width).toEqual(300);
     expect(s2.options.height).toEqual(400);
@@ -53,7 +53,7 @@ describe('useResize tests', () => {
     expect(canvas.style.width).toEqual(`200px`);
     expect(canvas.style.height).toEqual(`200px`);
 
-    expect(renderSpy).toHaveBeenCalled();
+    expect(renderSpy).not.toHaveBeenCalled();
 
     renderSpy.mockRestore();
   });

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -8,6 +8,8 @@ export interface UseResizeEffectParams {
   wrapper: HTMLDivElement; // 包含了 sheet + foot(page) + header
   s2: SpreadSheet;
   adaptive: Adaptive;
+  optionWidth: number;
+  optionHeight: number;
 }
 
 const RENDER_DELAY = 200; // ms
@@ -25,7 +27,7 @@ function analyzeAdaptive(paramsContainer: HTMLElement, adaptive: Adaptive) {
 }
 
 export const useResize = (params: UseResizeEffectParams) => {
-  const { s2, adaptive, container } = params;
+  const { s2, adaptive, container, optionWidth, optionHeight } = params;
   const {
     container: wrapper,
     adaptiveWidth,
@@ -47,19 +49,17 @@ export const useResize = (params: UseResizeEffectParams) => {
   const debounceRender = debounce(render, RENDER_DELAY);
 
   React.useLayoutEffect(() => {
-    if (!wrapper || !adaptive || !container) {
+    const isSetResize = wrapper && container && adaptive;
+    if (!isSetResize) {
       return;
     }
-
     const resizeObserver = new ResizeObserver(([entry] = []) => {
       if (entry) {
         const [size] = entry.borderBoxSize || [];
-        const width = adaptiveWidth
-          ? round(size?.inlineSize)
-          : s2?.options.width;
+        const width = adaptiveWidth ? round(size?.inlineSize) : optionHeight;
         const height = adaptiveHeight
           ? round(container?.getBoundingClientRect().height) // 去除 header 和 page 后才是 sheet 真正的高度
-          : s2?.options.height;
+          : optionHeight;
         if (!adaptiveWidth && !adaptiveHeight) {
           return;
         }
@@ -84,8 +84,8 @@ export const useResize = (params: UseResizeEffectParams) => {
     adaptive,
     adaptiveWidth,
     adaptiveHeight,
-    s2?.options.width,
-    s2?.options.height,
+    optionWidth,
+    optionHeight,
     render,
   ]);
 };

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -105,6 +105,8 @@ export function useSpreadSheet(
     container: containerRef.current,
     wrapper: wrapRef.current,
     adaptive: props.adaptive,
+    optionWidth: options.width,
+    optionHeight: options.height,
   });
 
   return {

--- a/s2-site/docs/manual/advanced/adaptive.zh.md
+++ b/s2-site/docs/manual/advanced/adaptive.zh.md
@@ -81,6 +81,8 @@ resizeObserver.observe(parent);
 
 如果是使用 `@antv/s2-react` 的方式，可以配置 `adaptive` 参数开启自适应。
 
+### Adaptive
+
 ```ts
 // `adaptive` 的类型 `Adaptive`
 type Adaptive =
@@ -92,7 +94,10 @@ type Adaptive =
     }
 ```
 
-配置为 `boolean` 值时，容器默认为内部的 container, 宽高都自适应
+配置为 `boolean` 值时:
+
+true: 容器默认为内部的 container, 只有宽度自适应，高度以 options 设置的为准。
+false: 宽高都以 options 设置的为准。
 
 ```tsx
 import { SheetComponent } from '@antv/s2-react';


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #1159 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
