### PR TITLE
fix: headerActionIcons更新不应清除上一次下钻数据

### DIFF
--- a/packages/s2-react/__tests__/spreadsheet/drill-down-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/drill-down-spec.tsx
@@ -13,6 +13,9 @@ const s2Options: S2Options = {
   hierarchyType: 'tree',
 };
 
+/** 下钻展示数量 */
+const EXPECT_DRILL_ITEMS_NUM = 3;
+
 const partDrillDownParams: BaseSheetComponentProps['partDrillDown'] = {
   drillConfig: {
     dataSet: [
@@ -72,6 +75,10 @@ describe('Spread Sheet Drill Down Tests', () => {
     });
     expect(findDrillDownIcon(s2Instance)).toBeDefined();
 
+    // mock drill down
+    s2Instance.store.set('drillDownIdPathMap', new Map());
+    s2Instance.store.set('drillItemsNum', EXPECT_DRILL_ITEMS_NUM);
+
     // update options.headerActionIcons
     act(() => {
       ReactDOM.render(
@@ -99,5 +106,10 @@ describe('Spread Sheet Drill Down Tests', () => {
       );
     });
     expect(findDrillDownIcon(s2Instance)).toBeDefined();
+
+    // render new headerActionIcons should not clear data
+    expect(s2Instance.store.get('drillItemsNum')).toEqual(
+      EXPECT_DRILL_ITEMS_NUM,
+    );
   });
 });

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -109,7 +109,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
     }, [partDrillDown?.clearDrillDown]);
 
     /**
-     * 表格重渲染 effect
+     * 表格完全渲染（清空下钻）
      */
     React.useEffect(() => {
       updateDrillDownOptions();
@@ -120,8 +120,16 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
       partDrillDown?.displayCondition,
       partDrillDown?.drillItemsNum,
       options.hierarchyType,
-      options.headerActionIcons,
     ]);
+
+    /**
+     * 表格仅重渲染视图（不清空数据）
+     */
+    React.useEffect(() => {
+      updateDrillDownOptions();
+      s2Ref.current.render(false);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [options.headerActionIcons]);
 
     return <BaseSheet {...props} ref={s2Ref} />;
   },


### PR DESCRIPTION
### 👀 PR includes
🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [x] Test case

### 📝 Description
在 #1222 中，修复了 headerActionIcons 变化时没有重新 render 的问题，但是默认的 `render()` 调用，会清除下钻数据 `clearDrillDownData@packages/s2-core/src/sheet-type/pivot-sheet.ts`。

考虑 deps 中 diff 的是 headerActionIcons 引用，业务层如何使用不可预知，所以变化时需调用 `render(false)`， 即仅更新 UI可。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
