### PR TITLE
fix(interaction): 设置 stateShape 的 visible 默认为 false 来减少绘制调用

### DIFF
--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -244,11 +244,13 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
         pickBy(SHAPE_ATTRS_MAP, (attrs) => includes(attrs, styleKey)),
       );
       targetShapeNames.forEach((shapeName: StateShapeLayer) => {
-        const shape = this.stateShapes.has(shapeName)
+        const isStateShape = this.stateShapes.has(shapeName);
+        const shape = isStateShape
           ? this.stateShapes.get(shapeName)
           : this[shapeName];
 
-        if (this.stateShapes.has(shapeName) && !shape.get('visible')) {
+        // stateShape 默认 visible 为 false
+        if (isStateShape && !shape.get('visible')) {
           shape.set('visible', true);
         }
 

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -276,7 +276,11 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
 
   public hideInteractionShape() {
     this.stateShapes.forEach((shape: IShape) => {
-      shape.set('visible', false);
+      updateShapeAttr(shape, SHAPE_STYLE_MAP.backgroundOpacity, 0);
+      updateShapeAttr(shape, SHAPE_STYLE_MAP.backgroundColor, 'transparent');
+      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderOpacity, 0);
+      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderWidth, 1);
+      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderColor, 'transparent');
     });
   }
 

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -248,6 +248,10 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
           ? this.stateShapes.get(shapeName)
           : this[shapeName];
 
+        if (this.stateShapes.has(shapeName) && !shape.get('visible')) {
+          shape.set('visible', true);
+        }
+
         // 根据borderWidth更新borderShape大小 https://github.com/antvis/S2/pull/705
         if (
           shapeName === 'interactiveBorderShape' &&
@@ -272,11 +276,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
 
   public hideInteractionShape() {
     this.stateShapes.forEach((shape: IShape) => {
-      updateShapeAttr(shape, SHAPE_STYLE_MAP.backgroundOpacity, 0);
-      updateShapeAttr(shape, SHAPE_STYLE_MAP.backgroundColor, 'transparent');
-      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderOpacity, 0);
-      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderWidth, 1);
-      updateShapeAttr(shape, SHAPE_STYLE_MAP.borderColor, 'transparent');
+      shape.set('visible', false);
     });
   }
 

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -76,11 +76,15 @@ export class ColCell extends HeaderCell {
   protected drawInteractiveBgShape() {
     this.stateShapes.set(
       'interactiveBgShape',
-      renderRect(this, {
-        ...this.getCellArea(),
-        fill: 'transparent',
-        stroke: 'transparent',
-      }),
+      renderRect(
+        this,
+        {
+          ...this.getCellArea(),
+        },
+        {
+          visible: false,
+        },
+      ),
     );
   }
 

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -379,14 +379,18 @@ export class DataCell extends BaseCell<ViewMeta> {
     const { x, y, height, width } = this.getCellArea();
     this.stateShapes.set(
       'interactiveBorderShape',
-      renderRect(this, {
-        x: x + margin,
-        y: y + margin,
-        width: width - margin * 2,
-        height: height - margin * 2,
-        fill: 'transparent',
-        stroke: 'transparent',
-      }),
+      renderRect(
+        this,
+        {
+          x: x + margin,
+          y: y + margin,
+          width: width - margin * 2,
+          height: height - margin * 2,
+        },
+        {
+          visible: false,
+        },
+      ),
     );
   }
 
@@ -396,11 +400,15 @@ export class DataCell extends BaseCell<ViewMeta> {
   protected drawInteractiveBgShape() {
     this.stateShapes.set(
       'interactiveBgShape',
-      renderRect(this, {
-        ...this.getCellArea(),
-        fill: 'transparent',
-        stroke: 'transparent',
-      }),
+      renderRect(
+        this,
+        {
+          ...this.getCellArea(),
+        },
+        {
+          visible: false,
+        },
+      ),
     );
   }
 

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -72,11 +72,15 @@ export class RowCell extends HeaderCell {
   protected drawInteractiveBgShape() {
     this.stateShapes.set(
       'interactiveBgShape',
-      renderRect(this, {
-        ...this.getCellArea(),
-        fill: 'transparent',
-        stroke: 'transparent',
-      }),
+      renderRect(
+        this,
+        {
+          ...this.getCellArea(),
+        },
+        {
+          visible: false,
+        },
+      ),
     );
   }
 

--- a/packages/s2-core/src/utils/g-renders.ts
+++ b/packages/s2-core/src/utils/g-renders.ts
@@ -7,10 +7,15 @@ import { forEach, isEmpty, set, isFunction } from 'lodash';
 import { GuiIcon, GuiIconCfg } from '@/common/icons/gui-icon';
 import { TextTheme } from '@/common/interface/theme';
 
-export function renderRect(group: Group, attrs: ShapeAttrs): IShape {
+export function renderRect(
+  group: Group,
+  attrs: ShapeAttrs,
+  other?: any,
+): IShape {
   return group?.addShape?.('rect', {
     zIndex: 1,
     attrs,
+    ...(other || {}),
   });
 }
 

--- a/packages/s2-core/src/utils/g-renders.ts
+++ b/packages/s2-core/src/utils/g-renders.ts
@@ -2,7 +2,13 @@
  * Utils to render all g supported shape
  * https://github.com/antvis/g
  */
-import { Group, IShape, ShapeAttrs, SimpleBBox } from '@antv/g-canvas';
+import {
+  Group,
+  IShape,
+  ShapeAttrs,
+  ShapeCfg,
+  SimpleBBox,
+} from '@antv/g-canvas';
 import { forEach, isEmpty, set, isFunction } from 'lodash';
 import { GuiIcon, GuiIconCfg } from '@/common/icons/gui-icon';
 import { TextTheme } from '@/common/interface/theme';
@@ -10,12 +16,12 @@ import { TextTheme } from '@/common/interface/theme';
 export function renderRect(
   group: Group,
   attrs: ShapeAttrs,
-  other?: any,
+  extraParams?: Omit<ShapeCfg, 'attrs'>,
 ): IShape {
   return group?.addShape?.('rect', {
     zIndex: 1,
     attrs,
-    ...(other || {}),
+    ...(extraParams || {}),
   });
 }
 


### PR DESCRIPTION
### 👀 PR includes

在 Cell 的初始状态，一般是没有交互状态的，比如首次渲染，或者滚动时新渲染的格子。把 stateShape 的 visible 位置为 false 来替换设置透明的背景和边框，可以让 g 在一开始不渲染这个 Shape，从而提升一些性能。

优化前：

<img width="205" alt="image" src="https://user-images.githubusercontent.com/10339692/164965059-ee40dd3f-5d17-443a-b12a-5ea47a44d875.png">

优化后：

<img width="208" alt="image" src="https://user-images.githubusercontent.com/10339692/164965049-df01bef1-852c-42fd-abad-dbdaf1e70575.png">

从 PanelGroup 的绘制时间和 Shape 的绘制调用次数来看，都有 30% 左右的提升。

