### PR TITLE
fix(facet): 修复getIndexRangeWithOffsets在minHeight和maxHeight相等的情况下返回错误的情况

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/facet-spec.ts
@@ -42,4 +42,12 @@ describe('Facet util test', () => {
       end: 0,
     });
   });
+
+  test('should get correct index range with equal min and max height', () => {
+    const offsets = [0, 30, 60, 90, 120, 150, 160, 170, 190];
+    expect(getIndexRangeWithOffsets(offsets, 60, 60)).toStrictEqual({
+      start: 2,
+      end: 2,
+    });
+  });
 });

--- a/packages/s2-core/src/utils/facet.ts
+++ b/packages/s2-core/src/utils/facet.ts
@@ -47,7 +47,7 @@ export const getIndexRangeWithOffsets = (
     heights,
     (height: number, idx: number) => {
       const y = maxHeight;
-      return y > height && y <= heights[idx + 1];
+      return y >= height && y < heights[idx + 1];
     },
     yMin,
   );


### PR DESCRIPTION
…min and max height

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

当minHeight等于maxHeight和某个heights节点时，yMax会因为findIndex的startIndex设置问题导致找不到当前节点所在index。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
