### PR TITLE
fix: 有自定义行高，但表格高度为 0 时卡死的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/facet-spec.ts
@@ -34,4 +34,12 @@ describe('Facet util test', () => {
       end: 7,
     });
   });
+
+  test('should get correct index range for invalid input', () => {
+    const offsets = [0, 30, 60, 90, 120, 150, 160, 170, 190];
+    expect(getIndexRangeWithOffsets(offsets, 0, -10)).toStrictEqual({
+      start: 0,
+      end: 0,
+    });
+  });
 });

--- a/packages/s2-core/src/utils/facet.ts
+++ b/packages/s2-core/src/utils/facet.ts
@@ -25,6 +25,13 @@ export const getIndexRangeWithOffsets = (
   minHeight: number,
   maxHeight: number,
 ) => {
+  if (maxHeight <= 0) {
+    return {
+      start: 0,
+      end: 0,
+    };
+  }
+
   let yMin = findIndex(
     heights,
     (height: number, idx: number) => {


### PR DESCRIPTION
### 👀 PR includes

getIndexRangeWithOffsets 添加了对不合法输入的判断。