### PR TITLE
fix(adaptive): 修复开启自适应后 组件在  Safari 上无法渲染的问题 close #1164

### DIFF
--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -563,7 +563,7 @@ function MainLayout() {
                 <Switch
                   checkedChildren="容器宽高自适应开"
                   unCheckedChildren="容器宽高自适应关"
-                  defaultChecked={adaptive}
+                  defaultChecked={Boolean(adaptive)}
                   onChange={setAdaptive}
                 />
                 <Switch

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -56,6 +56,7 @@ import {
   SheetType,
   PartDrillDown,
   PartDrillDownInfo,
+  Adaptive,
 } from '@/components';
 
 import './index.less';
@@ -148,7 +149,7 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({ name: 'default' });
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
-  const [adaptive, setAdaptive] = React.useState(false);
+  const [adaptive, setAdaptive] = React.useState<Adaptive>(true);
   const [options, setOptions] =
     React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);
   const [dataCfg, setDataCfg] =

--- a/packages/s2-react/src/hooks/useResize.ts
+++ b/packages/s2-react/src/hooks/useResize.ts
@@ -52,15 +52,22 @@ export const useResize = (params: UseResizeEffectParams) => {
       return;
     }
     const resizeObserver = new ResizeObserver(
-      debounce(([entry] = []) => {
+      debounce(([entry]: ResizeObserverEntry[] = []) => {
         if (entry) {
           const [size] = entry.borderBoxSize || [];
+
+          // Safari 不支持 borderBoxSize 属性
           const width = adaptiveWidth
-            ? Math.floor(size?.inlineSize)
+            ? Math.floor(
+                (size?.inlineSize || entry.contentRect?.width) ?? optionWidth,
+              )
             : optionWidth;
           const height = adaptiveHeight
-            ? Math.floor(container?.getBoundingClientRect().height) // 去除 header 和 page 后才是 sheet 真正的高度
+            ? Math.floor(
+                container?.getBoundingClientRect().height ?? optionHeight,
+              ) // 去除 header 和 page 后才是 sheet 真正的高度
             : optionHeight;
+
           if (!adaptiveWidth && !adaptiveHeight) {
             return;
           }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1164

### 📝 Description

![image](https://user-images.githubusercontent.com/21015895/158964861-4c127e9e-643b-45c6-9c1d-0418745d7793.png)

Safari 上不支持 borderBoxSize 属性, 导致 Math floor 的宽度为 `NaN`, 导致渲染异常

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/158965117-2a42a86e-6fd1-42ac-a57b-516341494321.png) | ![image](https://user-images.githubusercontent.com/21015895/158965029-465b6c4e-bbd1-452e-a928-b3b644f7c644.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
