### PR TITLE
fix(s2): 如果是 table mode，列头不需要被格式化

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/header-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/header-cell-spec.ts
@@ -1,0 +1,93 @@
+import { PivotSheet, SpreadSheet, TableSheet } from '@/sheet-type';
+import { PivotDataSet, TableDataSet } from '@/data-set';
+import { Formatter } from '@/common';
+import { ColCell, CornerCell, RowCell } from '@/cell';
+import { Node } from '@/facet/layout/node';
+
+const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
+const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
+const MockTableSheet = TableSheet as unknown as jest.Mock<TableSheet>;
+const MockTableDataSet = TableDataSet as unknown as jest.Mock<TableDataSet>;
+
+describe('header cell formatter test', () => {
+  const root = new Node({ id: `root`, key: '', value: '', children: [] });
+
+  const colNode = new Node({
+    id: `root[&]浙江`,
+    key: '',
+    value: '浙江',
+    field: 'province',
+    parent: root,
+    label: '浙江',
+  });
+  const rowNode = new Node({
+    id: `root[&]杭州`,
+    key: '',
+    value: '杭州',
+    field: 'city',
+    parent: root,
+    label: '杭州',
+  });
+
+  let s2: SpreadSheet;
+  describe('pivot header cell formatter test', () => {
+    beforeEach(() => {
+      const container = document.createElement('div');
+
+      s2 = new MockPivotSheet(container);
+      s2.dataSet = new MockPivotDataSet(s2);
+    });
+
+    test('pivot col cell and row cell formatter', () => {
+      const formatter: Formatter = (value) => {
+        return `${value}1`;
+      };
+      jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+
+      const rowCell = new RowCell(rowNode, s2);
+      const colCell = new ColCell(colNode, s2);
+
+      expect(colCell.getFieldValue()).toBe('浙江1');
+      expect(rowCell.getFieldValue()).toBe('杭州1');
+    });
+
+    test('pivot corner cell not formatter', () => {
+      const formatter: Formatter = (value) => {
+        return `${value}1`;
+      };
+      jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+      const cornerOption = {
+        spreadsheet: {
+          isHierarchyTreeType: () => jest.fn().mockReturnValue(false),
+        },
+        position: {
+          x: 30,
+          y: 30,
+        },
+      };
+
+      const cornerCell = new CornerCell(rowNode, s2, cornerOption);
+      expect(cornerCell.getFieldValue()).toBe('杭州');
+    });
+  });
+
+  describe('table header cell formatter test', () => {
+    beforeEach(() => {
+      const container = document.createElement('div');
+
+      s2 = new MockTableSheet(container);
+      s2.dataSet = new MockTableDataSet(s2);
+    });
+
+    test('table col cell not formatter', () => {
+      const formatter: Formatter = (value) => {
+        return `${value}1`;
+      };
+      jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+
+      const colCell = new ColCell(colNode, s2);
+
+      expect(colCell.getFieldValue()).toBe('浙江');
+    });
+  });
+});

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -18,6 +18,7 @@ import { S2Event } from '@/common/constant';
 import { CellTypes } from '@/common/constant';
 import { getSortTypeIcon } from '@/utils/sort-action';
 import { SortParam } from '@/common/interface';
+import { TableColCell } from '@/cell/table-col-cell';
 
 export abstract class HeaderCell extends BaseCell<Node> {
   protected headerConfig: BaseHeaderConfig;
@@ -59,7 +60,9 @@ export abstract class HeaderCell extends BaseCell<Node> {
       this.meta.field,
     );
 
-    if (formatter) {
+    const isTableMode = this.spreadsheet.isTableMode();
+    // 如果是 table mode，列头不需要被格式化
+    if (formatter && !isTableMode) {
       content = formatter(label);
     }
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

fix(s2): 如果是 table mode，列头不需要被格式化
🐛 Bugfix

- [X] Solve the issue and close #0

🔧 Chore

- [X] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| <img width="906" alt="image" src="https://user-images.githubusercontent.com/20497176/162740541-e5a9781b-db13-4621-9af0-7fe7802da085.png"> |<img width="880" alt="image" src="https://user-images.githubusercontent.com/20497176/162740239-02d5e0eb-ef7f-4948-8200-ccae149239cf.png">|


### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
