### PR TITLE
fix(table-facet): 修复row高度大于canvas高度后导致的index计算错误

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -358,7 +358,7 @@ describe('Table Mode Facet With Frozen Test', () => {
     expect(viewCellHeights.getCellOffsetY(7)).toBe(210);
   });
 
-  test('should get correct indexes with row height lt canvas height', () => {
+  test('should get correct indexes with row height gt canvas height', () => {
     const originHeight = facet.panelBBox.viewportHeight;
     facet.panelBBox.viewportHeight = 10;
     expect(facet.calculateXYIndexes(0, 0)).toStrictEqual({

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -357,6 +357,19 @@ describe('Table Mode Facet With Frozen Test', () => {
     expect(viewCellHeights.getCellOffsetY(0)).toBe(0);
     expect(viewCellHeights.getCellOffsetY(7)).toBe(210);
   });
+
+  test('should get correct indexes with row height lt canvas height', () => {
+    facet.panelBBox.viewportHeight = 10;
+    expect(facet.calculateXYIndexes(0, 0)).toStrictEqual({
+      center: [2, 2, 2, 0],
+      frozenCol: [0, 1, 2, 0],
+      frozenRow: [2, 2, 0, 1],
+      frozenTrailingCol: [3, 4, 2, 0],
+      frozenTrailingRow: [2, 2, 30, 31],
+    });
+    // reset
+    facet.panelBBox.viewportHeight = 564;
+  });
 });
 
 describe('Table Mode Facet Test With Custom Row Height', () => {

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -359,6 +359,7 @@ describe('Table Mode Facet With Frozen Test', () => {
   });
 
   test('should get correct indexes with row height lt canvas height', () => {
+    const originHeight = facet.panelBBox.viewportHeight;
     facet.panelBBox.viewportHeight = 10;
     expect(facet.calculateXYIndexes(0, 0)).toStrictEqual({
       center: [2, 2, 2, 0],
@@ -368,7 +369,7 @@ describe('Table Mode Facet With Frozen Test', () => {
       frozenTrailingRow: [2, 2, 30, 31],
     });
     // reset
-    facet.panelBBox.viewportHeight = 564;
+    facet.panelBBox.viewportHeight = originHeight;
   });
 });
 

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -1012,11 +1012,13 @@ export class TableFacet extends BaseFacet {
 
     if (frozenTrailingRowCount > 0 || frozenRowCount > 0) {
       const { row, trailingRow } = this.frozenGroupInfo;
-      // canvas 高度小于row height和trailingRow height的时候 以canvas高度为准
-      if (finalViewport.height > row.height + trailingRow.height) {
+      // canvas 高度小于row height和trailingRow height的时候 height 为 0
+      if (finalViewport.height < row.height + trailingRow.height) {
+        finalViewport.height = 0;
+      } else {
         finalViewport.height -= row.height + trailingRow.height;
-        finalViewport.y += row.height;
       }
+      finalViewport.y += row.height;
     }
 
     const indexes = calculateInViewIndexes(

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -1015,10 +1015,11 @@ export class TableFacet extends BaseFacet {
       // canvas 高度小于row height和trailingRow height的时候 height 为 0
       if (finalViewport.height < row.height + trailingRow.height) {
         finalViewport.height = 0;
+        finalViewport.y = 0;
       } else {
         finalViewport.height -= row.height + trailingRow.height;
+        finalViewport.y += row.height;
       }
-      finalViewport.y += row.height;
     }
 
     const indexes = calculateInViewIndexes(

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -1012,9 +1012,11 @@ export class TableFacet extends BaseFacet {
 
     if (frozenTrailingRowCount > 0 || frozenRowCount > 0) {
       const { row, trailingRow } = this.frozenGroupInfo;
-
-      finalViewport.height -= row.height + trailingRow.height;
-      finalViewport.y += row.height;
+      // canvas 高度小于row height和trailingRow height的时候 以canvas高度为准
+      if (finalViewport.height > row.height + trailingRow.height) {
+        finalViewport.height -= row.height + trailingRow.height;
+        finalViewport.y += row.height;
+      }
     }
 
     const indexes = calculateInViewIndexes(


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->



🐛 Bugfix

- [x] Solve the issue and close



### 📝 Description

修复row高度大于canvas高度后导致的index计算错误

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
