### PR TITLE
fix: 行列头多选支持 Ctrl 键

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -185,7 +185,7 @@ describe('Table Mode Facet Test With Compact Layout', () => {
     test('col hierarchy coordinate with compact layout', () => {
       const { colLeafNodes } = facet.layoutResult;
 
-      const COMPACT_WIDTH = [52, 52, 64, 40, 72];
+      const COMPACT_WIDTH = [53, 53, 65, 41, 73];
 
       let lastX = 0;
       colLeafNodes.forEach((node, index) => {
@@ -218,7 +218,7 @@ describe('Table Mode Facet Test With Compact Layout', () => {
     test('col hierarchy coordinate with compact layout with seriesNumber', () => {
       const { colLeafNodes } = facet.layoutResult;
 
-      const COMPACT_WIDTH = [80, 52, 52, 64, 40, 72];
+      const COMPACT_WIDTH = [80, 53, 53, 65, 41, 73];
 
       let lastX = 0;
       colLeafNodes.forEach((node, index) => {

--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -32,7 +32,7 @@ describe('TableSheet Tests', () => {
     s2?.destroy();
   });
 
-  describe('PivotSheet Sort Tests', () => {
+  describe('TableSheet Sort Tests', () => {
     test('should trigger sort', () => {
       const renderSpy = jest.spyOn(s2, 'render').mockImplementation(() => {});
 
@@ -64,6 +64,78 @@ describe('TableSheet Tests', () => {
         },
       ]);
       expect(renderSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('should update sort params', () => {
+      s2.onSortTooltipClick(
+        { key: 'desc' },
+        {
+          field: 'cost',
+        },
+      );
+
+      expect(s2.dataCfg.sortParams).toEqual([
+        {
+          sortFieldId: 'city',
+          sortMethod: 'asc',
+        },
+        {
+          sortFieldId: 'cost',
+          sortMethod: 'desc',
+        },
+      ]);
+
+      s2.onSortTooltipClick(
+        { key: 'desc' },
+        {
+          field: 'city',
+        },
+      );
+
+      expect(s2.dataCfg.sortParams).toEqual([
+        {
+          sortFieldId: 'cost',
+          sortMethod: 'desc',
+        },
+        {
+          sortFieldId: 'city',
+          sortMethod: 'desc',
+        },
+      ]);
+
+      s2.setDataCfg({
+        ...s2.dataCfg,
+        sortParams: [
+          {
+            sortFieldId: 'cost',
+            sortMethod: 'desc',
+            sortBy: ['1', '2'],
+          },
+          {
+            sortFieldId: 'city',
+            sortMethod: 'desc',
+          },
+        ],
+      });
+
+      s2.onSortTooltipClick(
+        { key: 'asc' },
+        {
+          field: 'cost',
+        },
+      );
+
+      expect(s2.dataCfg.sortParams).toEqual([
+        {
+          sortFieldId: 'city',
+          sortMethod: 'desc',
+        },
+        {
+          sortFieldId: 'cost',
+          sortMethod: 'asc',
+          sortBy: ['1', '2'],
+        },
+      ]);
     });
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/interaction/select-event-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/select-event-spec.ts
@@ -1,0 +1,20 @@
+import { isMultiSelectionKey } from 'src/utils/interaction/select-event';
+import { InteractionKeyboardKey } from 'src/common/constant';
+
+describe('Select Event Utils Tests', () => {
+  describe('isMultiSelection test', () => {
+    test('should return true for ctrl and meta key', () => {
+      expect(
+        isMultiSelectionKey({
+          key: InteractionKeyboardKey.META,
+        } as KeyboardEvent),
+      ).toBe(true);
+
+      expect(
+        isMultiSelectionKey({
+          key: InteractionKeyboardKey.CONTROL,
+        } as KeyboardEvent),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -88,15 +88,36 @@ export class TableFacet extends BaseFacet {
       if (!Array.isArray(sortParams)) {
         params = [sortParams];
       }
-      set(
-        s2.dataCfg,
-        'sortParams',
-        params.map((item: TableSortParam) => ({
+
+      const currentParams = s2.dataCfg.sortParams || [];
+
+      params = params.map((item: TableSortParam) => {
+        const newItem = {
           ...item,
           // 兼容之前 sortKey 的用法
           sortFieldId: item.sortKey ?? item.sortFieldId,
-        })),
-      );
+        };
+
+        const oldItem =
+          currentParams.find((p) => p.sortFieldId === newItem.sortFieldId) ??
+          {};
+        return {
+          ...oldItem,
+          ...newItem,
+        };
+      });
+
+      const oldConfigs = currentParams.filter((config) => {
+        const newItem = params.find(
+          (p) => p.sortFieldId === config.sortFieldId,
+        );
+        if (newItem) {
+          return false;
+        }
+        return true;
+      });
+
+      set(s2.dataCfg, 'sortParams', [...oldConfigs, ...params]);
       s2.setDataCfg(s2.dataCfg);
       s2.render(true);
       s2.emit(
@@ -381,10 +402,13 @@ export class TableFacet extends BaseFacet {
               spreadsheet.theme.colCell,
             );
         } else {
+          // 额外添加一像素余量，防止 maxLabel 有多个同样长度情况下，一些 label 不能展示完全
+          const EXTRA_PIXEL = 1;
           colWidth =
             measureTextWidth(maxLabel, dataCellTextStyle) +
             cellStyle.padding.left +
-            cellStyle.padding.right;
+            cellStyle.padding.right +
+            EXTRA_PIXEL;
         }
       } else {
         colWidth = adaptiveColWitdth;

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -1,5 +1,6 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { difference } from 'lodash';
+import { isMultiSelectionKey } from 'src/utils/interaction/select-event';
 import {
   hideColumnsByThunkGroup,
   isEqualDisplaySiblingNodeId,
@@ -7,7 +8,6 @@ import {
 import { BaseEvent, BaseEventImplement } from '@/interaction/base-event';
 import {
   S2Event,
-  InteractionKeyboardKey,
   InterceptType,
   CellTypes,
   TOOLTIP_OPERATOR_HIDDEN_COLUMNS_MENU,
@@ -39,12 +39,7 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
-        if (
-          [
-            InteractionKeyboardKey.META,
-            InteractionKeyboardKey.CONTROL,
-          ].includes(event.key as InteractionKeyboardKey)
-        ) {
+        if (isMultiSelectionKey(event)) {
           this.isMultiSelection = true;
         }
       },
@@ -53,11 +48,7 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
 
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
-      if (
-        [InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL].includes(
-          event.key as InteractionKeyboardKey,
-        )
-      ) {
+      if (isMultiSelectionKey(event)) {
         this.isMultiSelection = false;
         this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
       }

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -39,7 +39,12 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
-        if (event.key === InteractionKeyboardKey.META) {
+        if (
+          [
+            InteractionKeyboardKey.META,
+            InteractionKeyboardKey.CONTROL,
+          ].includes(event.key as InteractionKeyboardKey)
+        ) {
           this.isMultiSelection = true;
         }
       },
@@ -48,7 +53,11 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
 
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
-      if (event.key === InteractionKeyboardKey.META) {
+      if (
+        [InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL].includes(
+          event.key as InteractionKeyboardKey,
+        )
+      ) {
         this.isMultiSelection = false;
         this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
       }

--- a/packages/s2-core/src/interaction/data-cell-multi-selection.ts
+++ b/packages/s2-core/src/interaction/data-cell-multi-selection.ts
@@ -1,11 +1,13 @@
 import { Event } from '@antv/g-canvas';
 import { isEmpty } from 'lodash';
-import { getCellMeta } from 'src/utils/interaction/select-event';
+import {
+  getCellMeta,
+  isMultiSelectionKey,
+} from 'src/utils/interaction/select-event';
 import { BaseEvent, BaseEventImplement } from './base-interaction';
 import { getActiveCellsTooltipData } from '@/utils/tooltip';
 import {
   InterceptType,
-  InteractionKeyboardKey,
   InteractionStateName,
   S2Event,
 } from '@/common/constant';
@@ -28,12 +30,7 @@ export class DataCellMultiSelection
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
-        if (
-          [
-            InteractionKeyboardKey.META,
-            InteractionKeyboardKey.CONTROL,
-          ].includes(event.key as InteractionKeyboardKey)
-        ) {
+        if (isMultiSelectionKey(event)) {
           this.isMultiSelection = true;
           this.spreadsheet.interaction.addIntercepts([InterceptType.CLICK]);
         }
@@ -43,11 +40,7 @@ export class DataCellMultiSelection
 
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
-      if (
-        [InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL].includes(
-          event.key as InteractionKeyboardKey,
-        )
-      ) {
+      if (isMultiSelectionKey(event)) {
         this.isMultiSelection = false;
         this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
       }

--- a/packages/s2-core/src/sheet-type/table-sheet.ts
+++ b/packages/s2-core/src/sheet-type/table-sheet.ts
@@ -154,23 +154,12 @@ export class TableSheet extends SpreadSheet {
   public onSortTooltipClick = ({ key }, meta) => {
     const { field } = meta;
 
-    const prevOtherSortParams = [];
-    let prevSelectedSortParams: SortParam;
-    this.dataCfg.sortParams.forEach((item) => {
-      if (item?.sortFieldId !== field) {
-        prevOtherSortParams.push(item);
-      } else {
-        prevSelectedSortParams = item;
-      }
-    });
-
     const sortParam: SortParam = {
-      ...(prevSelectedSortParams || {}),
       sortFieldId: field,
       sortMethod: key as unknown as SortParam['sortMethod'],
     };
     // 触发排序事件
-    this.emit(S2Event.RANGE_SORT, [...prevOtherSortParams, sortParam]);
+    this.emit(S2Event.RANGE_SORT, [sortParam]);
   };
 
   public handleGroupSort(event: CanvasEvent, meta: Node) {

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -1,10 +1,16 @@
 import {
+  InteractionKeyboardKey,
   InteractionStateName,
-  INTERACTION_STATE_INFO_KEY,
   S2Event,
 } from '@/common/constant';
 import { CellMeta, S2CellType, ViewMeta } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
+
+export const isMultiSelectionKey = (e: KeyboardEvent) => {
+  return [InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL].includes(
+    e.key as InteractionKeyboardKey,
+  );
+};
 
 export const getCellMeta = (cell: S2CellType) => {
   const meta = cell.getMeta();


### PR DESCRIPTION
### 👀 PR includes

+ 行列头多选支持 Ctrl 键
+ 明细表排序增加单元测试 && 简单重构