### PR TITLE
fix: 修正auto reset 的 canvas 外判断逻辑

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -529,43 +529,63 @@ describe('Interaction Event Controller Tests', () => {
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
-  test('should hide tooltip and clear hover highlight cell if current mouse outside the cell', () => {
+  test('should hide tooltip and clear hover highlight cell if current mouse outside the canvas', () => {
     spreadsheet.interaction.changeState({
       cells: [{} as CellMeta],
       stateName: InteractionStateName.HOVER,
     });
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT);
+    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
+      shape: null,
+    });
 
     expect(spreadsheet.interaction.reset).toHaveBeenCalled();
     expect(spreadsheet.hideTooltip).toHaveBeenCalled();
     expect(spreadsheet.interaction.getActiveCells()).toHaveLength(0);
   });
 
-  test('should not hide tooltip if mouse outside the cell and has selected cells', () => {
+  test('should not hide tooltip if mouse move inside the canvas', () => {
     spreadsheet.interaction.changeState({
       cells: [{} as CellMeta],
       stateName: InteractionStateName.SELECTED,
     });
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT);
+    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
+      shape: 'mock',
+    });
 
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
-  test('should disable reset if mouse outside the cell and autoResetSheetStyle set to false', () => {
+  test('should not hide tooltip if mouse outside the canvas and has selected cells', () => {
+    spreadsheet.interaction.changeState({
+      cells: [{} as CellMeta],
+      stateName: InteractionStateName.SELECTED,
+    });
+    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
+      shape: null,
+    });
+
+    expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
+  });
+
+  test('should disable reset if mouse outside the canvas and autoResetSheetStyle set to false', () => {
     spreadsheet.setOptions({
       interaction: {
         autoResetSheetStyle: false,
       },
     });
 
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT);
+    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
+      shape: null,
+    });
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
-  test('should disable reset if mouse outside the cell and action tooltip is active', () => {
+  test('should disable reset if mouse outside the canvas and action tooltip is active', () => {
     spreadsheet.interaction.addIntercepts([InterceptType.HOVER]);
 
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT);
+    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
+      shape: null,
+    });
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -439,8 +439,8 @@ export class EventController {
     }
   };
 
-  private onCanvasMouseout = () => {
-    if (!this.isAutoResetSheetStyle) {
+  private onCanvasMouseout = (args) => {
+    if (!this.isAutoResetSheetStyle || args?.shape) {
       return;
     }
     const { interaction } = this.spreadsheet;

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -439,8 +439,8 @@ export class EventController {
     }
   };
 
-  private onCanvasMouseout = (args) => {
-    if (!this.isAutoResetSheetStyle || args?.shape) {
+  private onCanvasMouseout = (event: CanvasEvent) => {
+    if (!this.isAutoResetSheetStyle || event?.shape) {
       return;
     }
     const { interaction } = this.spreadsheet;


### PR DESCRIPTION
### 👀 PR includes

在做边框单独渲染的时候，会触发这样的问题：

![flash1](https://user-images.githubusercontent.com/10339692/164955126-7b2ae28d-ec9c-43f7-b12f-c671c27eb89f.gif)

闪烁的原因是，从 A Shape 移动到 B Shape 的时候，会触发 mouseout 事件，把交互重置了，造成鼠标经过边框 Shape 的时候会闪一下。

autoreset 我记得是在鼠标移动到 Canvas 外时 reset 交互样式。目前则是在任意 mouseout 触发的时候 reset。只要从 A Shape 移动到 B Shape 就会触发。看了一下测试用例。Tooltip 的自动隐藏其实在 ChangeState 的时候就已经做了。不需要单独在 CanvasMouseOut 里面做。

改动了一下 CanvasMouseOut 的判断逻辑，只有在鼠标移动到 Canvas 外时才会触发。