### PR TITLE
chore(ci): 修复自动发布后不能自动更新版本号的问题

### DIFF
--- a/.releaserc.base.js
+++ b/.releaserc.base.js
@@ -10,13 +10,13 @@ module.exports = {
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
+    '@semantic-release/npm',
     [
       '@semantic-release/git',
       {
         message: 'chore(release): 🤖 ${nextRelease.gitTag} [skip ci]',
       },
     ],
-    '@semantic-release/npm',
     '@semantic-release/github',
   ],
   preset: 'angular',


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [x] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

解决 semantic-release 只会提交 changelog, 不包含 package.json 的 version 修改问题
原因: @semantic-release/npm 需要在 @semantic-release/git 插件后, 应该是先发包, 再提交

