### PR TITLE
chore: 修复刷选测试用例稳定性问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
@@ -107,7 +107,7 @@ describe('Brush selection scroll spec', () => {
     const brushInteraction = s2.interaction.interactions.get(
       InteractionName.BRUSH_SELECTION,
     ) as BrushSelection;
-    // expect(brushInteraction.mouseMoveDistanceFromCanvas).toBeGreaterThan(0);
+
     const brushRange = brushInteraction.getBrushRange();
     const allCells = s2.interaction.getCells();
     const lastCell = allCells[allCells.length - 1];
@@ -115,21 +115,15 @@ describe('Brush selection scroll spec', () => {
     expect(brushRange.start.rowIndex).toBe(allCells[0].rowIndex);
     expect(brushRange.end.colIndex).toBe(lastCell.colIndex);
     expect(brushRange.end.rowIndex).toBe(lastCell.rowIndex);
-  });
 
-  test('Should scroll with frozen rows when mouse outside canvas', async () => {
-    const s2 = new TableSheet(getContainer(), dataCfg, {
-      ...options,
+    s2.setOptions({
       frozenColCount: 2,
       frozenRowCount: 2,
       frozenTrailingColCount: 2,
       frozenTrailingRowCount: 2,
     });
-
     s2.render();
-    const offsetY = s2.container.get('el').getBoundingClientRect().top;
-    const dataCells = s2.frozenTopGroup.getChildren();
-    const target = dataCells.find((item) => item instanceof DataCell);
+    s2.interaction.reset();
 
     s2.emit(S2Event.DATA_CELL_MOUSE_DOWN, {
       target,
@@ -139,21 +133,21 @@ describe('Brush selection scroll spec', () => {
 
     s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
       clientX: 400,
-      clientY: 400 + offsetY,
+      clientY: 400,
       preventDefault() {},
     } as any);
     await sleep(40);
 
     s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
       clientX: 400,
-      clientY: 1000 + offsetY,
+      clientY: 1000,
       preventDefault() {},
     } as any);
-    await sleep(30);
+    await sleep(60);
 
     s2.emit(S2Event.GLOBAL_MOUSE_UP, {
       clientX: 400,
-      clientY: 1000 + offsetY,
+      clientY: 1000,
       preventDefault() {},
     } as any);
 


### PR DESCRIPTION
### 👀 PR includes

把两个测试，两次创建 S2 DOM 节点合并到一个 case 里。避免 DOM 节点创建时候可能有一些 race 的情况。