### PR TITLE
fix(interaction): 树状模式列头非叶子节点选中无法高亮当前列

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/interaction-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-multi-selection-spec.ts
@@ -1,0 +1,59 @@
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { createMockCellInfo, getContainer } from 'tests/util/helpers';
+import { Event as GEvent } from '@antv/g-canvas';
+import { PivotSheet, SpreadSheet } from '@/sheet-type';
+import { S2Options } from '@/common/interface';
+import { S2Event } from '@/common/constant';
+
+const s2Options: S2Options = {
+  width: 600,
+  height: 400,
+  tooltip: {
+    showTooltip: true,
+  },
+};
+
+describe('Interaction Multi Selection Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    jest
+      .spyOn(SpreadSheet.prototype, 'getCell')
+      .mockImplementation(() => createMockCellInfo('testId').mockCell);
+
+    s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
+    s2.render();
+  });
+
+  afterEach(() => {
+    s2.destroy();
+  });
+
+  // https://github.com/antvis/S2/issues/1306
+  test('should selected belong data cell after selected root col cells', () => {
+    s2.setOptions({
+      hierarchyType: 'tree',
+    });
+    s2.render(false);
+
+    const colRootCell = s2.interaction.getAllColHeaderCells()[0];
+
+    s2.interaction.selectHeaderCell({
+      cell: colRootCell,
+    });
+
+    s2.interaction
+      .getPanelGroupAllDataCells()
+      .filter((cell) => {
+        const targetCellMeta = colRootCell.getMeta();
+        const meta = cell.getMeta();
+        return meta.colIndex === targetCellMeta.colIndex;
+      })
+      .forEach((cell) => {
+        expect(cell.getBackgroundColor()).toEqual({
+          backgroundColor: '#F5F8FE',
+          backgroundColorOpacity: 1,
+        });
+      });
+  });
+});

--- a/packages/s2-core/__tests__/spreadsheet/interaction-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-multi-selection-spec.ts
@@ -38,6 +38,7 @@ describe('Interaction Multi Selection Tests', () => {
 
     const colRootCell = s2.interaction.getAllColHeaderCells()[0];
 
+    // 选中
     s2.interaction.selectHeaderCell({
       cell: colRootCell,
     });
@@ -55,5 +56,12 @@ describe('Interaction Multi Selection Tests', () => {
           backgroundColorOpacity: 1,
         });
       });
+
+    // 取消选中
+    s2.interaction.selectHeaderCell({
+      cell: colRootCell,
+    });
+
+    expect(s2.interaction.getActiveCells()).toHaveLength(0);
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -6,7 +6,6 @@ import {
   CellTypes,
   InteractionStateName,
   InterceptType,
-  RowCell,
   DataCell,
   S2Options,
   SpreadSheet,
@@ -24,9 +23,8 @@ import {
   SelectedCellMove,
   BaseEvent,
   GuiIcon,
-  S2CellType,
-  S2Event,
 } from '@/index';
+import { Node } from '@/facet/layout/node';
 import { Store } from '@/common/store';
 import { mergeCell, unmergeCell } from '@/utils/interaction/merge-cell';
 

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -1,6 +1,6 @@
-import { Event as CanvasEvent } from '@antv/g-canvas';
+import type { Event as CanvasEvent } from '@antv/g-canvas';
 import { difference } from 'lodash';
-import { isMultiSelectionKey } from 'src/utils/interaction/select-event';
+import { isMultiSelectionKey } from '@/utils/interaction/select-event';
 import {
   hideColumnsByThunkGroup,
   isEqualDisplaySiblingNodeId,
@@ -11,7 +11,6 @@ import {
   InterceptType,
   CellTypes,
   TOOLTIP_OPERATOR_HIDDEN_COLUMNS_MENU,
-  InteractionStateName,
 } from '@/common/constant';
 import {
   TooltipOperation,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1306 

### 📝 Description

1. 列头联动高亮未考虑 树状列头非叶子节点的情况, 这次补上, 兼容多选 
2. 同时可以解决趋势分析表 粒度切换高亮, 无法高亮整列的问题

TODO: 

- [x] 单测

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-04-28 at 18 58 01](https://user-images.githubusercontent.com/21015895/165737853-c5f96c9d-8d02-44a3-8660-698327851c56.gif) | ![Kapture 2022-04-28 at 18 55 31](https://user-images.githubusercontent.com/21015895/165737605-5bbfc041-a568-474a-9974-b8da810c6d4b.gif)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
