### PR TITLE
fix(copy): 修复因为header的key内带有‘-’字符串导致的row和col id识别错误

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -393,4 +393,42 @@ describe('Pivot Table Core Data Process', () => {
     const data = getSelectedData(sss);
     expect(data).toBe(convertString(`7789\n元`));
   });
+
+  it('should get correct data with - string in header', () => {
+    const s2New = new PivotSheet(
+      getContainer(),
+      assembleDataCfg({
+        meta: [{ field: 'number', formatter: (v) => v + '\n元' }],
+        fields: {
+          columns: ['type', 'sub_type'],
+          rows: ['province', 'city'],
+          values: ['number'],
+        },
+        data: originalData.map((item) => {
+          return {
+            ...item,
+            province: item.province + '-1',
+          };
+        }),
+      }),
+      assembleOptions({
+        interaction: {
+          enableCopy: true,
+          copyWithFormat: true,
+        },
+        showSeriesNumber: false,
+      }),
+    );
+    s2New.render();
+    const cell = s2New.interaction
+      .getAllCells()
+      .filter(({ cellType }) => cellType === CellTypes.DATA_CELL)[0];
+
+    s2New.interaction.changeState({
+      cells: [getCellMeta(cell)],
+      stateName: InteractionStateName.SELECTED,
+    });
+    const data = getSelectedData(s2New);
+    expect(data).toBe(convertString(`7789\n元`));
+  });
 });

--- a/packages/s2-core/src/utils/export/copy.ts
+++ b/packages/s2-core/src/utils/export/copy.ts
@@ -30,10 +30,10 @@ const getFiledIdFromMeta = (meta: CellMeta, spreadsheet: SpreadSheet) => {
 };
 
 const getHeaderNodeFromMeta = (meta: CellMeta, spreadsheet: SpreadSheet) => {
-  const [rowId, colId] = meta.id.split('-');
+  const { rowIndex, colIndex } = meta;
   return [
-    spreadsheet.getRowNodes().find((row) => row.id === rowId),
-    spreadsheet.getColumnNodes().find((col) => col.id === colId),
+    spreadsheet.getRowNodes().find((row) => row.rowIndex === rowIndex),
+    spreadsheet.getColumnNodes().find((col) => col.colIndex === colIndex),
   ];
 };
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1220 


### 📝 Description

场景：复制功能报错
原因：获取当前单元格的rowHeader和colHeader时，因为header内自带了‘-’字符串，导致id切分识别错误
修复：通过meta中的rowIndex和colIndex获取到headerCell

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
