### PR TITLE
fix: dataCfg变化时未重新计算treeRow宽度

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -14,9 +14,7 @@ describe('SpreadSheet Tests', () => {
   describe('Mount Sheet Tests', () => {
     let container: HTMLElement;
     beforeAll(() => {
-      container = document.createElement('div');
-      container.id = 'container';
-      document.body.appendChild(container);
+      container = getContainer();
     });
 
     afterAll(() => {
@@ -24,8 +22,7 @@ describe('SpreadSheet Tests', () => {
     });
 
     test('should init sheet by dom container', () => {
-      const mountContainer = document.querySelector('#container');
-      const s2 = new PivotSheet(mountContainer, mockDataConfig, s2Options);
+      const s2 = new PivotSheet(container, mockDataConfig, s2Options);
       s2.render();
 
       expect(s2.container).toBeDefined();
@@ -36,7 +33,10 @@ describe('SpreadSheet Tests', () => {
     });
 
     test('should init sheet by selector container', () => {
-      const containerSelector = '#container';
+      const CONTAINER_ID = 'container';
+      container.id = CONTAINER_ID;
+
+      const containerSelector = `#${CONTAINER_ID}`;
       const s2 = new PivotSheet(containerSelector, mockDataConfig, s2Options);
       s2.render();
 

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-tree-mode-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-tree-mode-spec.ts
@@ -1,4 +1,5 @@
 import * as mockDataConfig from 'tests/data/simple-data.json';
+import { getContainer } from 'tests/util/helpers';
 import { PivotSheet } from '@/sheet-type';
 import { S2DataConfig, S2Options } from '@/common';
 
@@ -12,9 +13,7 @@ const s2Options: S2Options = {
 describe('SpreadSheet Tree Mode Tests', () => {
   let container: HTMLElement;
   beforeAll(() => {
-    container = document.createElement('div');
-    container.id = 'container';
-    document.body.appendChild(container);
+    container = getContainer();
   });
 
   afterAll(() => {
@@ -23,8 +22,7 @@ describe('SpreadSheet Tree Mode Tests', () => {
 
   describe('Facet Tests', () => {
     test('should re-calc row header width', () => {
-      const mountContainer = document.querySelector('#container');
-      const s2 = new PivotSheet(mountContainer, mockDataConfig, s2Options);
+      const s2 = new PivotSheet(container, mockDataConfig, s2Options);
       s2.render();
 
       const rowsHierarchyWidth = s2.facet.layoutResult.rowsHierarchy.width;

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-tree-mode-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-tree-mode-spec.ts
@@ -1,0 +1,55 @@
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { PivotSheet } from '@/sheet-type';
+import { S2DataConfig, S2Options } from '@/common';
+
+const s2Options: S2Options = {
+  width: 200,
+  height: 200,
+  hierarchyType: 'tree',
+  hdAdapter: true,
+};
+
+describe('SpreadSheet Tree Mode Tests', () => {
+  let container: HTMLElement;
+  beforeAll(() => {
+    container = document.createElement('div');
+    container.id = 'container';
+    document.body.appendChild(container);
+  });
+
+  afterAll(() => {
+    container?.remove();
+  });
+
+  describe('Facet Tests', () => {
+    test('should re-calc row header width', () => {
+      const mountContainer = document.querySelector('#container');
+      const s2 = new PivotSheet(mountContainer, mockDataConfig, s2Options);
+      s2.render();
+
+      const rowsHierarchyWidth = s2.facet.layoutResult.rowsHierarchy.width;
+      expect(rowsHierarchyWidth).toEqual(120);
+
+      // 行头维度均更改为较长的 name
+      const newDataCfg: S2DataConfig = {
+        ...mockDataConfig,
+        meta: [
+          {
+            field: 'province',
+            name: '省1234567890份',
+          },
+          {
+            field: 'city',
+            name: '城1234567890市',
+          },
+        ],
+      };
+      s2.setDataCfg(newDataCfg);
+      s2.render();
+
+      expect(s2.facet.layoutResult.rowsHierarchy.width).not.toEqual(
+        rowsHierarchyWidth,
+      );
+    });
+  });
+});

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -670,6 +670,7 @@ export class PivotFacet extends BaseFacet {
     if (rowCfg?.treeRowsWidth) {
       return rowCfg?.treeRowsWidth;
     }
+
     // + province/city/level
     const treeHeaderLabel = rows
       .map((key: string): string => dataSet.getFieldName(key))
@@ -685,10 +686,7 @@ export class PivotFacet extends BaseFacet {
       this.rowCellTheme.padding?.left +
       this.rowCellTheme.padding?.right;
 
-    const width = Math.max(treeRowsWidth, maxLabelWidth);
-    // NOTE: mark as user drag to calculate only one time
-    rowCfg.treeRowsWidth = width;
-    return width;
+    return Math.max(treeRowsWidth, maxLabelWidth);
   }
 
   /**


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

#### 说明
树状模式下，当表格首次渲染后，会缓存计算的行头宽度（rowCfg.treeRowsWidth）。
当 dataCfg 改变，如 meta[].name 变更，即各维度的名称长度会变化，导致整体行头宽度变化。
此时再使用缓存的宽度不合适，需要重新计算。

#### 修改点
- rowCfg.treeRowsWidth 本来用作记录用户的拖拽宽度，不应用作缓存
- 不再缓存计算的宽度，每次 render 重新计算。但仍优先取 rowCfg.treeRowsWidth（用户拖拽优先级最高）

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
