### PR TITLE
fix(facet): 修复 scrollY 越界问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/facet-spec.ts
@@ -1,6 +1,8 @@
 import {
   getSubTotalNodeWidthOrHeightByLevel,
   getIndexRangeWithOffsets,
+  getAdjustedRowScrollX,
+  getAdjustedScrollOffset,
 } from '@/utils/facet';
 
 describe('Facet util test', () => {
@@ -59,5 +61,25 @@ describe('Facet util test', () => {
       start: 2,
       end: 2,
     });
+  });
+
+  test('should get correct result for adjustedRowScrollX', () => {
+    const bbox = {
+      originalWidth: 200,
+      width: 100,
+    };
+    expect(getAdjustedRowScrollX(-10, bbox)).toBe(0);
+    expect(getAdjustedRowScrollX(120, bbox)).toBe(100);
+    expect(getAdjustedRowScrollX(100, bbox)).toBe(100);
+    expect(getAdjustedRowScrollX(99, bbox)).toBe(99);
+  });
+
+  test('should get correct result for getAdjustedScrollOffset', () => {
+    const content = 1000;
+    const container = 500;
+    expect(getAdjustedScrollOffset(-10, content, container)).toBe(0);
+    expect(getAdjustedScrollOffset(520, content, container)).toBe(500);
+    expect(getAdjustedScrollOffset(500, content, container)).toBe(500);
+    expect(getAdjustedScrollOffset(499, content, container)).toBe(499);
   });
 });

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -4,6 +4,10 @@ import { interpolateArray } from 'd3-interpolate';
 import { timer, Timer } from 'd3-timer';
 import { Group } from '@antv/g-canvas';
 import { debounce, each, find, get, isUndefined, last, reduce } from 'lodash';
+import {
+  getAdjustedRowScrollX,
+  getAdjustedScrollOffset,
+} from 'src/utils/facet';
 import { CornerBBox } from './bbox/cornerBBox';
 import { PanelBBox } from './bbox/panelBBox';
 import {
@@ -480,50 +484,23 @@ export abstract class BaseFacet {
     );
   };
 
-  private getAdjustedRowScrollX = (hRowScrollX: number): number => {
-    if (hRowScrollX + this.cornerBBox.width >= this.cornerBBox.originalWidth) {
-      return this.cornerBBox.originalWidth - this.cornerBBox.width;
-    }
-    return hRowScrollX;
-  };
-
-  private getAdjustedScrollX = (scrollX: number): number => {
-    const colsHierarchyWidth = this.layoutResult.colsHierarchy.width;
-    const panelWidth = this.panelBBox.width;
-    if (
-      scrollX + panelWidth >= colsHierarchyWidth &&
-      colsHierarchyWidth > panelWidth
-    ) {
-      return colsHierarchyWidth - panelWidth;
-    }
-    return Math.max(0, scrollX);
-  };
-
-  private getAdjustedScrollY = (scrollY: number): number => {
-    const rendererHeight = this.getRendererHeight();
-    const panelHeight = this.panelBBox.height;
-    if (
-      scrollY + panelHeight >= rendererHeight &&
-      rendererHeight > panelHeight
-    ) {
-      return rendererHeight - panelHeight;
-    }
-    // 当数据为空时，rendererHeight 可能为 0，此时 scrollY 为负值，需要调整为 0。
-    if (scrollY < 0) {
-      return 0;
-    }
-    return Math.max(0, scrollY);
-  };
-
   private getAdjustedScrollOffset = ({
     scrollX,
     scrollY,
     hRowScrollX,
   }: ScrollOffset): ScrollOffset => {
     return {
-      scrollX: this.getAdjustedScrollX(scrollX),
-      scrollY: this.getAdjustedScrollY(scrollY),
-      hRowScrollX: this.getAdjustedRowScrollX(hRowScrollX),
+      scrollX: getAdjustedScrollOffset(
+        scrollX,
+        this.layoutResult.colsHierarchy.width,
+        this.panelBBox.width,
+      ),
+      scrollY: getAdjustedScrollOffset(
+        scrollY,
+        this.getRendererHeight(),
+        this.panelBBox.height,
+      ),
+      hRowScrollX: getAdjustedRowScrollX(hRowScrollX, this.cornerBBox),
     };
   };
 
@@ -1196,14 +1173,11 @@ export abstract class BaseFacet {
     const { scrollX, scrollY: sy, hRowScrollX } = this.getScrollOffset();
     let scrollY = sy + this.getPaginationScrollY();
 
-    const maxScrollY = Math.max(
-      0,
-      this.viewCellHeights.getTotalHeight() - this.panelBBox.viewportHeight,
+    scrollY = getAdjustedScrollOffset(
+      scrollY,
+      this.viewCellHeights.getTotalHeight(),
+      this.panelBBox.viewportHeight,
     );
-
-    if (scrollY > maxScrollY) {
-      scrollY = maxScrollY;
-    }
 
     if (delay) {
       this.debounceRenderCell(scrollX, scrollY);

--- a/packages/s2-core/src/utils/facet.ts
+++ b/packages/s2-core/src/utils/facet.ts
@@ -61,3 +61,32 @@ export const getIndexRangeWithOffsets = (
     end: yMax,
   };
 };
+
+export const getAdjustedRowScrollX = (
+  hRowScrollX: number,
+  cornerBBox: {
+    width: number;
+    originalWidth: number;
+  },
+): number => {
+  const { width, originalWidth } = cornerBBox;
+
+  const scrollX = Math.min(originalWidth - width, hRowScrollX);
+
+  if (scrollX < 0) {
+    return 0;
+  }
+  return scrollX;
+};
+
+export const getAdjustedScrollOffset = (
+  scrollY: number,
+  contentLength: number,
+  containerLength: number,
+): number => {
+  const offset = Math.min(contentLength - containerLength, scrollY);
+  if (offset < 0) {
+    return 0;
+  }
+  return offset;
+};


### PR DESCRIPTION
### 👀 PR includes

修复 scrollY 未判断最大值的越界问题。之前判断的是 

```
scrollY  >= (rendererHeight - panelHeight) &&  rendererHeight > panelHeight
```

但其实 rendererHeight > panelHeight 这个判断是多余的。rendererHeight < panelHeight 时上一次 render 的 scrollY 未被调整到合法范围内。

同时对 getScrollOffset 系列函数做一个重构，添加单测。