### PR TITLE
docs: 增加如何在 Vue 中自定义 Tooltip 的文档

### DIFF
--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -9,6 +9,18 @@ order: 7
 
 <img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*zRquQpJqBzUAAAAAAAAAAAAAARQnAQ" width = "600"  alt="row" />
 
+## 注意事项
+
+`@antv/s2` 中只保留了 `tooltip` 的核心显隐逻辑，提供相应数据, **不渲染内容**, `@antv/s2-react` 中通过[组件](https://github.com/antvis/S2/blob/master/packages/s2-react/src/components/tooltip/custom-tooltip.tsx)的方式渲染 `tooltip` 的内容, 包括 `排序下拉菜单`, `单元格选中信息汇总`, `列头隐藏按钮` 等.
+
+- 如果您有 `tooltip` 的需求，您可以直接使用开箱即用的 `@antv/s2-react`, 免去你二次封装
+- 如果您不希望依赖框架, 或者希望在 `Vue`, `Angular` 框架中使用 `tooltip`, 请参考 [自定义 Tooltip 类](#自定义-tooltip-类) 章节
+- 别忘了引入样式
+
+```ts
+import "@antv/s2/dist/style.min.css";
+```
+
 ## 使用
 
 在 `s2Options` 中配置 [tooltip](/zh/docs/api/general/S2Options#tooltip) 字段，默认作用于**所有**单元格
@@ -194,11 +206,40 @@ s2.showTooltip({
 
 <playground path='react-component/tooltip/demo/custom-content.tsx' rid='container-1' height='300'></playground>
 
-##### 3. 内容显示优先级
+##### 3. 在 Vue3 中自定义
+
+在 `Vue3` 中可以通过 `defineCustomElement` 自定义内容. [例子](https://codesandbox.io/s/antv-s2-vue3-tooltip-demo-hpm3rf?file=/src/main.js)
+
+```ts
+import { defineCustomElement } from "vue";
+
+const VueTooltipContent = defineCustomElement({
+  props: ["meta"],
+  template: `
+    <div>我是自定义 Tooltip 内容</div>
+    <p>当前值: {{ meta?.label ?? meta?.fieldValue }}</p>
+  `
+});
+
+customElements.define("vue-tooltip-content", VueTooltipContent);
+
+const s2Options = {
+  tooltip: {
+    content: (cell, defaultTooltipShowOptions) => {
+      const meta = cell.getMeta();
+      return new VueTooltipContent({ meta });
+    },
+  },
+};
+```
+
+<img src="https://gw.alipayobjects.com/zos/antfincdn/AphZDgJvY/b4654699-927d-4b58-9da2-a5793f964061.png" width="600"  alt="preview" />
+
+##### 4. 内容显示优先级
 
 `方法调用` > `单元格配置` > `基本配置`
 
-<img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*EwvcRZjOslMAAAAAAAAAAAAAARQnAQ" width = "600"  alt="row" />
+<img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*EwvcRZjOslMAAAAAAAAAAAAAARQnAQ" width="600"  alt="row" />
 
 #### 自定义 Tooltip 操作项
 
@@ -289,10 +330,18 @@ const s2Options = {
 
 #### 自定义 Tooltip 类
 
-继承 `BaseTooltip` 基类，可重写 `显示 (show)`, `隐藏 (hide)`, `销毁 (destroy)` 等方法，结合 `this.spreadsheet` 实例，来实现满足你业务的 `tooltip`
+除了上面讲到的 `自定义 Tooltip 内容` 外, 你还可以 `自定义 Tooltip 类` 与任意框架 (`Vue`, `Angular`, `React`) 结合
+
+继承 `BaseTooltip` 基类，可重写 `显示 (show)`, `隐藏 (hide)`, `销毁 (destroy)` 等方法，结合 `this.spreadsheet` 实例，来实现满足你业务的 `tooltip`, 也可以重写 `renderContent` 方法, 渲染你封装的任意组件
+
+- [查看 BaseTooltip 基类](https://github.com/antvis/S2/blob/master/packages/s2-core/src/ui/tooltip/index.ts#L23)
+- [查看 React 示例](https://github.com/antvis/S2/blob/master/packages/s2-react/src/components/tooltip/custom-tooltip.tsx)
+- [查看 Vue 示例](https://codesandbox.io/s/compassionate-booth-hpm3rf?file=/src/App.vue)
 
 ```ts
 import { BaseTooltip, SpreadSheet } from '@antv/s2';
+// 引入 `tooltip` 样式文件
+import "@antv/s2/dist/style.min.css";
 
 export class CustomTooltip extends BaseTooltip {
   constructor(spreadsheet: SpreadSheet) {

--- a/s2-site/docs/manual/faq.zh.md
+++ b/s2-site/docs/manual/faq.zh.md
@@ -7,25 +7,6 @@ order: 8
 
 ## 1. 使用问题
 
-### 性能问题
-
-使用 [`S2`](https://github.com/antvis/S2) 过程中，如果出现性能问题，比如渲染时间长，浏览器无响应等，可能原因如下：
-
-- 数据量大。正常 `1w` 数据渲染时间是 `150ms`，`100w` 数据渲染时间是 `4s`，数据超过 `100w` 感受会比较明显，详见 [性能介绍](/zh/docs/manual/advanced/performance)。
-- 属性频繁变化。比如 `<SheetComponent />` 组件中，`options`、`dataCfg`等属性的引用频繁变化，每一次变化都会重新计算布局和渲染，因此属性改变时建议使用新的数据对象，避免重复渲染，[更多了解](https://zh-hans.reactjs.org/docs/optimizing-performance.html#the-power-of-not-mutating-data)。
-
-   举个例子：
-
-   ```ts
-   // bad
-   options.hierarchyType = 'tree';
-
-   // good
-   const newOptions = Object.assign({}, options, { hierarchyType: 'tree' });
-   ```
-
-   此外，当处理深层嵌套对象时，以 immutable （不可变）的方式更新它们，帮助你编写高可读性、高性能的代码。
-
 ### 浏览器兼容性
 
 如果出现兼容性问题请结合 `babel` 和 `@babel/polyfill` 使用，更多问题欢迎进群交流
@@ -150,6 +131,14 @@ s2.render(false)
 
 请查看 [这篇文章](/zh/docs/manual/advanced/get-cell-data)
 
+### 为什么 tooltip 在 `@antv/s2` 中不显示, 在 `@antv/s2-react` 中可以正常显示?
+
+请查看 [Tooltip 注意事项](/zh/docs/manual/basic/tooltip#%E7%AE%80%E4%BB%8B)
+
+### 如果在 Vue, Angular 中自定义 Tooltip
+
+请查看 [Tooltip 自定义](/zh/docs/manual/basic/tooltip#%E8%87%AA%E5%AE%9A%E4%B9%89)
+
 ### 表格支持导出 `Excel` 吗？
 
 支持，请查看 [这篇文章](/zh/docs/manual/basic/analysis/export), 或者 [示例](/zh/examples/react-component/export#export)
@@ -193,7 +182,7 @@ s2.render(false)
 
 - 你的**复现步骤**, 和可复现链接
 
-> 推荐使用 官方 [codesandbox 模板](https://codesandbox.io/s/29zle) 大家一些最小的可复现 demo
+> 推荐使用 官方 [codesandbox 模板](https://codesandbox.io/s/29zle) 搭建一些最小的可复现 demo
 
 - 你的**配置信息**, 并且使用 markdown 的 `code` 标签
 

--- a/s2-site/docs/manual/getting-started.zh.md
+++ b/s2-site/docs/manual/getting-started.zh.md
@@ -179,10 +179,6 @@ s2.render()
 
 <playground path='basic/pivot/demo/grid.ts' rid='container' height='400'></playground>
 
-#### tooltip 注意事项
-
-`@antv/s2` 中只保留了 tooltip 的核心显隐逻辑，我们将所有 tooltip 定制化交互都迁移到了`@antv/s2-react` 中，因此如果您有 tooltip 的需求，我们强烈建议您使用`@antv/s2-react`，细节参见 [tooltip 组件使用文档](https://s2.antv.vision/zh/examples/gallery#category-Tooltip%E7%BB%84%E4%BB%B6)。
-
 ### `React` 版本
 
 `S2` 提供了开箱即用的 `React` 版本 [表格组件](/zh/examples/gallery#category-表格组件)，还有配套丰富的 [分析组件](/zh/examples/gallery#category-Tooltip), 帮助开发者快速满足业务看数分析需求。

--- a/s2-site/examples/react-component/tooltip/demo/custom-tooltip.tsx
+++ b/s2-site/examples/react-component/tooltip/demo/custom-tooltip.tsx
@@ -5,8 +5,8 @@ import { SheetComponent } from '@antv/s2-react';
 import insertCss from 'insert-css';
 import '@antv/s2-react/dist/style.min.css';
 
-const MyCustomTooltip = () => (
-  <div className="tooltip-custom-component">custom tooltip</div>
+const MyCustomTooltipContent = () => (
+  <div className="tooltip-custom-component">我是自定义 tooltip 内容</div>
 );
 
 class CustomTooltip extends BaseTooltip {
@@ -15,7 +15,7 @@ class CustomTooltip extends BaseTooltip {
   }
 
   renderContent() {
-    ReactDOM.render(<MyCustomTooltip />, this.container);
+    ReactDOM.render(<MyCustomTooltipContent />, this.container);
   }
 
   show(options) {
@@ -23,16 +23,13 @@ class CustomTooltip extends BaseTooltip {
     console.log('options: ', options);
   }
 
-  hide() {
-    super.hide();
-    ReactDOM.unmountComponentAtNode(this.container);
-    console.log('hide tooltip');
-  }
-
   destroy() {
+    console.log('tooltip destroy');
+
     super.destroy();
-    ReactDOM.unmountComponentAtNode(this.container);
-    console.log('destroy tooltip');
+    if (this.container) {
+      ReactDOM.unmountComponentAtNode(this.container);
+    }
   }
 }
 

--- a/s2-site/package.json
+++ b/s2-site/package.json
@@ -37,7 +37,7 @@
     "@antv/g-canvas": "^0.5.12",
     "@antv/gatsby-theme-antv": "1.1.18-beta.0",
     "@antv/s2": "^1.16.0",
-    "@antv/s2-react": "^1.14.0",
+    "@antv/s2-react": "^1.15.0",
     "copy-to-clipboard": "^3.3.1",
     "gatsby": "^2.24.2",
     "gh-pages": "^3.1.0",

--- a/s2-site/yarn.lock
+++ b/s2-site/yarn.lock
@@ -312,10 +312,10 @@
     "@antv/util" "^2.0.9"
     tslib "^2.0.3"
 
-"@antv/s2-react@^1.14.0":
-  version "1.14.0"
-  resolved "https://registry.npmmirror.com/@antv/s2-react/-/s2-react-1.14.0.tgz#3e6f06fb364c4980df3c690119d03e705c1f7d6c"
-  integrity sha512-AjxR4QMqTzBVW2I0luJWfDD4dNNOlV/oBnQ1REHFQCYERekNBbrEzje9t+u/nu7w7UHXJLZ1qWTe5u9peXs8pQ==
+"@antv/s2-react@^1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@antv/s2-react/-/s2-react-1.15.0.tgz#983691527b96006da0329426775a7910b8a4be89"
+  integrity sha512-h2ypMpMlVZEuhZHyCMmz/t+jrSzKZ2VxA0WNAY6G1iPISp07Y9EMHzCvpn86HOnUyfP4tLP6EpE1vyPRKmwpAw==
   dependencies:
     ahooks "^3.1.13"
     classnames "^2.3.1"


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🔧 Chore

- [ ] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

1. 完善 Tooltip 相关文档
2. 增加 Vue3 自定义 tooltip demo 和文档 https://codesandbox.io/s/antv-s2-vue3-tooltip-demo-hpm3rf?file=/src/main.js
3. 修复 React 自定义 tooltip demo 白屏的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
