### PR TITLE
fix(copy): 修复同步复制时会触发页面滚动的问题 close #1317

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/index-spec.ts
@@ -48,4 +48,18 @@ describe('Copy Tests', () => {
     expect(textareaValue).toEqual(result);
     expect(textareaValue).toEqual(text);
   });
+
+  // https://github.com/antvis/S2/issues/1317
+  test('should prevent page scroll scroll after sync copy text', async () => {
+    // 让页面显示滚动条
+    document.body.style.height = '9999px';
+
+    const scrollY = 100;
+    window.scrollTo(0, scrollY);
+
+    const text = '222';
+    await copyToClipboard(text, true);
+
+    expect(window.scrollY).toEqual(scrollY);
+  });
 });

--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -23,7 +23,8 @@ export const copyToClipboardByExecCommand = (str: string): Promise<void> => {
     const textarea = document.createElement('textarea');
     textarea.value = str;
     document.body.appendChild(textarea);
-    textarea.focus();
+    // 开启 preventScroll, 防止页面有滚动条时触发滚动
+    textarea.focus({ preventScroll: true });
     textarea.select();
 
     const success = document.execCommand('copy');


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1317

### 📝 Description

去掉 Element.focus() 默认滚动行为

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focus_with_focusoption

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-05-10 at 13 59 11](https://user-images.githubusercontent.com/21015895/167558424-06f5a914-6b0a-4f18-8736-1b3ca498e968.gif) | ![Kapture 2022-05-10 at 13 56 58](https://user-images.githubusercontent.com/21015895/167558156-d4897b63-5251-4ce8-a694-ab1e433a62fc.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
