### PR TITLE
fix: 添加当多个数值在行头显示时，小计展示被遮挡的问题

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-368-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-368-spec.ts
@@ -52,4 +52,38 @@ describe('Total Cells Rendering Test', () => {
     expect(colSubTotalNodes[0].x).toEqual(192);
     expect(colSubTotalNodes[0].y).toEqual(30);
   });
+
+  test('should get right SubTotals position when valueInCols is false', () => {
+    s2.setDataCfg({
+      ...mockDataConfig,
+      fields: {
+        ...mockDataConfig.fields,
+        valueInCols: false,
+      },
+    });
+    s2.setOptions({
+      ...s2Options,
+      totals: {
+        ...s2Options.totals,
+        row: {
+          ...s2Options.totals.row,
+          subTotalsDimensions: ['row0'],
+        },
+      },
+    });
+
+    s2.render();
+
+    const layoutResult = s2.facet.layoutResult;
+    const rowSubTotalNodes = layoutResult.rowsHierarchy
+      .getNodes()
+      .filter((node: Node) => node.isSubTotals);
+    const rowSubTotalChildNode = rowSubTotalNodes[0].children[0];
+
+    expect(rowSubTotalNodes[0].x).toEqual(96);
+    expect(rowSubTotalNodes[0].y).toEqual(60);
+
+    expect(rowSubTotalChildNode.x).toEqual(288);
+    expect(rowSubTotalChildNode.y).toEqual(60);
+  });
 });

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -378,8 +378,8 @@ export class PivotFacet extends BaseFacet {
       'options.style.rowCfg.heightByField',
       {},
     );
-    const sampleNodeByLevel = new Map();
-    // const sampleNodeByLevel=rowsHierarchy.sampleNodesForAllLevels;
+
+    const sampleNodeByLevel = rowsHierarchy.sampleNodesForAllLevels ?? [];
 
     // 1、calculate first node's width in every level
     if (isTree) {
@@ -392,12 +392,11 @@ export class PivotFacet extends BaseFacet {
         );
         rowsHierarchy.width += levelSample.width;
         // debugger;
-        const preLevelSample = sampleNodeByLevel.get(levelSample.level - 1) ?? {
+        const preLevelSample = sampleNodeByLevel[levelSample.level - 1] ?? {
           x: 0,
           width: 0,
         };
         levelSample.x = preLevelSample?.x + preLevelSample?.width;
-        sampleNodeByLevel.set(levelSample.level, levelSample);
       }
     }
 
@@ -427,7 +426,7 @@ export class PivotFacet extends BaseFacet {
       if (isTree || currentNode.level === 0) {
         currentNode.x = 0;
       } else {
-        const preLevelSample = sampleNodeByLevel.get(currentNode.level - 1);
+        const preLevelSample = sampleNodeByLevel[currentNode.level - 1];
         currentNode.x = preLevelSample?.x + preLevelSample?.width;
       }
 
@@ -436,7 +435,7 @@ export class PivotFacet extends BaseFacet {
         currentNode.width = this.getTreeRowHeaderWidth();
       } else {
         // same level -> same width
-        const levelSampleNode = sampleNodeByLevel.get(currentNode.level);
+        const levelSampleNode = sampleNodeByLevel[currentNode.level];
         currentNode.width = levelSampleNode?.width;
       }
 

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -391,7 +391,6 @@ export class PivotFacet extends BaseFacet {
           colLeafNodes,
         );
         rowsHierarchy.width += levelSample.width;
-        // debugger;
         const preLevelSample = sampleNodeByLevel[levelSample.level - 1] ?? {
           x: 0,
           width: 0,

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -379,6 +379,7 @@ export class PivotFacet extends BaseFacet {
       {},
     );
     const sampleNodeByLevel = new Map();
+    // const sampleNodeByLevel=rowsHierarchy.sampleNodesForAllLevels;
 
     // 1、calculate first node's width in every level
     if (isTree) {
@@ -390,6 +391,12 @@ export class PivotFacet extends BaseFacet {
           colLeafNodes,
         );
         rowsHierarchy.width += levelSample.width;
+        // debugger;
+        const preLevelSample = sampleNodeByLevel.get(levelSample.level - 1) ?? {
+          x: 0,
+          width: 0,
+        };
+        levelSample.x = preLevelSample?.x + preLevelSample?.width;
         sampleNodeByLevel.set(levelSample.level, levelSample);
       }
     }


### PR DESCRIPTION
### 👀 PR includes

当小计展示在上方时， sample 没有被初始化导致。
单测放在 issue 378 中，因为都是校验小计展示。
<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #0

🔧 Chore

- [X] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| <img width="563" alt="image" src="https://user-images.githubusercontent.com/20497176/163788855-694283af-d3b5-4850-a637-e306bb38176b.png"> | <img width="506" alt="image" src="https://user-images.githubusercontent.com/20497176/163788836-b483a2c5-38a6-4c51-8813-646660089e62.png"> |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
