### PR TITLE
refactor: 不需要通过 root[&] 进行分割，仍可以获取正确的展示值

### DIFF
--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -9,7 +9,6 @@ import { SpreadSheet } from '@/sheet-type';
 import { getListBySorted, filterUndefined } from '@/utils/data-set-operate';
 import { getDimensionsWithoutPathPre } from '@/utils/dataset/pivot-data-set';
 import { PivotDataSet } from '@/data-set';
-import { ID_SEPARATOR, ROOT_ID } from '@/common/constant';
 
 const addTotals = (
   spreadsheet: SpreadSheet,
@@ -41,18 +40,10 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
   const sortedDimensionValues =
     (dataSet as PivotDataSet)?.sortedDimensionValues?.[currentField] || [];
 
-  // 为第一个子层级时，parentNode.id === ROOT_ID 时，不需要通过分割获取当前节点的真实 value
-  const dimensions =
-    ROOT_ID === id
-      ? sortedDimensionValues
-      : sortedDimensionValues?.filter((item) =>
-          item?.includes(id?.split(`${ROOT_ID}${ID_SEPARATOR}`)[1]),
-        );
-
   const dimValues = filterUndefined(
     getListBySorted(
       [...(pivotMeta.keys() || [])],
-      [...getDimensionsWithoutPathPre([...dimensions])],
+      [...getDimensionsWithoutPathPre([...sortedDimensionValues])],
     ),
   );
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [X] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

dimensions  只有在 `getDimensionsWithoutPathPre([...dimensions])` 中使用。
最终目的只是为了获取 dimension 的最后一个纬度值。
eg: 
root[&]浙江[&]杭州   获取 杭州
已和原作者沟通了目的，再进行删除的

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
