### PR TITLE
fix(interaction): 连续 Hover 失效问题修复

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/data-cell-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/data-cell-click-spec.ts
@@ -4,11 +4,11 @@ import {
   sleep,
 } from 'tests/util/helpers';
 import { Event as GEvent } from '@antv/g-canvas';
-import { DataCellClick } from '@/interaction/base-interaction/click';
 import { S2Options } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import {
   HOVER_FOCUS_DURATION,
+  InteractionName,
   InteractionStateName,
   S2Event,
 } from '@/common/constant';
@@ -16,14 +16,12 @@ import {
 jest.mock('@/interaction/event-controller');
 
 describe('Interaction Data Cell Click Tests', () => {
-  let dataCellClick: DataCellClick;
   let s2: SpreadSheet;
   const mockCellInfo = createMockCellInfo('testId');
 
   beforeEach(() => {
     s2 = createFakeSpreadSheet();
     s2.getCell = () => mockCellInfo.mockCell as any;
-    dataCellClick = new DataCellClick(s2 as unknown as SpreadSheet);
     s2.options = {
       tooltip: {
         operation: {
@@ -38,7 +36,10 @@ describe('Interaction Data Cell Click Tests', () => {
   });
 
   test('should bind events', () => {
-    expect(dataCellClick.bindEvents).toBeDefined();
+    expect(
+      s2.interaction.interactions.get(InteractionName.DATA_CELL_CLICK)
+        .bindEvents,
+    ).toBeDefined();
   });
 
   test('should trigger data cell click', () => {

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/hover-spec.ts
@@ -142,18 +142,21 @@ describe('Interaction Hover Tests', () => {
   });
 
   test('should not trigger header cell hover when hover cell not change', () => {
-    s2.emit(S2Event.ROW_CELL_HOVER, { target: {} } as GEvent);
-    expect(s2.interaction.getState()).toEqual({
-      cells: [mockCellMeta],
-      stateName: InteractionStateName.HOVER,
-    });
+    s2.emit(S2Event.ROW_CELL_HOVER, {
+      target: {
+        id: 'rowCellOne',
+        rowIndex: 0,
+      } as any,
+    } as GEvent);
 
     s2.emit(S2Event.ROW_CELL_HOVER, {
       target: {
-        cellType: 'rowCell',
+        id: 'rowCellOne',
+        rowIndex: 1,
       } as any,
     } as GEvent);
-    expect((s2.interaction.getState().cells[0] as any).type).toBe('dataCell');
+
+    expect((s2.interaction.getState().cells[0] as any).rowIndex).toBe(0);
   });
 
   test('should clear data cell hover focus timer when cell clicked', async () => {

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -362,6 +362,19 @@ describe('RootInteraction Tests', () => {
       });
       expect(rootInteraction.getActiveCells()).toHaveLength(2);
     });
+
+    test('should update state when changeState for same stateName', () => {
+      rootInteraction.resetState();
+      rootInteraction.changeState({
+        cells: [getCellMeta(mockCell)],
+        stateName: InteractionStateName.SELECTED,
+      });
+      rootInteraction.changeState({
+        cells: [getCellMeta(mockCell), getCellMeta(mockCell)],
+        stateName: InteractionStateName.SELECTED,
+      });
+      expect(rootInteraction.getActiveCells()).toHaveLength(2);
+    });
   });
 
   describe('RootInteraction Calc Utils Tests', () => {

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -362,19 +362,6 @@ describe('RootInteraction Tests', () => {
       });
       expect(rootInteraction.getActiveCells()).toHaveLength(2);
     });
-
-    test('should update state when changeState for same stateName', () => {
-      rootInteraction.resetState();
-      rootInteraction.changeState({
-        cells: [getCellMeta(mockCell)],
-        stateName: InteractionStateName.SELECTED,
-      });
-      rootInteraction.changeState({
-        cells: [getCellMeta(mockCell), getCellMeta(mockCell)],
-        stateName: InteractionStateName.SELECTED,
-      });
-      expect(rootInteraction.getActiveCells()).toHaveLength(2);
-    });
   });
 
   describe('RootInteraction Calc Utils Tests', () => {

--- a/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
@@ -52,7 +52,7 @@ describe('State Controller Utils Tests', () => {
     });
   });
 
-  test('should replace state when state name is the same', () => {
+  test('should do nothing when state name is the same', () => {
     setState(mockInstance, {
       stateName: InteractionStateName.SELECTED,
       cells: [getCellMeta(mockRowCell)],
@@ -70,7 +70,7 @@ describe('State Controller Utils Tests', () => {
 
     expect(mockInstance.interaction.getState()).toEqual({
       stateName: InteractionStateName.SELECTED,
-      cells: [],
+      cells: [getCellMeta(mockRowCell)],
     });
   });
 
@@ -92,6 +92,22 @@ describe('State Controller Utils Tests', () => {
     expect(mockInstance.interaction.getState()).toEqual({
       cells: [],
       force: false,
+    });
+  });
+
+  test('should only reset state for empty interactedCells or cells  when call clearState function', () => {
+    setState(mockInstance, {
+      stateName: InteractionStateName.SELECTED,
+      interactedCells: [],
+      cells: [],
+    });
+
+    clearState(mockInstance);
+
+    expect(mockInstance.interaction.getState()).toEqual({
+      cells: [],
+      interactedCells: [],
+      stateName: InteractionStateName.SELECTED,
     });
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/interaction/state-controller-spec.ts
@@ -52,7 +52,7 @@ describe('State Controller Utils Tests', () => {
     });
   });
 
-  test('should do nothing when state name is the same', () => {
+  test('should replace state when state name is the same', () => {
     setState(mockInstance, {
       stateName: InteractionStateName.SELECTED,
       cells: [getCellMeta(mockRowCell)],
@@ -70,7 +70,7 @@ describe('State Controller Utils Tests', () => {
 
     expect(mockInstance.interaction.getState()).toEqual({
       stateName: InteractionStateName.SELECTED,
-      cells: [getCellMeta(mockRowCell)],
+      cells: [],
     });
   });
 

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -116,7 +116,7 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
     interaction.clearHoverTimer();
 
     const meta = cell.getMeta() as ViewMeta;
-    // 避免在统一单元格内鼠标移动造成的多次渲染
+    // 避免在同一单元格内鼠标移动造成的多次渲染
     if (interaction.isActiveCell(cell)) {
       return;
     }
@@ -180,7 +180,7 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
       const { interaction: interactionOptions } = options;
       const meta = cell?.getMeta() as ViewMeta;
 
-      // 避免在统一单元格内鼠标移动造成的多次渲染
+      // 避免在同一单元格内鼠标移动造成的多次渲染
       if (interaction.isActiveCell(cell)) {
         return;
       }

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -113,12 +113,11 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
       return;
     }
     const { interaction } = this.spreadsheet;
-    const activeCells = interaction.getCells();
     interaction.clearHoverTimer();
 
     const meta = cell.getMeta() as ViewMeta;
     // 避免在统一单元格内鼠标移动造成的多次渲染
-    if (isEqual(activeCells?.[0]?.id, meta.id)) {
+    if (interaction.isActiveCell(cell)) {
       return;
     }
 
@@ -180,9 +179,9 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
       const { interaction, options } = this.spreadsheet;
       const { interaction: interactionOptions } = options;
       const meta = cell?.getMeta() as ViewMeta;
-      const activeCells = interaction.getCells();
+
       // 避免在统一单元格内鼠标移动造成的多次渲染
-      if (isEqual(activeCells?.[0]?.id, meta.id)) {
+      if (interaction.isActiveCell(cell)) {
         return;
       }
       interaction.changeState({

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -113,14 +113,15 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
       return;
     }
     const { interaction } = this.spreadsheet;
-    const activeCells = interaction.getActiveCells();
+    const activeCells = interaction.getCells();
     interaction.clearHoverTimer();
 
+    const meta = cell.getMeta() as ViewMeta;
     // 避免在统一单元格内鼠标移动造成的多次渲染
-    if (isEqual(activeCells?.[0], cell)) {
+    if (isEqual(activeCells?.[0]?.id, meta.id)) {
       return;
     }
-    const meta = cell.getMeta() as ViewMeta;
+
     interaction.changeState({
       cells: [getCellMeta(cell)],
       stateName: InteractionStateName.HOVER,
@@ -179,6 +180,11 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
       const { interaction, options } = this.spreadsheet;
       const { interaction: interactionOptions } = options;
       const meta = cell?.getMeta() as ViewMeta;
+      const activeCells = interaction.getCells();
+      // 避免在统一单元格内鼠标移动造成的多次渲染
+      if (isEqual(activeCells?.[0]?.id, meta.id)) {
+        return;
+      }
       interaction.changeState({
         cells: [getCellMeta(cell)],
         stateName: InteractionStateName.HOVER,

--- a/packages/s2-core/src/utils/interaction/state-controller.ts
+++ b/packages/s2-core/src/utils/interaction/state-controller.ts
@@ -17,7 +17,7 @@ export const clearState = (spreadsheet: SpreadSheet) => {
   const allInteractedCells = spreadsheet.interaction.getInteractedCells();
   const cellMetas = spreadsheet.interaction.getState().cells;
 
-  if (!isEmpty(allInteractedCells) && !isEmpty(cellMetas)) {
+  if (!isEmpty(allInteractedCells) || !isEmpty(cellMetas)) {
     forEach(allInteractedCells, (cell: S2CellType) => {
       cell.hideInteractionShape();
     });
@@ -48,6 +48,6 @@ export const setState = (
     // There can only be one state in the table. When the stateName is inconsistent with the state in the stateInfo, the previously stored state should be cleared.
     clearState(spreadsheet);
     spreadsheet.hideTooltip();
+    spreadsheet.store.set(INTERACTION_STATE_INFO_KEY, interactionStateInfo);
   }
-  spreadsheet.store.set(INTERACTION_STATE_INFO_KEY, interactionStateInfo);
 };

--- a/packages/s2-core/src/utils/interaction/state-controller.ts
+++ b/packages/s2-core/src/utils/interaction/state-controller.ts
@@ -48,6 +48,6 @@ export const setState = (
     // There can only be one state in the table. When the stateName is inconsistent with the state in the stateInfo, the previously stored state should be cleared.
     clearState(spreadsheet);
     spreadsheet.hideTooltip();
-    spreadsheet.store.set(INTERACTION_STATE_INFO_KEY, interactionStateInfo);
   }
+  spreadsheet.store.set(INTERACTION_STATE_INFO_KEY, interactionStateInfo);
 };


### PR DESCRIPTION
### 👀 PR includes

明细表之前有如下问题，Hover 事件有时候会不生效：

![hovergif](https://user-images.githubusercontent.com/10339692/164954968-c1bd0ded-62e3-4daa-bdb9-ef60b2ff21d1.gif)

经过排查，是因为 clearState 中判断条件：

```
if (!isEmpty(allInteractedCells) && !isEmpty(cellMetas)) {
```

应该改成

```
if (!isEmpty(allInteractedCells) || !isEmpty(cellMetas)) {
```

两者有一个不为空就需要触发 Clear 逻辑。

顺便还给 DATA_CELL_HOVER 事件添加了重复触发的判断逻辑，在一个 Cell 中不断移动鼠标 Hover 只会触发一次。和修复了 DataCell Click 的测试中重复 bindEvents 导致测试失败的问题。