### PR TITLE
fix: headerActionIcons更新覆盖了下钻icon展示

### DIFF
--- a/packages/s2-react/__tests__/spreadsheet/drill-down-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/drill-down-spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { GuiIcon, Node, RowCell, S2Options, SpreadSheet } from '@antv/s2';
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { get, noop } from 'lodash';
+import { BaseSheetComponentProps, SheetComponent } from '../../src';
+import { getContainer } from '../util/helpers';
+
+const s2Options: S2Options = {
+  width: 600,
+  height: 600,
+  hierarchyType: 'tree',
+};
+
+const partDrillDownParams: BaseSheetComponentProps['partDrillDown'] = {
+  drillConfig: {
+    dataSet: [
+      {
+        name: '地区',
+        value: 'area',
+      },
+    ],
+  },
+  fetchData: () =>
+    Promise.resolve({
+      drillField: 'area',
+      drillData: [],
+    }),
+};
+
+const findDrillDownIcon = (instance: SpreadSheet) => {
+  const rowHeaderActionIcons = get(
+    (instance.facet.rowHeader.getChildren() as RowCell[]).find(
+      (item) => item.getActualText() === '杭州',
+    ),
+    'actionIcons',
+    [],
+  );
+
+  return rowHeaderActionIcons.find(
+    (icon: GuiIcon) => icon.cfg.name === 'DrillDownIcon',
+  );
+};
+
+describe('Spread Sheet Drill Down Tests', () => {
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    container = getContainer();
+  });
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  test('should render drill down icon', () => {
+    let s2Instance: SpreadSheet = null;
+
+    // 首次 render
+    act(() => {
+      ReactDOM.render(
+        <SheetComponent
+          options={s2Options}
+          dataCfg={mockDataConfig}
+          getSpreadSheet={(instance) => {
+            s2Instance = instance;
+          }}
+          partDrillDown={partDrillDownParams}
+        />,
+        container,
+      );
+    });
+    expect(findDrillDownIcon(s2Instance)).toBeDefined();
+
+    // update options.headerActionIcons
+    act(() => {
+      ReactDOM.render(
+        <SheetComponent
+          options={{
+            ...s2Options,
+            headerActionIcons: [
+              {
+                iconNames: ['SortDown'],
+                belongsCell: 'colCell',
+                displayCondition: (meta: Node) => {
+                  return meta.isLeaf;
+                },
+                action: noop,
+              },
+            ],
+          }}
+          dataCfg={mockDataConfig}
+          getSpreadSheet={(instance) => {
+            s2Instance = instance;
+          }}
+          partDrillDown={partDrillDownParams}
+        />,
+        container,
+      );
+    });
+    expect(findDrillDownIcon(s2Instance)).toBeDefined();
+  });
+});

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -120,6 +120,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
       partDrillDown?.displayCondition,
       partDrillDown?.drillItemsNum,
       options.hierarchyType,
+      options.headerActionIcons,
     ]);
 
     return <BaseSheet {...props} ref={s2Ref} />;


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
说明：当表格 react 组件渲染完成后，再次更新 `props.options.headerActionIcons`，会导致下钻 icon 缺失不展示。
原因：
drillDownIcon 是由 react 组件层塞入到底表 headerActionIcons 中的
外部 `props.options.headerActionIcons` 更新会导致跳过上述的插入逻辑，并覆盖改底表的 headerActionIcons 数组
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
