### PR TITLE
fix: 行头/单元格icon颜色应默认与字体色一致

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
@@ -3,7 +3,7 @@ import { assembleDataCfg, assembleOptions } from 'tests/util';
 import { get } from 'lodash';
 import { ShapeAttrs } from '@antv/g-canvas';
 import { PivotSheet } from '@/sheet-type';
-import { TextAlign } from '@/common';
+import { CellTypes, TextAlign } from '@/common';
 import { RowCell } from '@/cell';
 
 describe('SpreadSheet Theme Tests', () => {
@@ -29,6 +29,29 @@ describe('SpreadSheet Theme Tests', () => {
 
   afterAll(() => {
     s2.destroy();
+  });
+
+  describe('Theme Default Value Tests', () => {
+    const CELL_TYPES: CellTypes[] = [
+      CellTypes.DATA_CELL,
+      CellTypes.ROW_CELL,
+      CellTypes.COL_CELL,
+      CellTypes.CORNER_CELL,
+    ];
+
+    test.each(CELL_TYPES)(
+      "should assign the same color for %s's text and icon",
+      (cellType: CellTypes) => {
+        s2.setThemeCfg({
+          name: 'colorful',
+        });
+        s2.render();
+        const cellTheme = s2.theme[cellType];
+
+        expect(cellTheme.bolderText.fill).toEqual(cellTheme.icon.fill);
+        expect(cellTheme.text.fill).toEqual(cellTheme.icon.fill);
+      },
+    );
   });
 
   describe('Custom SVG Icon Tests', () => {

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -127,7 +127,7 @@ export const getTheme = (
         },
       },
       icon: {
-        fill: basicColors[0],
+        fill: basicColors[14],
         size: 10,
         margin: {
           right: 4,
@@ -284,7 +284,7 @@ export const getTheme = (
         miniBarChartFillColor: basicColors[7],
       },
       icon: {
-        fill: basicColors[0],
+        fill: basicColors[13],
         downIconColor: semanticColors.red,
         upIconColor: semanticColors.green,
         size: 10,


### PR DESCRIPTION
🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

行头/单元格之前 icon.fill 错误的配置为了角头/列头的值（如果是彩色主题，即白色）。
但因为 icon 渲染时，一直取的是 text.fill，所以问题没有暴露，直到 #1261 修复了这个 BUG。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-04-20 at 18 11 20@2x](https://user-images.githubusercontent.com/6716092/164205567-b2985493-efad-46db-ad9e-ce4117bc8f92.png)    |   <img width="318" alt="CleanShot 2022-04-20 at 18 10 04@2x" src="https://user-images.githubusercontent.com/6716092/164205299-9ca49713-4d9f-4c31-8543-7a4217b71012.png">   |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
