### PR TITLE
fix: 单元格内换行存在"字符

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -12,6 +12,16 @@ import { convertString, getSelectedData } from '@/utils/export/copy';
 import { getCellMeta } from '@/utils/interaction/select-event';
 import { S2Event } from '@/common/constant';
 
+const newLineTest = `"### 问题摘要
+- **会话地址**："`;
+
+const testData = originalData.map((item, i) => {
+  if (i === 0) {
+    return { ...item, sub_type: newLineTest };
+  }
+  return { ...item };
+});
+
 describe('List Table Core Data Process', () => {
   let s2: TableSheet;
   beforeEach(() => {
@@ -22,6 +32,7 @@ describe('List Table Core Data Process', () => {
         fields: {
           columns: ['province', 'city', 'type', 'sub_type', 'number'],
         },
+        data: testData,
       }),
       assembleOptions({
         showSeriesNumber: true,
@@ -83,8 +94,8 @@ describe('List Table Core Data Process', () => {
     s2.interaction.changeState({
       stateName: InteractionStateName.ALL_SELECTED,
     });
-    expect(getSelectedData(s2).split('\n').length).toBe(32);
-    expect(getSelectedData(s2).split('\n')[1].split('\t').length).toBe(5);
+    expect(getSelectedData(s2).split('\n').length).toBe(33);
+    expect(getSelectedData(s2).split('\n')[2].split('\t').length).toBe(5);
   });
 
   it('should copy format data', () => {
@@ -153,18 +164,18 @@ describe('List Table Core Data Process', () => {
 
     const cell = s2.interaction
       .getAllCells()
-      .filter(({ cellType }) => cellType === CellTypes.ROW_CELL)[0];
+      .filter(({ cellType }) => cellType === CellTypes.ROW_CELL)[1];
 
     s2.interaction.changeState({
       cells: [getCellMeta(cell)],
       stateName: InteractionStateName.SELECTED,
     });
     const data = getSelectedData(s2);
-    expect(data).toBe('7789\t浙江省\t杭州市\t家具\t桌子');
+    expect(data).toBe('7234\t浙江省\t宁波市\t家具\t沙发');
     s2.interaction.changeState({
       stateName: InteractionStateName.ALL_SELECTED,
     });
-    expect(getSelectedData(s2).split('\n').length).toEqual(32);
+    expect(getSelectedData(s2).split('\n').length).toEqual(33);
   });
 
   it('should copy correct data with \n data', () => {

--- a/packages/s2-core/src/utils/export/copy.ts
+++ b/packages/s2-core/src/utils/export/copy.ts
@@ -77,8 +77,8 @@ const format = (
 
 export const convertString = (v: string) => {
   if (/\n/.test(v)) {
-    // 单元格内换行
-    return '"' + v.replace(/\r\n?/g, '\n') + '"';
+    // 单元格内换行 替换双引号 防止内容存在双引号 导致内容换行出错
+    return '"' + v.replace(/\r\n?/g, '\n').replace(/"/g, "'") + '"';
   }
   return v;
 };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

单元格内存在"字符会导致行内换行不生效 所以把"转成'再复制

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
