### PR TITLE
fix: 未开启自适应, 改变浏览器窗口大小, 会导致表格重新渲染 close #1197

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -1,12 +1,13 @@
 import * as mockDataConfig from 'tests/data/simple-data.json';
-import { getContainer } from 'tests/util/helpers';
+import { getContainer, sleep } from 'tests/util/helpers';
 import { PivotSheet, TableSheet } from '@/sheet-type';
-import { S2Options } from '@/common';
+import { S2Event, S2Options } from '@/common';
 
 const s2Options: S2Options = {
   width: 200,
   height: 200,
   hierarchyType: 'grid',
+  hdAdapter: true,
 };
 
 describe('SpreadSheet Tests', () => {
@@ -100,11 +101,28 @@ describe('SpreadSheet Tests', () => {
       });
       expect(s2.facet.hScrollBar.current()).toBeGreaterThan(0);
     });
+
+    // https://github.com/antvis/S2/issues/1197
+    test('should not rerender when window or visual viewport resize', async () => {
+      const render = jest.fn();
+      const s2 = new PivotSheet(container, mockDataConfig, s2Options);
+
+      s2.on(S2Event.LAYOUT_BEFORE_RENDER, render);
+      s2.render();
+
+      window.dispatchEvent(new Event('resize'));
+      visualViewport.dispatchEvent(new Event('resize'));
+
+      // await debounce
+      await sleep(1000);
+
+      expect(render).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Destroy Sheet Tests', () => {
     test.each([PivotSheet, TableSheet])(
-      'should destroy %s correctly',
+      'should destroy sheet correctly',
       async (Sheet) => {
         const container = getContainer();
         const s2 = new Sheet(container, mockDataConfig, s2Options);
@@ -123,7 +141,7 @@ describe('SpreadSheet Tests', () => {
 
     // https://github.com/antvis/S2/issues/1011
     test.each([PivotSheet, TableSheet])(
-      'should delay destroy %s correctly',
+      'should delay destroy sheet correctly',
       async (Sheet) => {
         const container = getContainer();
         const s2 = new Sheet(container, mockDataConfig, s2Options);

--- a/packages/s2-core/src/ui/hd-adapter/index.ts
+++ b/packages/s2-core/src/ui/hd-adapter/index.ts
@@ -84,6 +84,11 @@ export class HdAdapter {
       options: { width, height, devicePixelRatio },
     } = this.spreadsheet;
 
+    const lastRatio = container.get('pixelRatio');
+    if (lastRatio === ratio) {
+      return;
+    }
+
     // 缩放时, 以向上取整后的缩放比为准
     // 设备像素比改变时, 取当前和用户配置中最大的, 保证显示效果
     const pixelRatio = Math.max(

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -149,7 +149,7 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({ name: 'default' });
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
-  const [adaptive, setAdaptive] = React.useState<Adaptive>(true);
+  const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
     React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);
   const [dataCfg, setDataCfg] =


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1197 

### 📝 Description

window.visualViewport 的 `resize` 事件在浏览器窗口大小改变时也能触发, 会产生一次额外的渲染

优化: 在 pixelRatio 改变后才重新渲染

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/159221073-71326d75-232f-49eb-a126-6f561d15962a.png) |  ![Kapture 2022-03-21 at 15 44 23](https://user-images.githubusercontent.com/21015895/159221242-4dd84d46-ac9c-4850-8648-4e170531ad6f.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
