### PR TITLE
fix: 修复linkTextFill不生效的问题, close #1191

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1191-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1191-spec.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * @description spec for issue #1191
+ * https://github.com/antvis/S2/issues/1191
+ * link field should use linkFieldFill color
+ *
+ */
+import { getContainer } from 'tests/util/helpers';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { filter, get } from 'lodash';
+import { PivotSheet, SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+import { CornerCell } from '@/cell';
+
+const s2options: S2Options = {
+  width: 300,
+  height: 200,
+  style: {
+    colCfg: {
+      height: 60,
+    },
+    cellCfg: {
+      width: 100,
+      height: 50,
+    },
+  },
+  interaction: {
+    linkFields: ['province'],
+  },
+};
+
+const dataCfg = {
+  ...mockDataConfig,
+  fields: {
+    rows: ['province', 'city'],
+    values: ['price'],
+    valueInCols: true,
+  },
+  meta: [
+    {
+      field: 'province',
+      name: '省份',
+      formatter: (v) => `province: ${v}`,
+    },
+    {
+      field: 'city',
+      name: '城市',
+      formatter: (v) => `city: ${v}`,
+    },
+    {
+      field: 'price',
+      name: '价格',
+      formatter: (v) => `price:${v}`,
+    },
+  ],
+};
+
+describe('Link Field Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    s2 = new PivotSheet(getContainer(), dataCfg, s2options);
+    s2.setThemeCfg({
+      theme: {
+        rowCell: {
+          text: {
+            linkTextFill: 'red',
+          },
+          bolderText: {
+            linkTextFill: 'red',
+          },
+        },
+      },
+    });
+    s2.render();
+  });
+
+  test('province row cell should use link field style', () => {
+    // 浙江省对应 cell
+    const province = s2.facet.rowHeader.getChildByIndex(0);
+    // @ts-ignore
+    expect(province.textShape.attr('fill')).toEqual('red');
+    // @ts-ignore
+    expect(province.linkFieldShape).toBeDefined();
+  });
+  test('city row cell should not use link field style', () => {
+    // 义乌对应 cell
+    const city = s2.facet.rowHeader.getChildByIndex(1);
+    // @ts-ignore
+    expect(city.textShape.attr('fill')).not.toEqual('red');
+    // @ts-ignore
+    expect(city.linkFieldShape).not.toBeDefined();
+  });
+});

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -199,41 +199,34 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     showLinkFieldShape: boolean,
     linkFillColor: string,
   ) {
-    const { fill } = this.getTextStyle();
-
-    // handle link nodes
-    if (showLinkFieldShape) {
-      const device = this.spreadsheet.options.style.device;
-      let fillColor: string;
-
-      // 配置了链接跳转
-      if (isMobile(device)) {
-        fillColor = linkFillColor;
-      } else {
-        const { minX, maxX, maxY }: BBox = this.textShape.getBBox();
-        this.linkFieldShape = renderLine(
-          this,
-          {
-            x1: minX,
-            y1: maxY + 1,
-            x2: maxX,
-            y2: maxY + 1,
-          },
-          { stroke: fill, lineWidth: 1 },
-        );
-
-        fillColor = fill;
-      }
-
-      this.textShape.attr({
-        fill: fillColor,
-        cursor: 'pointer',
-        appendInfo: {
-          isRowHeaderText: true, // 标记为行头(明细表行头其实就是Data Cell)文本，方便做链接跳转直接识别
-          cellData: this.meta,
-        },
-      });
+    if (!showLinkFieldShape) {
+      return;
     }
+
+    const device = this.spreadsheet.options.style.device;
+    // 配置了链接跳转
+    if (!isMobile(device)) {
+      const { minX, maxX, maxY }: BBox = this.textShape.getBBox();
+      this.linkFieldShape = renderLine(
+        this,
+        {
+          x1: minX,
+          y1: maxY + 1,
+          x2: maxX,
+          y2: maxY + 1,
+        },
+        { stroke: linkFillColor, lineWidth: 1 },
+      );
+    }
+
+    this.textShape.attr({
+      fill: linkFillColor,
+      cursor: 'pointer',
+      appendInfo: {
+        isRowHeaderText: true, // 标记为行头(明细表行头其实就是Data Cell)文本，方便做链接跳转直接识别
+        cellData: this.meta,
+      },
+    });
   }
 
   // 根据当前state来更新cell的样式


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1191 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
之前的`linkTextFill`是按照pc和mobile端处理处理的，其中：
* pc 只添加下划线
* mobile 才应用 `linkTextFill`配置
对用户来说极具迷惑性，现在pc和mobile都统一应用`linkTextFill`，唯一区别仅有：pc端添加下划线
### 🖼️ Screenshot
主题配置：

```js
{ 
   theme: {
      rowCell: {
        text: {
          linkTextFill: 'red',
        },
        bolderText: {
          linkTextFill: 'red',
        },
      }
}
```
| Before | After |
| ------ | ----- |
|   ![image](https://user-images.githubusercontent.com/17964556/158771961-dfdb97d3-6319-4f74-94db-8fea8a5df8af.png)   | ![image](https://user-images.githubusercontent.com/17964556/158771700-239c1f1f-b884-4928-a4fc-a49e954159c2.png)   |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
