### PR TITLE
fix: 支持 Ctrl 键触发多选 Cell

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
@@ -85,6 +85,22 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
     expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
   });
 
+  test('should add click intercept when ctrl keydown', () => {
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.CONTROL,
+    } as KeyboardEvent);
+
+    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeTruthy();
+  });
+
+  test('should remove click intercept when ctrl keyup', () => {
+    s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
+      key: InteractionKeyboardKey.CONTROL,
+    } as KeyboardEvent);
+
+    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
+  });
+
   test('should select multiple data cell', () => {
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.META,

--- a/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
@@ -69,143 +69,148 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
     expect(dataCellMultiSelection.bindEvents).toBeDefined();
   });
 
-  test('should add click intercept when command keydown', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
-      key: InteractionKeyboardKey.META,
-    } as KeyboardEvent);
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should add click intercept when keydown',
+    (key) => {
+      s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+        key,
+      } as KeyboardEvent);
 
-    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeTruthy();
-  });
+      expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeTruthy();
+    },
+  );
 
-  test('should remove click intercept when command keyup', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
-      key: InteractionKeyboardKey.META,
-    } as KeyboardEvent);
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should remove click intercept when  keyup',
+    (key) => {
+      s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
+        key,
+      } as KeyboardEvent);
 
-    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
-  });
+      expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
+    },
+  );
 
-  test('should add click intercept when ctrl keydown', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
-      key: InteractionKeyboardKey.CONTROL,
-    } as KeyboardEvent);
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should select multiple data cell',
+    (key) => {
+      s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+        key,
+      } as KeyboardEvent);
 
-    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeTruthy();
-  });
+      s2.interaction.changeState({
+        cells: [],
+        stateName: InteractionStateName.SELECTED,
+      });
+      const mockCellA = createMockCell('testId2', { rowIndex: 0, colIndex: 0 });
+      s2.interaction.getCells = () => [mockCellA.mockCellMeta as CellMeta];
 
-  test('should remove click intercept when ctrl keyup', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
-      key: InteractionKeyboardKey.CONTROL,
-    } as KeyboardEvent);
+      const mockCellB = createMockCell('testId3', {
+        rowIndex: 1,
+        colIndex: 1,
+      });
 
-    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
-  });
+      s2.getCell = () => mockCellB.mockCell as any;
 
-  test('should select multiple data cell', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
-      key: InteractionKeyboardKey.META,
-    } as KeyboardEvent);
+      s2.interaction.getActiveCells = () =>
+        [mockCellA.mockCell, mockCellB.mockCell] as any;
 
-    s2.interaction.changeState({
-      cells: [],
-      stateName: InteractionStateName.SELECTED,
-    });
-    const mockCellA = createMockCell('testId2', { rowIndex: 0, colIndex: 0 });
-    s2.interaction.getCells = () => [mockCellA.mockCellMeta as CellMeta];
+      const selected = jest.fn();
+      s2.on(S2Event.GLOBAL_SELECTED, selected);
 
-    const mockCellB = createMockCell('testId3', {
-      rowIndex: 1,
-      colIndex: 1,
-    });
+      s2.emit(S2Event.DATA_CELL_CLICK, {
+        stopPropagation() {},
+      } as unknown as GEvent);
 
-    s2.getCell = () => mockCellB.mockCell as any;
+      expect(selected).toHaveBeenCalledWith([
+        mockCellA.mockCell,
+        mockCellB.mockCell,
+      ]);
 
-    s2.interaction.getActiveCells = () =>
-      [mockCellA.mockCell, mockCellB.mockCell] as any;
+      expect(s2.interaction.getState()).toEqual({
+        cells: [mockCellA.mockCellMeta, mockCellB.mockCellMeta],
+        stateName: InteractionStateName.SELECTED,
+      });
 
-    const selected = jest.fn();
-    s2.on(S2Event.GLOBAL_SELECTED, selected);
+      expect(
+        s2.interaction.hasIntercepts([
+          InterceptType.CLICK,
+          InterceptType.HOVER,
+        ]),
+      ).toBeTruthy();
+      expect(s2.hideTooltip).toHaveBeenCalled();
+      expect(s2.showTooltipWithInfo).toHaveBeenCalled();
+    },
+  );
 
-    s2.emit(S2Event.DATA_CELL_CLICK, {
-      stopPropagation() {},
-    } as unknown as GEvent);
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should unselect multiple data cell',
+    (key) => {
+      s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+        key,
+      } as KeyboardEvent);
 
-    expect(selected).toHaveBeenCalledWith([
-      mockCellA.mockCell,
-      mockCellB.mockCell,
-    ]);
+      const mockCellA = createMockCell('testId2', { rowIndex: 0, colIndex: 0 });
+      const mockCellB = createMockCell('testId3', {
+        rowIndex: 1,
+        colIndex: 1,
+      });
 
-    expect(s2.interaction.getState()).toEqual({
-      cells: [mockCellA.mockCellMeta, mockCellB.mockCellMeta],
-      stateName: InteractionStateName.SELECTED,
-    });
+      s2.interaction.getCells = () =>
+        [mockCellA.mockCellMeta, mockCellB.mockCellMeta] as CellMeta[];
 
-    expect(
-      s2.interaction.hasIntercepts([InterceptType.CLICK, InterceptType.HOVER]),
-    ).toBeTruthy();
-    expect(s2.hideTooltip).toHaveBeenCalled();
-    expect(s2.showTooltipWithInfo).toHaveBeenCalled();
-  });
+      // unselect cellA
+      s2.getCell = () => mockCellA.mockCell as any;
 
-  test('should unselect multiple data cell', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
-      key: InteractionKeyboardKey.META,
-    } as KeyboardEvent);
+      s2.emit(S2Event.DATA_CELL_CLICK, {
+        stopPropagation() {},
+      } as unknown as GEvent);
 
-    const mockCellA = createMockCell('testId2', { rowIndex: 0, colIndex: 0 });
-    const mockCellB = createMockCell('testId3', {
-      rowIndex: 1,
-      colIndex: 1,
-    });
+      expect(s2.interaction.getState()).toEqual({
+        cells: [mockCellB.mockCellMeta],
+        stateName: InteractionStateName.SELECTED,
+      });
 
-    s2.interaction.getCells = () =>
-      [mockCellA.mockCellMeta, mockCellB.mockCellMeta] as CellMeta[];
+      expect(
+        s2.interaction.hasIntercepts([
+          InterceptType.CLICK,
+          InterceptType.HOVER,
+        ]),
+      ).toBeTruthy();
+      expect(s2.hideTooltip).toHaveBeenCalled();
+      expect(s2.showTooltipWithInfo).toHaveBeenCalled();
+    },
+  );
 
-    // unselect cellA
-    s2.getCell = () => mockCellA.mockCell as any;
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should clear state when unselect all data cell and',
+    (key) => {
+      s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+        key,
+      } as KeyboardEvent);
 
-    s2.emit(S2Event.DATA_CELL_CLICK, {
-      stopPropagation() {},
-    } as unknown as GEvent);
+      s2.interaction.changeState({
+        cells: [],
+        stateName: InteractionStateName.SELECTED,
+      });
+      const mockCellA = createMockCell('testId2', { rowIndex: 0, colIndex: 0 });
 
-    expect(s2.interaction.getState()).toEqual({
-      cells: [mockCellB.mockCellMeta],
-      stateName: InteractionStateName.SELECTED,
-    });
+      s2.interaction.getCells = () => [mockCellA.mockCellMeta] as CellMeta[];
 
-    expect(
-      s2.interaction.hasIntercepts([InterceptType.CLICK, InterceptType.HOVER]),
-    ).toBeTruthy();
-    expect(s2.hideTooltip).toHaveBeenCalled();
-    expect(s2.showTooltipWithInfo).toHaveBeenCalled();
-  });
+      // unselect cellA
+      s2.getCell = () => mockCellA.mockCell as any;
 
-  test('should clear state when unselect all data cell and', () => {
-    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
-      key: InteractionKeyboardKey.META,
-    } as KeyboardEvent);
+      s2.emit(S2Event.DATA_CELL_CLICK, {
+        stopPropagation() {},
+      } as unknown as GEvent);
 
-    s2.interaction.changeState({
-      cells: [],
-      stateName: InteractionStateName.SELECTED,
-    });
-    const mockCellA = createMockCell('testId2', { rowIndex: 0, colIndex: 0 });
-
-    s2.interaction.getCells = () => [mockCellA.mockCellMeta] as CellMeta[];
-
-    // unselect cellA
-    s2.getCell = () => mockCellA.mockCell as any;
-
-    s2.emit(S2Event.DATA_CELL_CLICK, {
-      stopPropagation() {},
-    } as unknown as GEvent);
-
-    expect(s2.interaction.getState()).toEqual({
-      cells: [],
-      force: false,
-    });
-    expect(s2.hideTooltip).toHaveBeenCalled();
-  });
+      expect(s2.interaction.getState()).toEqual({
+        cells: [],
+        force: false,
+      });
+      expect(s2.hideTooltip).toHaveBeenCalled();
+    },
+  );
 
   test('should set lastClickedCell', () => {
     s2.interaction.changeState({

--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -372,23 +372,6 @@ describe('Interaction Event Controller Tests', () => {
     expect(copied).not.toHaveBeenCalled();
   });
 
-  test.each([
-    { type: OriginEventType.KEY_DOWN, event: S2Event.GLOBAL_KEYBOARD_DOWN },
-    { type: OriginEventType.KEY_UP, event: S2Event.GLOBAL_KEYBOARD_DOWN },
-  ])(
-    'should not trigger sheet %o if outside the canvas container',
-    ({ type, event }) => {
-      // 模拟点击的不是表格区域
-      window.dispatchEvent(new Event('click', {}));
-
-      const handler = jest.fn();
-      spreadsheet.on(event, handler);
-
-      window.dispatchEvent(new KeyboardEvent(type, {}));
-      expect(handler).not.toHaveBeenCalled();
-    },
-  );
-
   test('should not reset if current interaction has brush selection', () => {
     spreadsheet.interaction.addIntercepts([InterceptType.BRUSH_SELECTION]);
     const reset = jest.fn();

--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -63,6 +63,7 @@ export enum InteractionKeyboardKey {
   COPY = 'c',
   ESC = 'Escape',
   META = 'Meta',
+  CONTROL = 'Control',
   ARROW_UP = 'ArrowUp',
   ARROW_DOWN = 'ArrowDown',
   ARROW_LEFT = 'ArrowLeft',

--- a/packages/s2-core/src/interaction/brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection.ts
@@ -500,6 +500,11 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
 
     // 刷选过程中右键弹出系统菜单时, 应该重置刷选, 防止系统菜单关闭后 mouse up 未相应依然是刷选状态
     this.spreadsheet.on(S2Event.GLOBAL_CONTEXT_MENU, () => {
+      if (
+        this.brushSelectionStage === InteractionBrushSelectionStage.UN_DRAGGED
+      ) {
+        return;
+      }
       this.spreadsheet.interaction.removeIntercepts([InterceptType.HOVER]);
       this.resetDrag();
     });

--- a/packages/s2-core/src/interaction/data-cell-multi-selection.ts
+++ b/packages/s2-core/src/interaction/data-cell-multi-selection.ts
@@ -28,7 +28,12 @@ export class DataCellMultiSelection
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
-        if (event.key === InteractionKeyboardKey.META) {
+        if (
+          [
+            InteractionKeyboardKey.META,
+            InteractionKeyboardKey.CONTROL,
+          ].includes(event.key as InteractionKeyboardKey)
+        ) {
           this.isMultiSelection = true;
           this.spreadsheet.interaction.addIntercepts([InterceptType.CLICK]);
         }
@@ -38,7 +43,11 @@ export class DataCellMultiSelection
 
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
-      if (event.key === InteractionKeyboardKey.META) {
+      if (
+        [InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL].includes(
+          event.key as InteractionKeyboardKey,
+        )
+      ) {
         this.isMultiSelection = false;
         this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
       }

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -93,9 +93,6 @@ export class EventController {
       window,
       OriginEventType.KEY_DOWN,
       (event: KeyboardEvent) => {
-        if (!this.isCanvasEffect) {
-          return;
-        }
         this.onKeyboardCopy(event);
         this.onKeyboardEsc(event);
         this.spreadsheet.emit(S2Event.GLOBAL_KEYBOARD_DOWN, event);
@@ -105,9 +102,6 @@ export class EventController {
       window,
       OriginEventType.KEY_UP,
       (event: KeyboardEvent) => {
-        if (!this.isCanvasEffect) {
-          return;
-        }
         this.spreadsheet.emit(S2Event.GLOBAL_KEYBOARD_UP, event);
       },
     );
@@ -134,6 +128,7 @@ export class EventController {
   private onKeyboardCopy(event: KeyboardEvent) {
     // windows and macos copy
     if (
+      this.isCanvasEffect &&
       this.spreadsheet.options.interaction.enableCopy &&
       keyEqualTo(event.key, InteractionKeyboardKey.COPY) &&
       (event.metaKey || event.ctrlKey)
@@ -146,7 +141,10 @@ export class EventController {
   }
 
   private onKeyboardEsc(event: KeyboardEvent) {
-    if (keyEqualTo(event.key, InteractionKeyboardKey.ESC)) {
+    if (
+      this.isCanvasEffect &&
+      keyEqualTo(event.key, InteractionKeyboardKey.ESC)
+    ) {
       this.resetSheetStyle(event);
     }
   }
@@ -445,11 +443,8 @@ export class EventController {
       return;
     }
     const { interaction } = this.spreadsheet;
-    // 两种情况不能重置 1. 选中单元格 2. 有交互功能的tooltip打开时
-    if (
-      !interaction.isSelectedState() &&
-      !interaction.hasIntercepts([InterceptType.HOVER])
-    ) {
+    // 两种情况不能重置 1. 选中单元格 2. 有 intercepts 时（重置会清空 intercepts）
+    if (!interaction.isSelectedState() && !(interaction.intercepts.size > 0)) {
       interaction.reset();
     }
   };


### PR DESCRIPTION
### 👀 PR includes

支持 Ctrl 键触发多选 Cell。

对之前的 Keydown 和 Keyup 事件焦点触发的逻辑做了一下改动。如果只在点击后才能监听。那只能点击一下画布才能按键多选。但用户一般会先按键然后点击画布。体验并不好。所以这里改成针对复制和 Esc 键操作才判断是否有焦点。