### PR TITLE
fix: 修复容器设置transform样式后框选背景框错位问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
@@ -79,6 +79,7 @@ describe('Brush selection scroll spec', () => {
     s2.emit(S2Event.DATA_CELL_MOUSE_DOWN, {
       target,
       originalEvent: { layerX: 1, layerY: 1 },
+      event: { x: 1, y: 1 },
       preventDefault() {},
     } as any);
     await sleep(40);
@@ -127,7 +128,7 @@ describe('Brush selection scroll spec', () => {
 
     s2.emit(S2Event.DATA_CELL_MOUSE_DOWN, {
       target,
-      originalEvent: { layerX: 128, layerY: 49 },
+      event: { x: 128, y: 49 },
       preventDefault() {},
     } as any);
 

--- a/packages/s2-core/src/interaction/brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection.ts
@@ -553,8 +553,8 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
     const { scrollY, scrollX } = this.spreadsheet.facet.getScrollOffset();
     const originalEvent = event.originalEvent as unknown as OriginalEvent;
     const point: Point = {
-      x: originalEvent?.layerX,
-      y: originalEvent?.layerY,
+      x: event?.x ?? originalEvent?.layerX,
+      y: event?.y ?? originalEvent?.layerY,
     };
     const cell = this.spreadsheet.getCell(event.target);
     const { colIndex, rowIndex } = cell.getMeta();


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #1209,  #1206

### 📝 Description

layerX layerY Chrome / Webkit 已经移除了，咱就是说先别用了 = =

https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/layerX
