### PR TITLE
fix(interaction): 角头单元格增加对自定义tooltip的适配

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/corner-cell-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/corner-cell-click-spec.ts
@@ -42,7 +42,8 @@ describe('Interaction Corner Cell Click Tests', () => {
     expect(s2.interaction.reset).toHaveBeenCalled();
   });
 
-  test('should remove hover intercepts after corner cell click', async () => {
+  test('should remove hover intercepts after corner cell click if tooltip is hidden', async () => {
+    s2.tooltip.visible = false;
     s2.emit(S2Event.CORNER_CELL_CLICK, {} as unknown as GEvent);
 
     await sleep(500);

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/corner-cell-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/corner-cell-click-spec.ts
@@ -1,0 +1,59 @@
+import {
+  createFakeSpreadSheet,
+  createMockCellInfo,
+  sleep,
+} from 'tests/util/helpers';
+import { Event as GEvent } from '@antv/g-canvas';
+import { S2Options } from '@/common/interface';
+import { SpreadSheet } from '@/sheet-type';
+import { InterceptType, S2Event } from '@/common/constant';
+import { CornerCellClick } from '@/interaction';
+
+jest.mock('@/interaction/event-controller');
+
+describe('Interaction Corner Cell Click Tests', () => {
+  let s2: SpreadSheet;
+  const mockCellInfo = createMockCellInfo('testId');
+  let cornerCellClick: CornerCellClick;
+
+  beforeEach(() => {
+    s2 = createFakeSpreadSheet();
+    s2.getCell = () => mockCellInfo.mockCell as any;
+    s2.options = {
+      tooltip: {
+        operation: {
+          trend: false,
+        },
+      },
+    } as S2Options;
+    s2.isTableMode = jest.fn(() => true);
+    s2.interaction.reset = jest.fn();
+    cornerCellClick = new CornerCellClick(s2);
+  });
+
+  test('should bind events', () => {
+    expect(cornerCellClick.bindEvents).toBeDefined();
+  });
+
+  test('should reset interaction and add hover intercepts after corner cell click', () => {
+    s2.emit(S2Event.CORNER_CELL_CLICK, {} as unknown as GEvent);
+
+    expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+    expect(s2.interaction.reset).toHaveBeenCalled();
+  });
+
+  test('should remove hover intercepts after corner cell click', async () => {
+    s2.emit(S2Event.CORNER_CELL_CLICK, {} as unknown as GEvent);
+
+    await sleep(500);
+    expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeFalsy();
+  });
+
+  test('should not remove hover intercepts after corner cell click when display tooltip', async () => {
+    s2.tooltip.visible = true;
+    s2.emit(S2Event.CORNER_CELL_CLICK, {} as unknown as GEvent);
+
+    await sleep(500);
+    expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+  });
+});

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -23,8 +23,8 @@ import {
   SelectedCellMove,
   BaseEvent,
   GuiIcon,
+  CornerCellClick,
 } from '@/index';
-import { Node } from '@/facet/layout/node';
 import { Store } from '@/common/store';
 import { mergeCell, unmergeCell } from '@/utils/interaction/merge-cell';
 
@@ -513,6 +513,7 @@ describe('RootInteraction Tests', () => {
 
   test.each`
     key                                          | expected
+    ${InteractionName.CORNER_CELL_CLICK}         | ${CornerCellClick}
     ${InteractionName.DATA_CELL_CLICK}           | ${DataCellClick}
     ${InteractionName.ROW_COLUMN_CLICK}          | ${RowColumnClick}
     ${InteractionName.ROW_TEXT_CLICK}            | ${RowTextClick}

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -498,7 +498,7 @@ describe('RootInteraction Tests', () => {
   });
 
   test('should get correctly default interaction size', () => {
-    expect(defaultInteractionSize).toEqual(10);
+    expect(defaultInteractionSize).toEqual(11);
   });
 
   test('should register default interaction', () => {

--- a/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
@@ -25,6 +25,7 @@ describe('Tooltip Tests', () => {
       x: 0,
       y: 0,
     });
+    expect(tooltip.visible).toBeFalsy();
   });
 
   test('should show tooltip', () => {
@@ -48,6 +49,8 @@ describe('Tooltip Tests', () => {
     expect(tooltip.container.className).toEqual(
       `${TOOLTIP_CONTAINER_CLS} ${TOOLTIP_CONTAINER_CLS}-show`,
     );
+    // visible status
+    expect(tooltip.visible).toBeTruthy();
     // set style
     expect(style.left).toEqual(`${left}px`);
     expect(style.top).toEqual(`${top}px`);
@@ -71,6 +74,8 @@ describe('Tooltip Tests', () => {
       x: 0,
       y: 0,
     });
+    // visible status
+    expect(tooltip.visible).toBeFalsy();
     // add class
     expect(tooltip.container.className).toEqual(
       `${TOOLTIP_CONTAINER_CLS} ${TOOLTIP_CONTAINER_CLS}-hide`,
@@ -96,6 +101,8 @@ describe('Tooltip Tests', () => {
       x: 0,
       y: 0,
     });
+    // visible status
+    expect(tooltip.visible).toBeFalsy();
     // remove container
     expect(document.getElementById(containerId)).toBeFalsy();
   });

--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -1,4 +1,5 @@
 export enum InteractionName {
+  CORNER_CELL_CLICK = 'cornerCellClick',
   DATA_CELL_CLICK = 'dataCellClick',
   MERGED_CELLS_CLICK = 'mergedCellsClick',
   ROW_COLUMN_CLICK = 'rowColumnClick',

--- a/packages/s2-core/src/interaction/base-interaction/click/corner-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/corner-cell-click.ts
@@ -1,0 +1,25 @@
+import { BaseEvent, BaseEventImplement } from '@/interaction/base-event';
+import { S2Event, InterceptType } from '@/common/constant';
+
+export class CornerCellClick extends BaseEvent implements BaseEventImplement {
+  public bindEvents() {
+    this.bindCornerCellClick();
+  }
+
+  private bindCornerCellClick() {
+    this.spreadsheet.on(S2Event.CORNER_CELL_CLICK, () => {
+      const { interaction, tooltip } = this.spreadsheet;
+
+      interaction.reset();
+      interaction.addIntercepts([InterceptType.HOVER]);
+
+      // 角头点击后如果 tooltip 未显示, 则取消 hover 拦截
+      setTimeout(() => {
+        if (tooltip.visible) {
+          return;
+        }
+        interaction.removeIntercepts([InterceptType.HOVER]);
+      });
+    });
+  }
+}

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -1,9 +1,6 @@
 import { Event as CanvasEvent } from '@antv/g-canvas';
 import { get } from 'lodash';
-import {
-  getTooltipOptions,
-  getTooltipVisibleOperator,
-} from '../../../utils/tooltip';
+import { getTooltipOptions, getTooltipVisibleOperator } from '@/utils/tooltip';
 import { getCellMeta } from '@/utils/interaction/select-event';
 import { DataCell } from '@/cell/data-cell';
 import {

--- a/packages/s2-core/src/interaction/base-interaction/click/index.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/index.ts
@@ -2,3 +2,4 @@ export { DataCellClick } from './data-cell-click';
 export { MergedCellClick } from './merged-cell-click';
 export { RowColumnClick } from './row-column-click';
 export { RowTextClick } from './row-text-click';
+export { CornerCellClick } from './corner-cell-click';

--- a/packages/s2-core/src/interaction/base-interaction/click/merged-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/merged-cell-click.ts
@@ -1,5 +1,5 @@
 import { Event } from '@antv/g-canvas';
-import { BaseEvent, BaseEventImplement } from '../../base-event';
+import { BaseEvent, BaseEventImplement } from '@/interaction/base-event';
 import { InterceptType, S2Event } from '@/common/constant';
 
 export class MergedCellClick extends BaseEvent implements BaseEventImplement {

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -1,6 +1,7 @@
 import { concat, filter, find, forEach, isEmpty, isNil, map } from 'lodash';
 import { getCellMeta } from 'src/utils/interaction/select-event';
 import type { IElement } from '@antv/g-canvas';
+import { CornerCellClick } from './base-interaction/click/corner-cell-click';
 import {
   DataCellClick,
   MergedCellClick,
@@ -356,6 +357,10 @@ export class RootInteraction {
     } = this.spreadsheet.options.interaction;
 
     return [
+      {
+        key: InteractionName.CORNER_CELL_CLICK,
+        interaction: CornerCellClick,
+      },
       {
         key: InteractionName.DATA_CELL_CLICK,
         interaction: DataCellClick,

--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -21,6 +21,8 @@ import './index.less';
  * Base tooltips component
  */
 export class BaseTooltip {
+  public visible = false;
+
   public spreadsheet: SpreadSheet; // the type of Spreadsheet
 
   public container: HTMLElement; // the base container element
@@ -46,6 +48,7 @@ export class BaseTooltip {
     const container = this.getContainer();
     const { autoAdjustBoundary } = this.spreadsheet.options.tooltip || {};
 
+    this.visible = true;
     this.options = showOptions as unknown as TooltipShowOptions;
 
     this.renderContent<T>(content as T);
@@ -73,6 +76,8 @@ export class BaseTooltip {
   }
 
   public hide() {
+    this.visible = false;
+
     if (!this.container) {
       return;
     }
@@ -87,6 +92,7 @@ export class BaseTooltip {
   }
 
   public destroy() {
+    this.visible = false;
     const container = this.getContainer();
     if (container) {
       this.resetPosition();

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -31,6 +31,7 @@ import {
   DataType,
   generatePalette,
   getPalette,
+  InterceptType,
 } from '@antv/s2';
 import corePkg from '@antv/s2/package.json';
 import { debounce, forEach, random } from 'lodash';
@@ -746,7 +747,24 @@ function MainLayout() {
               onDestroy={logHandler('onDestroy')}
               onColCellClick={onColCellClick}
               onRowCellClick={logHandler('onRowCellClick')}
-              onCornerCellClick={logHandler('onCornerCellClick')}
+              onCornerCellClick={(cellInfo) => {
+                s2Ref.current.showTooltip({
+                  position: {
+                    x: cellInfo.event.clientX,
+                    y: cellInfo.event.clientY,
+                  },
+                  content: 'click',
+                });
+              }}
+              onCornerCellHover={(cellInfo) => {
+                s2Ref.current.showTooltip({
+                  position: {
+                    x: cellInfo.event.clientX,
+                    y: cellInfo.event.clientY,
+                  },
+                  content: 'hover',
+                });
+              }}
               onDataCellClick={logHandler('onDataCellClick')}
               onLayoutResizeMouseDown={logHandler('onLayoutResizeMouseDown')}
               onCopied={logHandler('onCopied')}

--- a/s2-site/docs/api/basic-class/base-data-set.zh.md
+++ b/s2-site/docs/api/basic-class/base-data-set.zh.md
@@ -5,9 +5,13 @@ order: 5
 
 功能描述：表格数据集。[详情](https://github.com/antvis/S2/blob/master/packages/s2-core/src/data-set/pivot-data-set.ts)
 
+```ts
+s2.dataSet.xx()
+```
+
 | 参数 | 说明 | 类型 |
 | --- | --- | --- |
-| fields | 字段信息 | () => [Fields](#/zh/docs/api/general/S2DataConfig#fields) |
+| fields | 字段信息 | () => [Fields](/zh/docs/api/general/S2DataConfig#fields) |
 | meta | 字段元信息，包含有字段名、格式化等 | () => [Meta[]](#/zh/docs/api/general/S2DataConfig#meta) |
 | originData | 原始数据 | () => [DataType[]](#datatype) |
 | totalData | 汇总数据 | () => [DataType[]](#datatype)  |

--- a/s2-site/docs/api/basic-class/base-tooltip.zh.md
+++ b/s2-site/docs/api/basic-class/base-tooltip.zh.md
@@ -20,7 +20,6 @@ s2.tooltip.xx()
 | `hide` | 隐藏 tooltip | `() => void` |
 | `destroy` | 销毁 tooltip, 并移除挂载容器 | `() => void` |
 | `clearContent` | 清空 tooltip 内容 | `() => void` |
-| `destroy` | 清空 tooltip 内容 | `() => void` |
 | `disablePointerEvent` | 禁用 tooltip 鼠标响应 | `() => void` |
 
 `markdown:docs/common/custom-tooltip.zh.md`

--- a/s2-site/docs/api/basic-class/base-tooltip.zh.md
+++ b/s2-site/docs/api/basic-class/base-tooltip.zh.md
@@ -1,0 +1,26 @@
+---
+title: BaseTooltip
+order: 6
+---
+
+功能描述：Tooltip 类。[详情](https://github.com/antvis/S2/blob/master/packages/s2-core/src/ui/tooltip/index.ts)
+
+```ts
+s2.tooltip.xx()
+```
+
+| 参数 | 说明 | 类型 |
+| --- | --- | --- |
+| `spreadsheet` | 表格实例 | () => [SpreadSheet](/zh/docs/api/basic-class/spreadsheet) |
+| `container` | tooltip 挂载容器 | [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) |
+| `options` | tooltip 配置 | [TooltipShowOptions](#tooltipshowoptions) |
+| `position` | 坐标 | `{ x: number, y: number }` |
+| `visible` | 显示状态 | `boolean` |
+| `show` | 显示 tooltip | (showOptions: [TooltipShowOptions](#tooltipshowoptions)) => void |
+| `hide` | 隐藏 tooltip | `() => void` |
+| `destroy` | 销毁 tooltip, 并移除挂载容器 | `() => void` |
+| `clearContent` | 清空 tooltip 内容 | `() => void` |
+| `destroy` | 清空 tooltip 内容 | `() => void` |
+| `disablePointerEvent` | 禁用 tooltip 鼠标响应 | `() => void` |
+
+`markdown:docs/common/custom-tooltip.zh.md`

--- a/s2-site/docs/api/basic-class/interaction.zh.md
+++ b/s2-site/docs/api/basic-class/interaction.zh.md
@@ -6,7 +6,7 @@ order: 2
 功能描述：交互类相关属性和方法。[详情](https://github.com/antvis/S2/blob/master/packages/s2-core/src/interaction/root.ts)
 
 ```ts
-this.spreadsheet.interaction.xx()
+s2.interaction.xx()
 ```
 
 | 参数 | 说明 | 类型 |

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -5,6 +5,12 @@ order: 1
 
 功能描述：表格实例相关属性和方法。[详情](https://github.com/antvis/S2/blob/master/packages/s2-core/src/sheet-type/spread-sheet.ts)
 
+```ts
+const s2 = new PivotSheet()
+
+s2.xx()
+```
+
 | 参数 | 说明 | 类型 |
 | --- | --- | --- |
 | dom | 挂载的容器节点 | `string` \| `HTMLElement` |

--- a/s2-site/docs/api/basic-class/store.zh.md
+++ b/s2-site/docs/api/basic-class/store.zh.md
@@ -6,8 +6,8 @@ order: 3
 功能描述：存储一些信息。[详情](https://github.com/antvis/S2/blob/master/packages/s2-core/src/common/store/index.ts)
 
 ```ts
-this.spreadsheet.store.get('key') // 获取
-this.spreadsheet.store.set('key', value) // 存储
+s2.store.get('key') // 获取
+s2.store.set('key', value) // 存储
 ```
 
 | 参数 | 说明                                   | 类型 |

--- a/s2-site/docs/api/general/S2Options.zh.md
+++ b/s2-site/docs/api/general/S2Options.zh.md
@@ -53,6 +53,8 @@ order: 1
 
 `markdown:docs/common/tooltip.zh.md`
 
+`markdown:docs/common/custom-tooltip.zh.md`
+
 ## Pagination
 
 boolean ｜ object **必选**,_default: null_ 功能描述： 分页配置

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -13,7 +13,7 @@ object **必选**,_default：null_ 功能描述： tooltip 显示配置
 | data      | [TooltipData](#tooltipdata)                                                 |       |        | tooltip 数据        |
 | cellInfos | `Record<string, any>`                                                       |       |        | 单元格信息          |
 | options   | [TooltipOptions](#tooltipoptions)                                           |       |        | tooltip 部分配置    |
-| content   | `React.ReactNode | string` \| `(cell, defaultTooltipShowOptions) => React.ReactNode | string` |       |        | 自定义 tooltip 内容 |
+| content   | `React.ReactNode | string` \| `(cell, defaultTooltipShowOptions: TooltipShowOptions) => React.ReactNode | string` |       |        | 自定义 tooltip 内容 |
 | event     | `Event`                                                                     |       |        | 当前事件 Event      |
 
 ### TooltipPosition

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -334,7 +334,7 @@ const s2Options = {
 
 继承 `BaseTooltip` 基类，可重写 `显示 (show)`, `隐藏 (hide)`, `销毁 (destroy)` 等方法，结合 `this.spreadsheet` 实例，来实现满足你业务的 `tooltip`, 也可以重写 `renderContent` 方法, 渲染你封装的任意组件
 
-- [查看 BaseTooltip 基类](https://github.com/antvis/S2/blob/master/packages/s2-core/src/ui/tooltip/index.ts#L23)
+- [查看 BaseTooltip 基类](/zh/docs/api/basic-class/base-tooltip)
 - [查看 React 示例](https://github.com/antvis/S2/blob/master/packages/s2-react/src/components/tooltip/custom-tooltip.tsx)
 - [查看 Vue 示例](https://codesandbox.io/s/compassionate-booth-hpm3rf?file=/src/App.vue)
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1320 

🔧 Chore

- [x] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

1. 增加角头交互, 兼容点击角头显示 自定义 tooltip 的场景, 角头由于没有选中和悬停的状态, 需要额外处理
2. tooltip 增加 `visible` 属性, 便捷的获取当前显示状态
3. 增加 `BaseTooltip` 基础类文档

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-05-10 at 16 27 50](https://user-images.githubusercontent.com/21015895/167584421-0f60663f-004a-400a-8ccb-ccfc5b605711.gif) | ![Kapture 2022-05-10 at 16 25 31](https://user-images.githubusercontent.com/21015895/167584076-d688be13-67a0-407a-8723-8df1e5e8bbb3.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
