### PR TITLE
feat(interaction): 支持行列头反选

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/interaction-tooltip-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-tooltip-spec.ts
@@ -19,7 +19,7 @@ describe('Interaction Tooltip Tests', () => {
   beforeEach(() => {
     jest
       .spyOn(SpreadSheet.prototype, 'getCell')
-      .mockImplementation(() => createMockCellInfo('testId').mockCell as any);
+      .mockImplementation(() => createMockCellInfo('testId').mockCell);
 
     s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
     s2.render();

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -4,8 +4,8 @@ import { PivotSheet, TableSheet } from '@/sheet-type';
 import { S2Event, S2Options } from '@/common';
 
 const s2Options: S2Options = {
-  width: 800,
-  height: 600,
+  width: 200,
+  height: 200,
   hierarchyType: 'grid',
   hdAdapter: true,
 };
@@ -31,6 +31,8 @@ describe('SpreadSheet Tests', () => {
       expect(s2.container).toBeDefined();
       expect(s2.container.get('el')).toBeInstanceOf(HTMLCanvasElement);
       expect(container.querySelector('canvas')).toBeDefined();
+
+      s2.destroy();
     });
 
     test('should init sheet by selector container', () => {
@@ -74,6 +76,8 @@ describe('SpreadSheet Tests', () => {
       expect(canvas.height).toEqual(s2Options.height * devicePixelRatio);
       expect(canvas.style.width).toEqual(`${s2Options.width}px`);
       expect(canvas.style.height).toEqual(`${s2Options.height}px`);
+
+      s2.destroy();
     });
 
     test('should render sheet if custom DPR less than zero', () => {
@@ -88,6 +92,8 @@ describe('SpreadSheet Tests', () => {
       expect(canvas.height).toEqual(s2Options.height);
       expect(canvas.style.width).toEqual(`${s2Options.width}px`);
       expect(canvas.style.height).toEqual(`${s2Options.height}px`);
+
+      s2.destroy();
     });
 
     test('should update scroll offset immediately', () => {
@@ -117,6 +123,8 @@ describe('SpreadSheet Tests', () => {
       await sleep(1000);
 
       expect(render).toHaveBeenCalledTimes(1);
+
+      s2.destroy();
     });
   });
 
@@ -159,19 +167,21 @@ describe('SpreadSheet Tests', () => {
 
         expect(s2.container.get('el')).not.toBeDefined();
         expect(container.querySelectorAll('canvas')).toHaveLength(0);
+
+        s2.destroy();
       },
     );
 
     // https://github.com/antvis/S2/issues/1011
     test('should toggle sheet type', () => {
       const container = getContainer();
-      const pivotSheet = new PivotSheet(container, mockDataConfig, s2Options);
-      pivotSheet.render();
+      const s2 = new PivotSheet(container, mockDataConfig, s2Options);
+      s2.render();
 
-      expect(pivotSheet).toBeInstanceOf(PivotSheet);
+      expect(s2).toBeInstanceOf(PivotSheet);
       expect(container.querySelectorAll('canvas')).toHaveLength(1);
 
-      pivotSheet.destroy();
+      s2.destroy();
       const tableSheet = new TableSheet(container, mockDataConfig, s2Options);
       tableSheet.render();
 

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -4,8 +4,8 @@ import { PivotSheet, TableSheet } from '@/sheet-type';
 import { S2Event, S2Options } from '@/common';
 
 const s2Options: S2Options = {
-  width: 200,
-  height: 200,
+  width: 800,
+  height: 600,
   hierarchyType: 'grid',
   hdAdapter: true,
 };

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -49,7 +49,6 @@ describe('Interaction Data Cell Click Tests', () => {
     s2.interaction.getActiveCells = () => [mockCell] as unknown as S2CellType[];
     s2.interaction.getRowColActiveCells = () =>
       [mockCell] as unknown as S2CellType[];
-    // s2.interaction.reset = jest.fn();
     rowColumnClick = new RowColumnClick(s2 as unknown as SpreadSheet);
     s2.isHierarchyTreeType = () => false;
     s2.dataCfg = {
@@ -218,5 +217,7 @@ describe('Interaction Data Cell Click Tests', () => {
     expect(resetSpy).toHaveBeenCalledTimes(1);
     // rerender table
     expect(s2.render).toHaveBeenCalledTimes(1);
+
+    resetSpy.mockRestore();
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -1,5 +1,6 @@
 import { createFakeSpreadSheet, createMockCellInfo } from 'tests/util/helpers';
 import { Event as GEvent } from '@antv/g-canvas';
+import { S2CellType } from './../../../src/common/interface/interaction';
 import { S2Options } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import {
@@ -95,7 +96,7 @@ describe('Interaction Range Selection Tests', () => {
     });
   });
 
-  test('should select range data', () => {
+  test('should select range cells', () => {
     jest.spyOn(s2, 'showTooltipWithInfo').mockImplementationOnce(() => {});
 
     s2.interaction.changeState({
@@ -116,20 +117,21 @@ describe('Interaction Range Selection Tests', () => {
     const mockCell10 = createMockCellInfo('1-0', { rowIndex: 1, colIndex: 0 });
     const mockCell11 = createMockCellInfo('1-1', { rowIndex: 1, colIndex: 1 });
 
-    s2.store.set('lastClickedCell', mockCell00.mockCell as any);
+    const activeCells: S2CellType[] = [
+      mockCell00.mockCell,
+      mockCell10.mockCell,
+      mockCell01.mockCell,
+      mockCell11.mockCell,
+    ];
+
+    s2.store.set('lastClickedCell', mockCell00.mockCell);
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.SHIFT,
     } as KeyboardEvent);
 
     s2.getCell = () => mockCell11.mockCell as any;
 
-    s2.interaction.getActiveCells = () =>
-      [
-        mockCell00.mockCell,
-        mockCell10.mockCell,
-        mockCell01.mockCell,
-        mockCell11.mockCell,
-      ] as any;
+    s2.interaction.getActiveCells = () => activeCells;
 
     const selected = jest.fn();
     s2.on(S2Event.GLOBAL_SELECTED, selected);
@@ -151,12 +153,7 @@ describe('Interaction Range Selection Tests', () => {
       ],
       stateName: InteractionStateName.SELECTED,
     });
-    expect(selected).toHaveBeenCalledWith([
-      mockCell00.mockCell,
-      mockCell10.mockCell,
-      mockCell01.mockCell,
-      mockCell11.mockCell,
-    ]);
+    expect(selected).toHaveBeenCalledWith(activeCells);
     expect(
       s2.interaction.hasIntercepts([InterceptType.CLICK, InterceptType.HOVER]),
     ).toBeTruthy();

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@/common/constant';
 import { RangeSelection } from '@/interaction/range-selection';
 
+jest.mock('@/utils/tooltip');
 jest.mock('@/interaction/event-controller');
 jest.mock('@/interaction/base-interaction/click/data-cell-click');
 
@@ -95,6 +96,8 @@ describe('Interaction Range Selection Tests', () => {
   });
 
   test('should select range data', () => {
+    jest.spyOn(s2, 'showTooltipWithInfo').mockImplementationOnce(() => {});
+
     s2.interaction.changeState({
       cells: [],
       stateName: InteractionStateName.SELECTED,
@@ -157,6 +160,6 @@ describe('Interaction Range Selection Tests', () => {
     expect(
       s2.interaction.hasIntercepts([InterceptType.CLICK, InterceptType.HOVER]),
     ).toBeTruthy();
-    expect(s2.hideTooltip).toHaveBeenCalled();
+    expect(s2.showTooltipWithInfo).toHaveBeenCalled();
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -1,6 +1,6 @@
 import { createFakeSpreadSheet, createMockCellInfo } from 'tests/util/helpers';
 import { Event as GEvent } from '@antv/g-canvas';
-import { S2CellType } from './../../../src/common/interface/interaction';
+import { S2CellType } from '@/common/interface/interaction';
 import { S2Options } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import {

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -25,6 +25,7 @@ import {
   BaseEvent,
   GuiIcon,
   S2CellType,
+  S2Event,
 } from '@/index';
 import { Store } from '@/common/store';
 import { mergeCell, unmergeCell } from '@/utils/interaction/merge-cell';
@@ -162,8 +163,6 @@ describe('RootInteraction Tests', () => {
 
   // https://github.com/antvis/S2/issues/1243
   test('should multi selected header cells', () => {
-    rootInteraction.reset();
-
     const isEqualStateNameSpy = jest
       .spyOn(rootInteraction, 'isEqualStateName')
       .mockImplementation(() => false);
@@ -177,7 +176,10 @@ describe('RootInteraction Tests', () => {
       isMultiSelection: true,
     });
 
-    expect(rootInteraction.getState().cells).toEqual([getCellMeta(mockCellA)]);
+    expect(rootInteraction.getState().cells).toEqual([
+      getCellMeta(mockCell),
+      getCellMeta(mockCellA),
+    ]);
 
     // 选中 cellB
     rootInteraction.selectHeaderCell({
@@ -186,6 +188,7 @@ describe('RootInteraction Tests', () => {
     });
 
     expect(rootInteraction.getState().cells).toEqual([
+      getCellMeta(mockCell),
       getCellMeta(mockCellA),
       getCellMeta(mockCellB),
     ]);
@@ -197,7 +200,10 @@ describe('RootInteraction Tests', () => {
     });
 
     // 取消选中
-    expect(rootInteraction.getState().cells).toEqual([getCellMeta(mockCellA)]);
+    expect(rootInteraction.getState().cells).toEqual([
+      getCellMeta(mockCell),
+      getCellMeta(mockCellA),
+    ]);
 
     isEqualStateNameSpy.mockRestore();
   });
@@ -389,9 +395,10 @@ describe('RootInteraction Tests', () => {
     });
 
     test.each`
-      stateName                        | handler
-      ${InteractionStateName.SELECTED} | ${'isSelectedState'}
-      ${InteractionStateName.HOVER}    | ${'isHoverState'}
+      stateName                           | handler
+      ${InteractionStateName.SELECTED}    | ${'isSelectedState'}
+      ${InteractionStateName.HOVER}       | ${'isHoverState'}
+      ${InteractionStateName.HOVER_FOCUS} | ${'isHoverFocusState'}
     `('should get correctly %s state', ({ stateName, handler }) => {
       rootInteraction.changeState({
         cells: [getCellMeta(mockCell)],
@@ -416,20 +423,16 @@ describe('RootInteraction Tests', () => {
       ).toBeTruthy();
     });
 
-    test('should get target cell is selected status', () => {
-      const mockRowCell = {
-        type: CellTypes.ROW_CELL,
-        cellType: CellTypes.ROW_CELL,
-        getMeta: () => {
-          return {
-            colIndex: 0,
-            rowIndex: 1,
-            id: '0-1',
-          };
-        },
-      } as unknown as RowCell;
+    test('should get selected cell status', () => {
+      const mockCellA = createMockCellInfo('cellA');
       expect(rootInteraction.isSelectedCell(mockCell)).toBeTruthy();
-      expect(rootInteraction.isSelectedCell(mockRowCell)).toBeFalsy();
+      expect(rootInteraction.isSelectedCell(mockCellA.mockCell)).toBeFalsy();
+    });
+
+    test('should get active cell status', () => {
+      const mockCellA = createMockCellInfo('cellA');
+      expect(rootInteraction.isActiveCell(mockCell)).toBeTruthy();
+      expect(rootInteraction.isActiveCell(mockCellA.mockCell)).toBeFalsy();
     });
   });
 

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -1,6 +1,6 @@
 import { Canvas, Group } from '@antv/g-canvas';
 import { getCellMeta } from 'src/utils/interaction/select-event';
-import { sleep } from 'tests/util/helpers';
+import { createMockCellInfo, sleep } from 'tests/util/helpers';
 import { RootInteraction } from '@/interaction/root';
 import {
   CellTypes,
@@ -24,6 +24,7 @@ import {
   SelectedCellMove,
   BaseEvent,
   GuiIcon,
+  S2CellType,
 } from '@/index';
 import { Store } from '@/common/store';
 import { mergeCell, unmergeCell } from '@/utils/interaction/merge-cell';
@@ -81,6 +82,7 @@ describe('RootInteraction Tests', () => {
     } as unknown as Canvas;
     mockSpreadSheetInstance.panelGroup = new Group('');
     mockSpreadSheetInstance.isTableMode = jest.fn();
+    mockSpreadSheetInstance.isHierarchyTreeType = () => false;
     rootInteraction = new RootInteraction(mockSpreadSheetInstance);
     rootInteraction.getPanelGroupAllDataCells = () => panelGroupAllDataCells;
     rootInteraction.getAllColHeaderCells = () => [];
@@ -150,11 +152,54 @@ describe('RootInteraction Tests', () => {
     });
   });
 
-  test('should set headerCell selected interaction state correct', () => {
+  test('should set header cell selected interaction state correct', () => {
     rootInteraction.selectHeaderCell({ cell: mockCell });
     const state = rootInteraction.getState();
     expect(state.stateName).toEqual(InteractionStateName.SELECTED);
     expect(state.cells).toEqual([getCellMeta(mockCell)]);
+    expect(rootInteraction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+  });
+
+  // https://github.com/antvis/S2/issues/1243
+  test('should multi selected header cells', () => {
+    rootInteraction.reset();
+
+    const isEqualStateNameSpy = jest
+      .spyOn(rootInteraction, 'isEqualStateName')
+      .mockImplementation(() => false);
+
+    const mockCellA = createMockCellInfo('test-A').mockCell;
+    const mockCellB = createMockCellInfo('test-B').mockCell;
+
+    // 选中 cellA
+    rootInteraction.selectHeaderCell({
+      cell: mockCellA,
+      isMultiSelection: true,
+    });
+
+    expect(rootInteraction.getState().cells).toEqual([getCellMeta(mockCellA)]);
+
+    // 选中 cellB
+    rootInteraction.selectHeaderCell({
+      cell: mockCellB,
+      isMultiSelection: true,
+    });
+
+    expect(rootInteraction.getState().cells).toEqual([
+      getCellMeta(mockCellA),
+      getCellMeta(mockCellB),
+    ]);
+
+    // 再次选中 cellB
+    rootInteraction.selectHeaderCell({
+      cell: mockCellB,
+      isMultiSelection: true,
+    });
+
+    // 取消选中
+    expect(rootInteraction.getState().cells).toEqual([getCellMeta(mockCellA)]);
+
+    isEqualStateNameSpy.mockRestore();
   });
 
   test('should call merge cells', () => {
@@ -347,7 +392,7 @@ describe('RootInteraction Tests', () => {
       stateName                        | handler
       ${InteractionStateName.SELECTED} | ${'isSelectedState'}
       ${InteractionStateName.HOVER}    | ${'isHoverState'}
-    `('should get correctly %o state', ({ stateName, handler }) => {
+    `('should get correctly %s state', ({ stateName, handler }) => {
       rootInteraction.changeState({
         cells: [getCellMeta(mockCell)],
         stateName,
@@ -358,6 +403,8 @@ describe('RootInteraction Tests', () => {
     });
 
     test('should get current cell status is equal', () => {
+      rootInteraction.changeState({ stateName: InteractionStateName.SELECTED });
+
       expect(
         rootInteraction.isEqualStateName('' as InteractionStateName),
       ).toBeFalsy();

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -115,7 +115,7 @@ export const createMockCellInfo = (
     x: 0,
     y: 0,
   };
-  const mockCellMeta = omit(mockCellViewMeta, 'update');
+  const mockCellMeta = omit(mockCellViewMeta, ['x', 'y', 'update']);
   const mockCell = {
     ...mockCellViewMeta,
     getMeta: () => mockCellViewMeta,

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -6,7 +6,7 @@ import { Canvas } from '@antv/g-canvas';
 import { omit } from 'lodash';
 import { RootInteraction } from '@/interaction/root';
 import { Store } from '@/common/store';
-import { S2Options, ViewMeta } from '@/common/interface';
+import { S2CellType, S2Options, ViewMeta } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import { BaseTooltip } from '@/ui/tooltip';
 import { customMerge } from '@/utils/merge';
@@ -112,6 +112,8 @@ export const createMockCellInfo = (
     colIndex,
     rowIndex,
     type: undefined,
+    x: 0,
+    y: 0,
   };
   const mockCellMeta = omit(mockCellViewMeta, 'update');
   const mockCell = {
@@ -121,7 +123,7 @@ export const createMockCellInfo = (
     getActualText: jest.fn(),
     getFieldValue: jest.fn(),
     hideInteractionShape: jest.fn(),
-  };
+  } as unknown as S2CellType;
 
   return {
     mockCell,

--- a/packages/s2-core/src/common/interface/interaction.ts
+++ b/packages/s2-core/src/common/interface/interaction.ts
@@ -52,8 +52,6 @@ export interface InteractionStateInfo {
 export interface SelectHeaderCellInfo {
   // target header cell
   cell: S2CellType<ViewMeta>;
-  // whether the target header cell is in tree mode
-  isTreeRowClick?: boolean;
   isMultiSelection?: boolean;
 }
 

--- a/packages/s2-core/src/facet/layout/node.ts
+++ b/packages/s2-core/src/facet/layout/node.ts
@@ -141,7 +141,7 @@ export class Node {
    * get a branch's all leaves(c1~c4)
    * @param node
    */
-  public static getAllLeavesOfNodes(node: Node): Node[] {
+  public static getAllLeaveNodes(node: Node): Node[] {
     const leaves: Node[] = [];
     if (node.isLeaf) {
       return [node];
@@ -202,7 +202,7 @@ export class Node {
    */
   public static getAllBranch(parent: Node): Node[][] {
     const all: Node[][] = [];
-    const leaves = this.getAllLeavesOfNodes(parent);
+    const leaves = this.getAllLeaveNodes(parent);
     let current = leaves.shift();
     let tempBranch = [];
     while (current) {

--- a/packages/s2-core/src/facet/layout/node.ts
+++ b/packages/s2-core/src/facet/layout/node.ts
@@ -141,7 +141,7 @@ export class Node {
    * get a branch's all leaves(c1~c4)
    * @param node
    */
-  public static getAllLeavesOfNode(node: Node): Node[] {
+  public static getAllLeavesOfNodes(node: Node): Node[] {
     const leaves: Node[] = [];
     if (node.isLeaf) {
       return [node];
@@ -172,7 +172,7 @@ export class Node {
    * get a branch's all nodes(c1~c4, b1, b2)
    * @param node
    */
-  public static getAllChildrenNode(node: Node): Node[] {
+  public static getAllChildrenNodes(node: Node): Node[] {
     const all: Node[] = [];
     if (node.isLeaf) {
       return [node];
@@ -202,7 +202,7 @@ export class Node {
    */
   public static getAllBranch(parent: Node): Node[][] {
     const all: Node[][] = [];
-    const leaves = this.getAllLeavesOfNode(parent);
+    const leaves = this.getAllLeavesOfNodes(parent);
     let current = leaves.shift();
     let tempBranch = [];
     while (current) {

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -11,6 +11,7 @@ import {
   InterceptType,
   CellTypes,
   TOOLTIP_OPERATOR_HIDDEN_COLUMNS_MENU,
+  InteractionStateName,
 } from '@/common/constant';
 import {
   TooltipOperation,
@@ -57,7 +58,7 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
 
   private bindRowCellClick() {
     this.spreadsheet.on(S2Event.ROW_CELL_CLICK, (event: CanvasEvent) => {
-      this.handleRowColClick(event, this.spreadsheet.isHierarchyTreeType());
+      this.handleRowColClick(event);
     });
   }
 
@@ -67,23 +68,17 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     });
   }
 
-  private handleRowColClick = (event: CanvasEvent, isTreeRowClick = false) => {
+  private handleRowColClick = (event: CanvasEvent) => {
     event.stopPropagation();
     const { interaction } = this.spreadsheet;
     const cell = this.spreadsheet.getCell(event.target);
 
-    if (interaction.isSelectedCell(cell)) {
-      interaction.reset();
-      return;
-    }
+    const success = interaction.selectHeaderCell({
+      cell,
+      isMultiSelection: this.isMultiSelection,
+    });
 
-    if (
-      interaction.selectHeaderCell({
-        cell,
-        isTreeRowClick,
-        isMultiSelection: this.isMultiSelection,
-      })
-    ) {
+    if (success) {
       this.showTooltip(event);
     }
   };

--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -1,6 +1,7 @@
 import { Event } from '@antv/g-canvas';
 import { inRange, isNil, range } from 'lodash';
 import { getCellMeta } from 'src/utils/interaction/select-event';
+import { getActiveCellsTooltipData } from '../utils/tooltip';
 import { BaseEvent, BaseEventImplement } from './base-interaction';
 import {
   InterceptType,
@@ -99,11 +100,14 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
       });
 
       interaction.addIntercepts([InterceptType.CLICK, InterceptType.HOVER]);
-      this.spreadsheet.hideTooltip();
       interaction.changeState({
         cells,
         stateName: InteractionStateName.SELECTED,
       });
+      this.spreadsheet.showTooltipWithInfo(
+        event,
+        getActiveCellsTooltipData(this.spreadsheet),
+      );
       this.spreadsheet.emit(
         S2Event.GLOBAL_SELECTED,
         interaction.getActiveCells(),

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -157,15 +157,13 @@ export class RootInteraction {
   }
 
   public clearStyleIndependent() {
-    const currentState = this.getState();
-    if (
-      currentState?.stateName === InteractionStateName.SELECTED ||
-      currentState?.stateName === InteractionStateName.HOVER
-    ) {
-      this.getPanelGroupAllDataCells().forEach((cell) => {
-        cell.hideInteractionShape();
-      });
+    if (!this.isSelectedState() && !this.isHoverState()) {
+      return;
     }
+
+    this.getPanelGroupAllDataCells().forEach((cell) => {
+      cell.hideInteractionShape();
+    });
   }
 
   public getPanelGroupAllUnSelectedDataCells() {
@@ -292,12 +290,17 @@ export class RootInteraction {
       }
     }
 
+    if (isEmpty(selectedCells)) {
+      this.reset();
+      this.spreadsheet.emit(S2Event.GLOBAL_SELECTED, this.getActiveCells());
+      return;
+    }
+
     // 兼容行列多选 (高亮 行/列头 以及相对应的数值单元格)
     this.changeState({
       cells: selectedCells,
       nodes: leafNodes,
       stateName: InteractionStateName.SELECTED,
-      force: isEmpty(selectedCells),
     });
 
     const selectedCellIds = selectedCells.map(({ id }) => id);

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -132,11 +132,11 @@ export class RootInteraction {
     return this.isStateOf(InteractionStateName.HOVER);
   }
 
-  public isActiveCell(cell: S2CellType) {
-    return this.getCells().find((meta) => cell.getMeta().id === meta.id);
+  public isActiveCell(cell: S2CellType): boolean {
+    return !!this.getCells().find((meta) => cell.getMeta().id === meta.id);
   }
 
-  public isSelectedCell(cell: S2CellType) {
+  public isSelectedCell(cell: S2CellType): boolean {
     return this.isSelectedState() && this.isActiveCell(cell);
   }
 
@@ -242,47 +242,69 @@ export class RootInteraction {
     });
   };
 
-  public selectHeaderCell = (selectHeaderCellInfo: SelectHeaderCellInfo) => {
-    const { cell } = selectHeaderCellInfo || {};
+  public getCellLeafNodes = (cell: Node): Node[] => {
+    const isHierarchyTree = this.spreadsheet.isHierarchyTreeType();
+
+    // 树状结构的行头点击不需要遍历当前行头的所有子节点，因为只会有一级
+    return isHierarchyTree
+      ? Node.getAllLeavesOfNodes(cell).filter(
+          (node) => node.rowIndex === cell.rowIndex,
+        )
+      : Node.getAllChildrenNodes(cell);
+  };
+
+  public selectHeaderCell = (
+    selectHeaderCellInfo: SelectHeaderCellInfo = {} as SelectHeaderCellInfo,
+  ) => {
+    const { cell } = selectHeaderCellInfo;
     if (isEmpty(cell)) {
       return;
     }
-    const lastState = this.getState();
-    const meta = cell?.getMeta() as Node;
-    if (isNil(meta.x)) {
+
+    const currentCellMeta = cell?.getMeta() as Node;
+    if (isNil(currentCellMeta.x)) {
       return;
     }
-    this.addIntercepts([InterceptType.HOVER]);
-    // 树状结构的行头点击不需要遍历当前行头的所有子节点，因为只会有一级
-    let leafNodes = selectHeaderCellInfo?.isTreeRowClick
-      ? Node.getAllLeavesOfNode(meta).filter(
-          (node) => node.rowIndex === meta.rowIndex,
-        )
-      : Node.getAllChildrenNode(meta);
-    let selectedCells = [getCellMeta(cell)];
 
-    if (selectHeaderCellInfo?.isMultiSelection && this.isSelectedState()) {
-      selectedCells = isEmpty(lastState?.cells)
-        ? selectedCells
-        : concat(lastState?.cells, selectedCells);
-      leafNodes = isEmpty(lastState?.nodes)
-        ? leafNodes
-        : concat(lastState?.nodes, leafNodes);
+    this.addIntercepts([InterceptType.HOVER]);
+
+    const isHierarchyTree = this.spreadsheet.isHierarchyTreeType();
+    const lastState = this.getState();
+    const isSelectedCell = this.isSelectedCell(cell);
+    const isMultiSelected =
+      selectHeaderCellInfo?.isMultiSelection && this.isSelectedState();
+
+    // 如果是已选中的单元格, 则取消选中, 兼容行列多选 (含叶子节点)
+    let leafNodes = isSelectedCell
+      ? []
+      : this.getCellLeafNodes(currentCellMeta);
+    let selectedCells = isSelectedCell ? [] : [getCellMeta(cell)];
+
+    if (isMultiSelected) {
+      selectedCells = concat(lastState?.cells, selectedCells);
+      leafNodes = concat(lastState?.nodes, leafNodes);
+
+      if (isSelectedCell) {
+        selectedCells = selectedCells.filter(
+          ({ id }) => id !== currentCellMeta.id,
+        );
+        leafNodes = leafNodes.filter((node) => node.id !== currentCellMeta.id);
+      }
     }
 
-    // 兼容行列多选
-    // Set the header cells (colCell or RowCell)  selected information and update the dataCell state.
+    // 兼容行列多选 (高亮 行/列头 以及相对应的数值单元格)
     this.changeState({
       cells: selectedCells,
       nodes: leafNodes,
       stateName: InteractionStateName.SELECTED,
+      force: isEmpty(selectedCells),
     });
 
     const selectedCellIds = selectedCells.map(({ id }) => id);
-    // Update the interaction state of all the selected cells:  header cells(colCell or RowCell) and dataCells belong to them.
     this.updateCells(this.getRowColActiveCells(selectedCellIds));
 
-    if (!selectHeaderCellInfo?.isTreeRowClick) {
+    // 平铺模式下选中子节点
+    if (!isHierarchyTree) {
       leafNodes.forEach((node) => {
         node?.belongsCell?.updateByState(
           InteractionStateName.SELECTED,

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -245,7 +245,7 @@ export class RootInteraction {
 
     // 树状结构的行头点击不需要遍历当前行头的所有子节点，因为只会有一级
     return isHierarchyTree
-      ? Node.getAllLeavesOfNodes(cell).filter(
+      ? Node.getAllLeaveNodes(cell).filter(
           (node) => node.rowIndex === cell.rowIndex,
         )
       : Node.getAllChildrenNodes(cell);

--- a/s2-site/docs/api/basic-class/interaction.zh.md
+++ b/s2-site/docs/api/basic-class/interaction.zh.md
@@ -41,6 +41,7 @@ this.spreadsheet.interaction.xx()
 | getAllCells | 获取所有单元格 | `() => S2CellType[]` |
 | selectAll | 选中所有单元格 | `() => void` |
 | selectHeaderCell | 选中指定行列头单元格 | `(selectHeaderCellInfo: SelectHeaderCellInfo) => boolean` |
+| getCellLeafNodes | 获取当前单元格的叶子节点 | `(cell: S2CellType[]) => Node[]` |
 | hideColumns | 隐藏列 | `(hiddenColumnFields: string[]) => void` |
 | mergeCells | 合并单元格 | `(cellsInfo?: MergedCellInfo[], hideData?: boolean) => void` |
 | unmergeCells | 取消合并单元格 | `(removedCells: MergedCell) => void` |
@@ -105,7 +106,6 @@ type S2CellType<T extends SimpleBBox = ViewMeta> =
 ```ts
 interface SelectHeaderCellInfo {
   cell: S2CellType<ViewMeta>; // 目标单元格
-  isTreeRowClick?: boolean; // 是否是树形结构下的行头点击（该情况下只会高亮整行，而不会高亮所有叶子节点）
   isMultiSelection?: boolean; // 是否是多选
 }
 ```

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -238,7 +238,7 @@ const s2Options = {
 
 Shift + click: 区间选择（类似刷选）, 默认开启，可配置 `rangeSelection` 关闭：
 
-<img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*wq-XRYpVAGMAAAAAAAAAAAAAARQnAQ" width="600" alt="preview" />
+<img src="https://gw.alipayobjects.com/zos/antfincdn/RcIcQc7O2/Kapture%2525202022-04-15%252520at%25252011.52.52.gif" width="600" alt="preview" />
 
 ```ts
 const s2Options = {

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -204,6 +204,8 @@ const s2Options = {
 
 鼠标悬停在当前单元格超过 `800ms` 后，保持当前高亮，显示 `tooltip`, 所对应的行列头取消高亮，聚焦于当前数据，默认开启，可配置 `hoverFocus` 关闭：
 
+> 如果你实现了自定义交互，如 hover 后显示 tooltip, 推荐关闭此功能，以免出现 hover 悬停后 tooltip 被意外关闭
+
 <img src="https://gw.alipayobjects.com/zos/antfincdn/1OIXucjGb/9c0b42b5-259e-4693-83b3-8cf6a034be93.png" alt="preview" width="600" />
 
 ```ts
@@ -230,9 +232,9 @@ const s2Options = {
 
 ### 快捷键多选
 
-(Command/Ctrl) + click: 单个多选叠加，默认开启，可配置 `multiSelection` 关闭：
+(Command/Ctrl) + click: 单个多选叠加，再次点击选中的单元格或行列可取消选中，默认开启，可配置 `multiSelection` 关闭：
 
-<img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*Ubk0RrTI0ZsAAAAAAAAAAAAAARQnAQ" width="600" alt="preview" />
+<img src="https://gw.alipayobjects.com/zos/antfincdn/XYZaL1w%24M/Kapture%2525202022-04-15%252520at%25252011.45.55.gif" width="600" alt="preview" />
 
 Shift + click: 区间选择（类似刷选）, 默认开启，可配置 `rangeSelection` 关闭：
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

- 支持行头和列头 偶数次点击时 取消选中
- 支持行头和列头 多选时, 按住 ctrl / Command 再次点击选中行/列, 进行反选
- 修复区间多选, 不显示 tooltip 的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-04-14 at 19 03 36](https://user-images.githubusercontent.com/21015895/163378707-57096911-e4ab-447a-b085-f0d9181cbab0.gif)| ![Kapture 2022-04-14 at 19 02 05](https://user-images.githubusercontent.com/21015895/163378533-e6a3dd3f-92bd-4f10-883d-bb33ea3e8dcd.gif) |

### 🔗 Related issue link

close #1243 

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
