### PR TITLE
feat: 支持自定义角头的虚拟数值字段文本 close #1212

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,4 @@ packages/s2-*/dist/
 packages/s2-*/coverage/
 packages/s2-*/stats.html
 
-
-
-
+.swc

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -2,7 +2,7 @@
 import { getContainer } from 'tests/util/helpers';
 import * as dataCfg from 'tests/data/simple-data.json';
 import { Canvas, Event as GEvent } from '@antv/g-canvas';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, get, last } from 'lodash';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
 import {
   CellTypes,
@@ -20,6 +20,7 @@ import {
 import { Node } from '@/facet/layout/node';
 import { customMerge, getSafetyDataConfig } from '@/utils';
 import { BaseTooltip } from '@/ui/tooltip';
+import { CornerCell } from '@/cell/corner-cell';
 
 const originalDataCfg = cloneDeep(dataCfg);
 
@@ -53,8 +54,8 @@ describe('PivotSheet Tests', () => {
   });
 
   afterAll(() => {
-    container?.remove();
-    s2?.destroy();
+    // container?.remove();
+    // s2?.destroy();
   });
 
   describe('PivotSheet Tooltip Tests', () => {
@@ -619,6 +620,40 @@ describe('PivotSheet Tests', () => {
     ).toBeFalsy();
 
     renderSpy.mockRestore();
+  });
+
+  test('should get extra field text', () => {
+    s2.setDataCfg(
+      customMerge(originalDataCfg, {
+        fields: {
+          valueInCols: false,
+        },
+      }),
+    );
+    s2.render();
+
+    const extraField = last(s2.facet.cornerHeader.getChildren()) as CornerCell;
+    expect(get(extraField, 'actualText')).toEqual('数值');
+  });
+
+  // https://github.com/antvis/S2/issues/1212
+  test('should get custom extra field text', () => {
+    const cornerExtraFieldText = 'custom';
+
+    s2.setDataCfg(
+      customMerge(originalDataCfg, {
+        fields: {
+          valueInCols: false,
+        },
+      }),
+    );
+    s2.setOptions({
+      cornerExtraFieldText,
+    });
+    s2.render();
+
+    const extraField = last(s2.facet.cornerHeader.getChildren()) as CornerCell;
+    expect(get(extraField, 'actualText')).toEqual(cornerExtraFieldText);
   });
 
   describe('Tree Collapse Tests', () => {

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -623,16 +623,20 @@ describe('PivotSheet Tests', () => {
   });
 
   test('should get extra field text', () => {
-    s2.setDataCfg(
+    const pivotSheet = new PivotSheet(
+      container,
       customMerge(originalDataCfg, {
         fields: {
           valueInCols: false,
         },
       }),
+      s2Options,
     );
-    s2.render();
+    pivotSheet.render();
 
-    const extraField = last(s2.facet.cornerHeader.getChildren()) as CornerCell;
+    const extraField = last(
+      pivotSheet.facet.cornerHeader.getChildren(),
+    ) as CornerCell;
     expect(get(extraField, 'actualText')).toEqual('数值');
   });
 
@@ -640,19 +644,23 @@ describe('PivotSheet Tests', () => {
   test('should get custom extra field text', () => {
     const cornerExtraFieldText = 'custom';
 
-    s2.setDataCfg(
+    const pivotSheet = new PivotSheet(
+      container,
       customMerge(originalDataCfg, {
         fields: {
           valueInCols: false,
         },
       }),
+      {
+        ...s2Options,
+        cornerExtraFieldText,
+      },
     );
-    s2.setOptions({
-      cornerExtraFieldText,
-    });
-    s2.render();
+    pivotSheet.render();
 
-    const extraField = last(s2.facet.cornerHeader.getChildren()) as CornerCell;
+    const extraField = last(
+      pivotSheet.facet.cornerHeader.getChildren(),
+    ) as CornerCell;
     expect(get(extraField, 'actualText')).toEqual(cornerExtraFieldText);
   });
 

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -54,8 +54,8 @@ describe('PivotSheet Tests', () => {
   });
 
   afterAll(() => {
-    // container?.remove();
-    // s2?.destroy();
+    container?.remove();
+    s2?.destroy();
   });
 
   describe('PivotSheet Tooltip Tests', () => {

--- a/packages/s2-core/__tests__/unit/utils/merge-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-spec.ts
@@ -103,6 +103,7 @@ describe('merge test', () => {
       hierarchyType: 'grid',
       conditions: {},
       cornerText: '',
+      cornerExtraFieldText: '',
       totals: {},
       tooltip: {
         showTooltip: false,

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -71,14 +71,11 @@ export class CornerCell extends HeaderCell {
   }
 
   protected drawCellText() {
-    const { label } = this.meta;
-
     const { x } = this.getContentArea();
     const { y, height } = this.getCellArea();
 
     const textStyle = this.getTextStyle();
-
-    const cornerText = this.getCornerText(label);
+    const cornerText = this.getCornerText();
 
     // 当为树状结构下需要计算文本前收起展开的icon占的位置
 
@@ -378,8 +375,8 @@ export class CornerCell extends HeaderCell {
     };
   }
 
-  protected getCornerText(label: string): string {
-    if (isEqual(label, EXTRA_FIELD)) {
+  protected getCornerText(): string {
+    if (isEqual(this.meta.label, EXTRA_FIELD)) {
       return this.spreadsheet.options?.cornerText || DEFAULT_CORNER_TEXT;
     }
 

--- a/packages/s2-core/src/common/constant/options.ts
+++ b/packages/s2-core/src/common/constant/options.ts
@@ -86,6 +86,7 @@ export const DEFAULT_OPTIONS: Readonly<S2Options> = {
   frozenTrailingColCount: 0,
   hdAdapter: true,
   cornerText: '',
+  cornerExtraFieldText: '',
   placeholder: EMPTY_PLACEHOLDER,
   supportCSSTransform: false,
   devicePixelRatio: window.devicePixelRatio,

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -68,6 +68,8 @@ export interface S2BasicOptions<T = Element | string> {
   readonly placeholder?: string;
   // custom corner text
   readonly cornerText?: string;
+  // custom virtual extra field text
+  readonly cornerExtraFieldText?: string;
   readonly supportCSSTransform?: boolean;
   // custom device pixel ratio, default "window.devicePixelRatio"
   readonly devicePixelRatio?: number;

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -299,7 +299,7 @@ export class PivotDataSet extends BaseDataSet {
 
     // 虚拟列字段，为文本分类字段
     const extraFieldName =
-      this.spreadsheet?.options?.cornerExtraFieldText ?? i18n('数值');
+      this.spreadsheet?.options?.cornerExtraFieldText || i18n('数值');
 
     const extraFieldMeta: Meta = {
       field: EXTRA_FIELD,

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -74,9 +74,6 @@ export class PivotDataSet extends BaseDataSet {
   // sorted dimension values
   public sortedDimensionValues: SortedDimensionValues;
 
-  // each path items max index
-  protected pathIndexMax = [];
-
   /**
    * When data related config changed, we need
    * 1、re-process config
@@ -281,6 +278,7 @@ export class PivotDataSet extends BaseDataSet {
   }
 
   public processDataCfg(dataCfg: S2DataConfig): S2DataConfig {
+    const { cornerExtraFieldText } = this.spreadsheet.options;
     const { data, meta = [], fields, sortParams = [], totalData } = dataCfg;
     const { columns, rows, values, valueInCols, customValueOrder } = fields;
     let newColumns = columns;
@@ -300,20 +298,17 @@ export class PivotDataSet extends BaseDataSet {
       return get(findOne, 'name', value);
     };
 
-    const newMeta = [
-      ...meta,
-      // 虚拟列字段，为文本分类字段
-      {
-        field: EXTRA_FIELD,
-        name: i18n('数值'),
-        formatter: (value: string) => valueFormatter(value),
-      } as Meta,
-    ];
+    // 虚拟列字段，为文本分类字段
+    const extraFieldMeta: Meta = {
+      field: EXTRA_FIELD,
+      name: cornerExtraFieldText || i18n('数值'),
+      formatter: (value: string) => valueFormatter(value),
+    };
+    const newMeta: Meta[] = [...meta, extraFieldMeta];
 
     const newData = this.standardTransform(data, values);
     const newTotalData = this.standardTransform(totalData, values);
 
-    // 返回新的结构
     return {
       data: newData,
       meta: newMeta,

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -278,7 +278,6 @@ export class PivotDataSet extends BaseDataSet {
   }
 
   public processDataCfg(dataCfg: S2DataConfig): S2DataConfig {
-    const { cornerExtraFieldText } = this.spreadsheet.options;
     const { data, meta = [], fields, sortParams = [], totalData } = dataCfg;
     const { columns, rows, values, valueInCols, customValueOrder } = fields;
     let newColumns = columns;
@@ -294,14 +293,17 @@ export class PivotDataSet extends BaseDataSet {
     }
 
     const valueFormatter = (value: string) => {
-      const findOne = find(meta, (mt: Meta) => mt.field === value);
-      return get(findOne, 'name', value);
+      const currentMeta = find(meta, ({ field }: Meta) => field === value);
+      return get(currentMeta, 'name', value);
     };
 
     // 虚拟列字段，为文本分类字段
+    const extraFieldName =
+      this.spreadsheet?.options?.cornerExtraFieldText ?? i18n('数值');
+
     const extraFieldMeta: Meta = {
       field: EXTRA_FIELD,
-      name: cornerExtraFieldText || i18n('数值'),
+      name: extraFieldName,
       formatter: (value: string) => valueFormatter(value),
     };
     const newMeta: Meta[] = [...meta, extraFieldMeta];

--- a/packages/s2-react/__tests__/unit/utils/options-spec.ts
+++ b/packages/s2-react/__tests__/unit/utils/options-spec.ts
@@ -55,6 +55,7 @@ describe('Options Tests', () => {
       frozenTrailingColCount: 0,
       hdAdapter: true,
       cornerText: '',
+      cornerExtraFieldText: '',
       placeholder: '-',
       supportCSSTransform: false,
       devicePixelRatio: window.devicePixelRatio,

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -96,6 +96,7 @@ export const s2Options: S2Options = {
   interaction: {
     enableCopy: true,
   },
+  cornerExtraFieldText: '11',
 };
 
 export const sliderOptions: SliderSingleProps = {

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -96,7 +96,6 @@ export const s2Options: S2Options = {
   interaction: {
     enableCopy: true,
   },
-  cornerExtraFieldText: '11',
 };
 
 export const sliderOptions: SliderSingleProps = {

--- a/s2-site/docs/api/general/S2Options.zh.md
+++ b/s2-site/docs/api/general/S2Options.zh.md
@@ -28,8 +28,8 @@ order: 1
 | hdAdapter | `boolean` |  |   `true` | 是否开启高清屏适配，解决多屏切换，高清视网膜屏字体渲染模糊的问题 |
 | mergedCellsInfo | [MergedCellInfo[][]](#mergedcellinfo) |    |  | 合并单元格信息 |
 | placeholder | string |    |  | 空单元格的填充内容 |
-| cornerText | string |    |  | 自定义角头文本 |
-| cornerExtraFieldText | string |    |  | 自定义角头虚拟数值字段文本 （数值挂行头时，替换 "数值" 这两个字） |
+| cornerText | string |    |  | 自定义角头文本 （自定义树 `hierarchyType: customTree` 时有效） |
+| cornerExtraFieldText | string |    |  | 自定义角头虚拟数值字段文本 （数值挂行头时有效，替换 "数值" 这两个字） |
 | dataCell | [DataCellCallback](#datacellcallback) |  |    | 自定义单元格 cell |
 | cornerCell | [CellCallback](#cellcallback) |  |    | 自定义 cornerCell |
 | rowCell | [CellCallback](#cellcallback) |  |  |   自定义行头 cell |

--- a/s2-site/docs/api/general/S2Options.zh.md
+++ b/s2-site/docs/api/general/S2Options.zh.md
@@ -28,7 +28,8 @@ order: 1
 | hdAdapter | `boolean` |  |   `true` | 是否开启高清屏适配，解决多屏切换，高清视网膜屏字体渲染模糊的问题 |
 | mergedCellsInfo | [MergedCellInfo[][]](#mergedcellinfo) |    |  | 合并单元格信息 |
 | placeholder | string |    |  | 空单元格的填充内容 |
-| cornerText | string |    |  | 自定义角头显示文本 |
+| cornerText | string |    |  | 自定义角头文本 |
+| cornerExtraFieldText | string |    |  | 自定义角头虚拟数值字段文本 （数值挂行头时，替换 "数值" 这两个字） |
 | dataCell | [DataCellCallback](#datacellcallback) |  |    | 自定义单元格 cell |
 | cornerCell | [CellCallback](#cellcallback) |  |    | 自定义 cornerCell |
 | rowCell | [CellCallback](#cellcallback) |  |  |   自定义行头 cell |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

![image](https://user-images.githubusercontent.com/21015895/160836329-9efaf2fd-1319-407f-a306-3bbe87e0fe6c.png)

数值挂行头时有效

这里有个特殊点就是如果这个 options 更改, 对应 react 是 `s2.render(false)` 即不重新加载数据, 但是这里文本其实对应 dataCfg 一部分, 需要 `s2.render(true)` 才行, 但考虑到这个文本应该不会有变更的场景 (cornerText. 也有这个问题), 所以暂时未做处理 : 

```ts
React.useEffect(() => {
  const reloadData = prevText !== text
  s2.render(reloadData)
},[s2Options])
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

close #1212 

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
