### PR TITLE
fix: pagination从null变为非空时未触发total更新

### DIFF
--- a/packages/s2-react/__tests__/unit/hooks/usePagination-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/usePagination-spec.ts
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { PivotSheet, S2Options, SpreadSheet } from '@antv/s2';
 import { getContainer } from 'tests/util/helpers';
 import * as mockDataConfig from 'tests/data/simple-data.json';
-import { omit } from 'lodash';
+import { cloneDeep, omit } from 'lodash';
 import { usePagination } from '@/hooks';
 import { BaseSheetComponentProps } from '@/components/sheets/interface';
 
@@ -71,8 +71,20 @@ describe('usePagination tests', () => {
   });
 
   test('should update total after render with new data', () => {
-    const { result } = renderHook(() => usePagination(s2, props));
+    let paginationProps = { ...props };
+    const { result, rerender } = renderHook(() =>
+      usePagination(s2, paginationProps),
+    );
 
+    expect(result.current.total).toBe(2); // 浙江-杭州、浙江-义乌
+
+    act(() => {
+      result.current.setTotal(0);
+
+      // 触发内部更新
+      paginationProps = cloneDeep(props);
+      rerender();
+    });
     expect(result.current.total).toBe(2); // 浙江-杭州、浙江-义乌
 
     act(() => {

--- a/packages/s2-react/src/hooks/usePagination.ts
+++ b/packages/s2-react/src/hooks/usePagination.ts
@@ -12,9 +12,8 @@ export const usePagination = (
   props: BaseSheetComponentProps,
 ) => {
   const { options } = props;
-  const [total, setTotal] = React.useState<number>(
-    s2?.facet?.viewCellHeights.getTotalLength() ?? 0,
-  );
+  const s2Ref = useLatest(s2);
+  const [total, setTotal] = React.useState<number>(0);
   const paginationRef = useLatest(options.pagination);
   const [current, setCurrent] = React.useState<number>(
     options.pagination?.current || DEFAULT_PAGE_NUMBER,
@@ -43,6 +42,8 @@ export const usePagination = (
   React.useEffect(() => {
     setCurrent(options?.pagination?.current || DEFAULT_PAGE_NUMBER);
     setPageSize(options?.pagination?.pageSize || DEFAULT_PAGE_SIZE);
+    setTotal(s2Ref.current?.facet?.viewCellHeights.getTotalLength() ?? 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.pagination]);
 
   // sync layout result total -> state.total


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
以下流程下，total 未更新：
1. 初始化 `options.pagnation` 为 null，且 dataCfg 为空（无数据）
2. 为 dataCfg 设置数据（填充数据）
3. 更新 `options.pagination` 为 `{ current: 10, pageSize: 20 }`

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
