### PR TITLE
fix: 修复交叉表分页问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/facet-spec.ts
@@ -33,6 +33,16 @@ describe('Facet util test', () => {
       start: 3,
       end: 7,
     });
+
+    expect(getIndexRangeWithOffsets(offsets, 0, 90)).toStrictEqual({
+      start: 0,
+      end: 2,
+    });
+
+    expect(getIndexRangeWithOffsets(offsets, 60, 120)).toStrictEqual({
+      start: 2,
+      end: 3,
+    });
   });
 
   test('should get correct index range for invalid input', () => {

--- a/packages/s2-core/src/utils/facet.ts
+++ b/packages/s2-core/src/utils/facet.ts
@@ -43,14 +43,17 @@ export const getIndexRangeWithOffsets = (
 
   yMin = Math.max(yMin, 0);
 
-  let yMax = findIndex(
-    heights,
-    (height: number, idx: number) => {
-      const y = maxHeight;
-      return y >= height && y < heights[idx + 1];
-    },
-    yMin,
-  );
+  let yMax =
+    maxHeight === minHeight
+      ? yMin
+      : findIndex(
+          heights,
+          (height: number, idx: number) => {
+            const y = maxHeight;
+            return y > height && y <= heights[idx + 1];
+          },
+          yMin,
+        );
   yMax = Math.min(yMax === -1 ? Infinity : yMax, heights.length - 2);
 
   return {

--- a/packages/s2-react/src/hooks/usePagination.ts
+++ b/packages/s2-react/src/hooks/usePagination.ts
@@ -27,11 +27,9 @@ export const usePagination = (
       return;
     }
 
-    s2.setOptions({
-      pagination: {
-        current,
-        pageSize,
-      },
+    s2.updatePagination({
+      current,
+      pageSize,
     });
     s2.render(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [x] Test case

### 📝 Description
#### 1. 当 pageSize=10 时，展示了 11 条数据
最初这个问题在 #1037 修改了，见 https://github.com/antvis/S2/pull/1037/files#diff-c0e3de302ea541a5e2183682d30e86a39bc28b07e8f1aa2ba567c4446076f97aL35
主要是 `getIndexRangeWithOffsets` 在处理可视范围与单元格边界重合时，意外返回了大于边界的index

最近在 #1218 重新引入了该 BUG

#### 2. 切换分页条件时，未重置已滚动的 offset
分页条件变更时，之前使用的是 setOptions，实际应用 updatePagination

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
