### PR TITLE
feat(derection): 方向键加快捷键操作

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -342,8 +342,7 @@ describe('Interaction Event Controller Tests', () => {
 
     window.dispatchEvent(
       new KeyboardEvent('keydown', {
-        key: InteractionKeyboardKey.ARROW_UP,
-        metaKey: true,
+        key: InteractionKeyboardKey.ESC,
       }),
     );
     expect(copied).not.toHaveBeenCalled();

--- a/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
@@ -71,6 +71,9 @@ describe('Interaction Keyboard Move Tests', () => {
   test('should move selected cell right', () => {
     s2.interaction.changeState = jest.fn((state) => {});
     s2.interaction.getCells = () => [mockCell00.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell00.mockCell;
+    keyboardMove.endCell = mockCell00.mockCell;
 
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.ARROW_RIGHT,
@@ -92,6 +95,9 @@ describe('Interaction Keyboard Move Tests', () => {
   test('should move selected cell left', () => {
     s2.interaction.changeState = jest.fn((state) => {});
     s2.interaction.getCells = () => [mockCell01.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell01.mockCell;
+    keyboardMove.endCell = mockCell01.mockCell;
 
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.ARROW_LEFT,
@@ -114,6 +120,9 @@ describe('Interaction Keyboard Move Tests', () => {
   test('should move selected cell up', () => {
     s2.interaction.changeState = jest.fn((state) => {});
     s2.interaction.getCells = () => [mockCell10.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell10.mockCell;
+    keyboardMove.endCell = mockCell10.mockCell;
 
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.ARROW_UP,
@@ -136,6 +145,9 @@ describe('Interaction Keyboard Move Tests', () => {
   test('should move selected cell down', () => {
     s2.interaction.changeState = jest.fn((state) => {});
     s2.interaction.getCells = () => [mockCell01.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell01.mockCell;
+    keyboardMove.endCell = mockCell01.mockCell;
 
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.ARROW_DOWN,

--- a/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
@@ -166,4 +166,125 @@ describe('Interaction Keyboard Move Tests', () => {
     } as KeyboardEvent);
     expect(s2.interaction.changeState).not.toBeCalled();
   });
+
+  test('should move selected with meta', () => {
+    s2.interaction.changeState = jest.fn((state) => {});
+    s2.interaction.getCells = () => [mockCell00.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell00.mockCell;
+    keyboardMove.endCell = mockCell00.mockCell;
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_RIGHT,
+      metaKey: true,
+    } as KeyboardEvent);
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [{ colIndex: 1, id: '0-1', rowIndex: 0, type: 'dataCell' }],
+      stateName: 'selected',
+    });
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_DOWN,
+      metaKey: true,
+    } as KeyboardEvent);
+
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [{ colIndex: 1, id: '1-1', rowIndex: 1, type: 'dataCell' }],
+      stateName: 'selected',
+    });
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_LEFT,
+      metaKey: true,
+    } as KeyboardEvent);
+
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [{ colIndex: 0, id: '1-0', rowIndex: 1, type: 'dataCell' }],
+      stateName: 'selected',
+    });
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_UP,
+      metaKey: true,
+    } as KeyboardEvent);
+
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [{ colIndex: 1, id: '0-1', rowIndex: 0, type: 'dataCell' }],
+      stateName: 'selected',
+    });
+  });
+
+  test('should move selected with shift', () => {
+    s2.interaction.changeState = jest.fn((state) => {});
+    s2.interaction.getCells = () => [mockCell00.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell00.mockCell;
+    keyboardMove.endCell = mockCell00.mockCell;
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_RIGHT,
+      shiftKey: true,
+    } as KeyboardEvent);
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [
+        { colIndex: 0, id: '0-0', rowIndex: 0, type: 'dataCell' },
+        { colIndex: 1, id: '0-1', rowIndex: 0, type: 'dataCell' },
+      ],
+      stateName: 'selected',
+    });
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_DOWN,
+      shiftKey: true,
+    } as KeyboardEvent);
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [
+        { colIndex: 0, id: '0-0', rowIndex: 0, type: 'dataCell' },
+        { colIndex: 1, id: '0-1', rowIndex: 0, type: 'dataCell' },
+        { colIndex: 0, id: '1-0', rowIndex: 1, type: 'dataCell' },
+        { colIndex: 1, id: '1-1', rowIndex: 1, type: 'dataCell' },
+      ],
+      stateName: 'selected',
+    });
+  });
+
+  test('should move selected with shift and meta', () => {
+    s2.interaction.changeState = jest.fn((state) => {});
+    s2.interaction.getCells = () => [mockCell00.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell00.mockCell;
+    keyboardMove.endCell = mockCell00.mockCell;
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_RIGHT,
+      shiftKey: true,
+      metaKey: true,
+    } as KeyboardEvent);
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [
+        { colIndex: 0, id: '0-0', rowIndex: 0, type: 'dataCell' },
+        { colIndex: 1, id: '0-1', rowIndex: 0, type: 'dataCell' },
+      ],
+      stateName: 'selected',
+    });
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_DOWN,
+      shiftKey: true,
+    } as KeyboardEvent);
+    expect(s2.interaction.changeState).toBeCalled();
+    expect(s2.interaction.changeState).toBeCalledWith({
+      cells: [
+        { colIndex: 0, id: '0-0', rowIndex: 0, type: 'dataCell' },
+        { colIndex: 1, id: '0-1', rowIndex: 0, type: 'dataCell' },
+        { colIndex: 0, id: '1-0', rowIndex: 1, type: 'dataCell' },
+        { colIndex: 1, id: '1-1', rowIndex: 1, type: 'dataCell' },
+      ],
+      stateName: 'selected',
+    });
+  });
 });

--- a/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
@@ -78,11 +78,13 @@ describe('State Controller Utils Tests', () => {
     setState(mockInstance, {
       stateName: InteractionStateName.SELECTED,
       interactedCells: [mockRowCell],
+      cells: [getCellMeta(mockRowCell)],
     });
 
     expect(mockInstance.interaction.getState()).toEqual({
       stateName: InteractionStateName.SELECTED,
       interactedCells: [mockRowCell],
+      cells: [getCellMeta(mockRowCell)],
     });
 
     clearState(mockInstance);

--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -12,6 +12,7 @@ import {
 import { S2CellType, ViewMeta } from '@/common/interface';
 import { DataCell } from '@/cell';
 import { Node } from '@/facet/layout/node';
+import { getRangeIndex } from '@/utils/interaction/select-event';
 
 export class RangeSelection extends BaseEvent implements BaseEventImplement {
   private isRangeSelection = false;
@@ -56,23 +57,6 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
     });
   }
 
-  private getShiftSelectRange(start: ViewMeta, end: ViewMeta) {
-    const minRowIndex = Math.min(start.rowIndex, end.rowIndex);
-    const maxRowIndex = Math.max(start.rowIndex, end.rowIndex);
-    const minColIndex = Math.min(start.colIndex, end.colIndex);
-    const maxColIndex = Math.max(start.colIndex, end.colIndex);
-    return {
-      start: {
-        rowIndex: minRowIndex,
-        colIndex: minColIndex,
-      },
-      end: {
-        rowIndex: maxRowIndex,
-        colIndex: maxColIndex,
-      },
-    };
-  }
-
   private bindDataCellClick() {
     this.spreadsheet.on(S2Event.DATA_CELL_CLICK, (event: Event) => {
       event.stopPropagation();
@@ -93,7 +77,7 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
         return;
       }
 
-      const { start, end } = this.getShiftSelectRange(
+      const { start, end } = getRangeIndex(
         lastClickedCell.getMeta() as ViewMeta,
         cell.getMeta(),
       );
@@ -148,7 +132,7 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
           this.spreadsheet.facet.layoutResult.rowsHierarchy.maxLevel,
           this.spreadsheet.facet.layoutResult.colsHierarchy.maxLevel,
         ];
-        const { start, end } = this.getShiftSelectRange(
+        const { start, end } = getRangeIndex(
           lastCell.getMeta() as ViewMeta,
           cell.getMeta() as ViewMeta,
         );

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -1,4 +1,10 @@
-import { S2CellType } from '@/common/interface';
+import {
+  InteractionStateName,
+  INTERACTION_STATE_INFO_KEY,
+  S2Event,
+} from '@/common/constant';
+import { CellMeta, S2CellType, ViewMeta } from '@/common/interface';
+import { SpreadSheet } from '@/sheet-type';
 
 export const getCellMeta = (cell: S2CellType) => {
   const meta = cell.getMeta();
@@ -10,3 +16,29 @@ export const getCellMeta = (cell: S2CellType) => {
     type: cell.cellType,
   };
 };
+
+export const selectCells = (spreadsheet: SpreadSheet, cells: CellMeta[]) => {
+  const { interaction } = spreadsheet;
+  interaction.changeState({
+    stateName: InteractionStateName.SELECTED,
+    cells,
+  });
+  spreadsheet.emit(S2Event.GLOBAL_SELECTED, interaction.getActiveCells());
+};
+
+export function getRangeIndex<T extends CellMeta | ViewMeta>(start: T, end: T) {
+  const minRowIndex = Math.min(start.rowIndex, end.rowIndex);
+  const maxRowIndex = Math.max(start.rowIndex, end.rowIndex);
+  const minColIndex = Math.min(start.colIndex, end.colIndex);
+  const maxColIndex = Math.max(start.colIndex, end.colIndex);
+  return {
+    start: {
+      rowIndex: minRowIndex,
+      colIndex: minColIndex,
+    },
+    end: {
+      rowIndex: maxRowIndex,
+      colIndex: maxColIndex,
+    },
+  };
+}

--- a/packages/s2-core/src/utils/interaction/state-controller.ts
+++ b/packages/s2-core/src/utils/interaction/state-controller.ts
@@ -15,8 +15,9 @@ export const clearState = (spreadsheet: SpreadSheet) => {
   spreadsheet.store.set('visibleActionIcons', []);
 
   const allInteractedCells = spreadsheet.interaction.getInteractedCells();
+  const cellMetas = spreadsheet.interaction.getState().cells;
 
-  if (!isEmpty(allInteractedCells)) {
+  if (!isEmpty(cellMetas)) {
     forEach(allInteractedCells, (cell: S2CellType) => {
       cell.hideInteractionShape();
     });

--- a/packages/s2-core/src/utils/interaction/state-controller.ts
+++ b/packages/s2-core/src/utils/interaction/state-controller.ts
@@ -17,7 +17,7 @@ export const clearState = (spreadsheet: SpreadSheet) => {
   const allInteractedCells = spreadsheet.interaction.getInteractedCells();
   const cellMetas = spreadsheet.interaction.getState().cells;
 
-  if (!isEmpty(cellMetas)) {
+  if (!isEmpty(allInteractedCells) && !isEmpty(cellMetas)) {
     forEach(allInteractedCells, (cell: S2CellType) => {
       cell.hideInteractionShape();
     });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

需要支持的快捷键类型

以下使用META键替代WINDOWS下的CTRL和MacOS下的COMMAND

1. META + A
全选表格内容（已支持）

2. 方向键
按照上下左右方向键移动选中光标（已支持）

2. META + SHIFT + 方向键

上： 选中当前单元格所在列的包括当前单元格以及以上的所有单元格。
下： 选中当前单元格所在列的包括当前单元格以及以下的所有单元格。
左： 选中当前单元格所在行的包括当前单元格以及以左的所有单元格。
右： 选中当前单元格所在行的包括当前单元格以及以右的所有单元格。
单元格区块操作：多（行/列）复用以上逻辑。

3. META + 方向键

上： 移动选中当前单元格所在列的最上方单元格。
下： 移动选中当前单元格所在列的最下方单元格。
左： 移动选中当前单元格所在行的最左方单元格。
右： 移动选中当前单元格所在行的最右方单元格。
单元格区块操作：将以第一个选中的单元格为基础。


4. SHIFT + 方向键

上： 增量选中当前单元格所在列的上方一个单元格。
下： 增量选中当前单元格所在列的下方一个单元格。
左： 增量选中当前单元格所在行的左方一个单元格。
右： 增量选中当前单元格所在行的右方一个单元格。
单元格区块操作：多（行/列）复用以上逻辑。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
