### PR TITLE
fix(react): 修复宽高改变后未重新渲染表格的问题 close #1193

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -493,16 +493,16 @@ describe('PivotSheet Tests', () => {
     expect(s2.getColumnNodes()).toHaveLength(3);
   });
 
-  test('should change sheet size', () => {
+  test('should change sheet container size', () => {
     s2.changeSheetSize(1000, 500);
 
-    expect(s2.options.width).toEqual(1000);
-    expect(s2.options.height).toEqual(500);
+    expect(s2.options.width).toStrictEqual(1000);
+    expect(s2.options.height).toStrictEqual(500);
 
     const canvas = s2.container.get('el') as HTMLCanvasElement;
 
-    expect(canvas.style.width).toEqual(`1000px`);
-    expect(canvas.style.height).toEqual(`500px`);
+    expect(canvas.style.width).toStrictEqual(`1000px`);
+    expect(canvas.style.height).toStrictEqual(`500px`);
   });
 
   test('should set display:block style with canvas', () => {
@@ -534,6 +534,46 @@ describe('PivotSheet Tests', () => {
     expect(s2.panelGroup.getChildren()).toHaveLength(1);
     expect(s2.panelGroup.findAllByName(KEY_GROUP_PANEL_SCROLL)).toHaveLength(1);
   });
+
+  test.each([
+    {
+      width: s2Options.width + 100,
+      height: s2Options.height + 100,
+    },
+    {
+      width: s2Options.width + 100,
+      height: s2Options.height,
+    },
+    {
+      width: s2Options.width,
+      height: s2Options.height + 100,
+    },
+    {
+      width: s2Options.width,
+      height: s2Options.height,
+    },
+  ])(
+    'should skip change sheet container size if width and height not changed %o',
+    ({ width, height }) => {
+      s2.changeSheetSize(s2Options.width, s2Options.height);
+
+      const isCalled = width !== s2Options.width || height !== s2Options.height;
+
+      const changeSizeSpy = jest
+        .spyOn(s2.container, 'changeSize')
+        .mockImplementationOnce(() => {});
+
+      s2.changeSheetSize(width, height);
+
+      expect(s2.options.width).toStrictEqual(
+        isCalled ? width : s2.options.width,
+      );
+      expect(s2.options.height).toStrictEqual(
+        isCalled ? height : s2.options.height,
+      );
+      expect(changeSizeSpy).toHaveBeenCalledTimes(isCalled ? 1 : 0);
+    },
+  );
 
   test('should init column nodes', () => {
     // [type -> cost, type -> price] => [笔 -> cost, 笔 -> price]

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -399,7 +399,7 @@ export abstract class SpreadSheet extends EE {
   /**
    * @param width
    * @param height
-   * @deprecated 该方法将会在2.0被移除
+   * @deprecated 该方法将会在2.0被移除, 请使用 changeSheetSize 代替
    */
   public changeSize(
     width: number = this.options.width,
@@ -417,10 +417,13 @@ export abstract class SpreadSheet extends EE {
     width: number = this.options.width,
     height: number = this.options.height,
   ) {
-    const isEqualSize =
-      width === this.options.width && height === this.options.height;
+    const containerWidth = this.container.get('width');
+    const containerHeight = this.container.get('height');
 
-    if (isEqualSize) {
+    const isSizeChanged =
+      width !== containerWidth || height !== containerHeight;
+
+    if (!isSizeChanged) {
       return;
     }
 

--- a/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
@@ -3,6 +3,7 @@ import { PivotSheet, S2Options } from '@antv/s2';
 import { getContainer } from 'tests/util/helpers';
 import * as mockDataConfig from 'tests/data/simple-data.json';
 import { useSpreadSheet } from '@/hooks';
+import { BaseSheetComponentProps } from '@/components';
 
 const s2Options: S2Options = {
   width: 200,
@@ -12,34 +13,22 @@ const s2Options: S2Options = {
 
 describe('useSpreadSheet tests', () => {
   const container = getContainer();
+  const props: BaseSheetComponentProps = {
+    spreadsheet: () => new PivotSheet(container, mockDataConfig, s2Options),
+    options: s2Options,
+    dataCfg: mockDataConfig,
+  };
 
   test('should build spreadSheet', () => {
     const { result } = renderHook(() =>
-      useSpreadSheet(
-        {
-          spreadsheet: () =>
-            new PivotSheet(container, mockDataConfig, s2Options),
-          options: s2Options,
-          dataCfg: mockDataConfig,
-        },
-        { sheetType: 'pivot' },
-      ),
+      useSpreadSheet(props, { sheetType: 'pivot' }),
     );
     expect(result.current.s2Ref).toBeDefined();
   });
 
   test('should cannot change table size when width or height updated and disable adaptive', () => {
     const { result } = renderHook(() =>
-      useSpreadSheet(
-        {
-          spreadsheet: () =>
-            new PivotSheet(container, mockDataConfig, s2Options),
-          options: s2Options,
-          dataCfg: mockDataConfig,
-          adaptive: false,
-        },
-        { sheetType: 'pivot' },
-      ),
+      useSpreadSheet({ ...props, adaptive: false }, { sheetType: 'pivot' }),
     );
     const s2 = result.current.s2Ref.current;
 

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -31,7 +31,7 @@ import {
   DataType,
 } from '@antv/s2';
 import corePkg from '@antv/s2/package.json';
-import { forEach, random } from 'lodash';
+import { debounce, forEach, random } from 'lodash';
 import { customTreeFields } from '../__tests__/data/custom-tree-fields';
 import { dataCustomTrees } from '../__tests__/data/data-custom-trees';
 import { mockGridAnalysisDataCfg } from '../__tests__/data/grid-analysis-data';
@@ -188,11 +188,12 @@ function MainLayout() {
     });
   };
 
-  const onSizeChange = (type: 'width' | 'height') => (e) => {
-    updateOptions({
-      [type]: e.target.value,
-    });
-  };
+  const onSizeChange = (type: 'width' | 'height') =>
+    debounce((e) => {
+      updateOptions({
+        [type]: Number(e.target.value),
+      });
+    }, 300);
 
   const onScrollSpeedRatioChange =
     (type: 'horizontal' | 'vertical') => (value: number) => {
@@ -744,7 +745,7 @@ function MainLayout() {
                 advancedSortCfg: { open: true },
               }}
               onDataCellTrendIconClick={logHandler('onDataCellTrendIconClick')}
-              onAfterRender={logHandler('onLoad')}
+              onAfterRender={logHandler('onAfterRender')}
               onDestroy={logHandler('onDestroy')}
               onColCellClick={onColCellClick}
               onRowCellClick={logHandler('onRowCellClick')}

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { debounce } from 'lodash';
 import type { SpreadSheet } from '@antv/s2';
 import { Adaptive } from '@/components';
@@ -37,7 +37,7 @@ export const useResize = (params: UseResizeEffectParams) => {
   // 第一次自适应时不需要 debounce, 防止抖动
   const isFirstRender = React.useRef<boolean>(true);
 
-  const render = useCallback(
+  const render = React.useCallback(
     (width: number, height: number) => {
       s2.changeSheetSize(width, height);
       s2.render(false);

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -93,6 +93,7 @@ export function useSpreadSheet(
         s2Ref.current?.setDataCfg(dataCfg);
       }
       s2Ref.current?.setOptions(options);
+      s2Ref.current?.changeSheetSize(options.width, options.height);
     }
     if (!Object.is(prevThemeCfg, themeCfg)) {
       s2Ref.current?.setThemeCfg(themeCfg);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1193


### 📝 Description

原因是因为 s2Options 的宽高修改了, 但是没有修改 `g-canvas` 生成的 `canvas` dom 节点的宽高

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-03-18 at 15 43 42](https://user-images.githubusercontent.com/21015895/158958130-cabd9182-2d52-4ad4-a880-f99bdd36579d.gif) | ![Kapture 2022-03-18 at 15 07 55](https://user-images.githubusercontent.com/21015895/158953480-e907a4ed-a4a4-45ee-b03f-01f7b804cb36.gif) |

### 🔗 Related issue link

<!-- close #0 -->

close #1159 

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
