### PR TITLE
perf(useResize): :zap: 减少当 adaptive 为false时宽高改变引发的重复渲染

### DIFF
--- a/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useResize-spec.ts
@@ -23,39 +23,6 @@ describe('useResize tests', () => {
     jest.spyOn(s2, 'buildFacet' as any).mockImplementation(() => {});
   });
 
-  test('should rerender when option width or height changed and adaptive disable', () => {
-    const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
-
-    const { rerender } = renderHook(() =>
-      useResize({
-        container,
-        wrapper,
-        s2,
-        adaptive: false,
-      }),
-    );
-
-    expect(s2.options.width).toEqual(s2Options.width);
-    expect(s2.options.height).toEqual(s2Options.height);
-
-    act(() => {
-      s2.setOptions({ width: 300, height: 400 });
-    });
-
-    rerender();
-
-    const canvas = s2.container.get('el') as HTMLCanvasElement;
-    expect(s2.options.width).toEqual(300);
-    expect(s2.options.height).toEqual(400);
-
-    expect(canvas.style.width).toEqual(`200px`);
-    expect(canvas.style.height).toEqual(`200px`);
-
-    expect(renderSpy).toHaveBeenCalled();
-
-    renderSpy.mockRestore();
-  });
-
   test('should cannot change table size when width or height updated and enable adaptive', () => {
     const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
     const changeSizeSpy = jest

--- a/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { PivotSheet, S2Options } from '@antv/s2';
+import { getContainer } from 'tests/util/helpers';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { useSpreadSheet } from '@/hooks';
+
+const s2Options: S2Options = {
+  width: 200,
+  height: 200,
+  hdAdapter: false,
+};
+
+describe('useSpreadSheet tests', () => {
+  const container = getContainer();
+
+  test('should build spreadSheet', () => {
+    const { result } = renderHook(() =>
+      useSpreadSheet(
+        {
+          spreadsheet: () =>
+            new PivotSheet(container, mockDataConfig, s2Options),
+          options: s2Options,
+          dataCfg: mockDataConfig,
+        },
+        { sheetType: 'pivot' },
+      ),
+    );
+    expect(result.current.s2Ref).toBeDefined();
+  });
+
+  test('should cannot change table size when width or height updated and disable adaptive', () => {
+    const { result } = renderHook(() =>
+      useSpreadSheet(
+        {
+          spreadsheet: () =>
+            new PivotSheet(container, mockDataConfig, s2Options),
+          options: s2Options,
+          dataCfg: mockDataConfig,
+          adaptive: false,
+        },
+        { sheetType: 'pivot' },
+      ),
+    );
+    const s2 = result.current.s2Ref.current;
+
+    expect(s2.options.width).toEqual(s2Options.width);
+    expect(s2.options.height).toEqual(s2Options.height);
+    act(() => {
+      s2.setOptions({ width: 300, height: 400 });
+    });
+
+    const canvas = s2.container.get('el') as HTMLCanvasElement;
+    expect(s2.options.width).toEqual(300);
+    expect(s2.options.height).toEqual(400);
+
+    expect(canvas.style.width).toEqual(`200px`);
+    expect(canvas.style.height).toEqual(`200px`);
+  });
+});

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import React, { useCallback } from 'react';
 import { debounce, round } from 'lodash';
 import type { SpreadSheet } from '@antv/s2';
@@ -47,14 +46,6 @@ export const useResize = (params: UseResizeEffectParams) => {
 
   const debounceRender = debounce(render, RENDER_DELAY);
 
-  // rerender by option
-  React.useEffect(() => {
-    if (!adaptive && s2) {
-      s2.render(false);
-    }
-  }, [s2?.options.width, s2?.options.height, adaptive, s2]);
-
-  // rerender by container resize or window resize
   React.useLayoutEffect(() => {
     if (!wrapper || !adaptive || !container) {
       return;
@@ -90,6 +81,7 @@ export const useResize = (params: UseResizeEffectParams) => {
   }, [
     wrapper,
     container,
+    adaptive,
     adaptiveWidth,
     adaptiveHeight,
     s2?.options.width,


### PR DESCRIPTION
### 👀 PR includes


🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [x] Improve the performance
- [ ] Type optimization

### 📝 Description
options 改变时在 useSpreadSheet 中已经 render 过一次了，useResize 里不需要重复 render
![image](https://user-images.githubusercontent.com/10885578/157437907-765eb8a5-537b-4f3b-94b0-b624ede521aa.png)


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌  ![image](https://user-images.githubusercontent.com/10885578/157438106-d4aa1692-dcf4-4f17-a69b-7b52793e56fd.png) | ✅  ![image](https://user-images.githubusercontent.com/10885578/157438135-51638d36-c06a-481a-a765-5244a6439164.png)|
