### PR TITLE
feat: 当子维度不足2个时可隐藏小计节点

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-totals-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-totals-spec.ts
@@ -2,6 +2,8 @@ import { getContainer } from 'tests/util/helpers';
 import { assembleDataCfg, assembleOptions, TOTALS_OPTIONS } from 'tests/util';
 import { flatMap, merge } from 'lodash';
 import { PivotSheet } from '@/sheet-type';
+import { S2DataConfig, S2Options } from '@/common';
+import { Node } from '@/facet/layout/node';
 
 describe('Spreadsheet Totals Tests', () => {
   let spreadsheet: PivotSheet;
@@ -73,5 +75,57 @@ describe('Spreadsheet Totals Tests', () => {
 
     expect(totalNodes.filter((node) => node.isGrandTotals)).toHaveLength(0);
     expect(totalNodes).toHaveLength(4);
+  });
+
+  test('should not render sub total nodes when always=false', () => {
+    const anotherDataCfg = assembleDataCfg() as S2DataConfig;
+    /**
+     * 构建专用数据集
+     * 行头：浙江省下有多个城市、四川省下只有成都
+     * 列头：办公用品下有两个维度，家具下只有桌子
+     */
+    const filterCond = (item) =>
+      (item.province === '浙江省' || item.city === '成都市') &&
+      (item.type === '办公用品' || item.sub_type === '桌子');
+    anotherDataCfg.data = anotherDataCfg.data.filter(filterCond);
+    anotherDataCfg.totalData = anotherDataCfg.totalData.filter(filterCond);
+
+    spreadsheet.setDataCfg(anotherDataCfg);
+    spreadsheet.setOptions({
+      totals: merge({}, TOTALS_OPTIONS, {
+        row: {
+          showSubTotals: {
+            always: false,
+          },
+        },
+        col: {
+          showSubTotals: {
+            always: false,
+          },
+        },
+      } as S2Options['totals']),
+    });
+    spreadsheet.render();
+
+    const findSubTotalNode = (
+      nodes: Node[],
+      parentLabel: string,
+      subTotalDimension: string,
+    ) => {
+      return nodes.find(
+        (node) =>
+          node.parent.label === parentLabel &&
+          node.field === subTotalDimension &&
+          node.isSubTotals,
+      );
+    };
+
+    const { rowNodes, colNodes } = spreadsheet.facet.layoutResult;
+
+    // 当子维度只有一个时，不展示小计节点
+    expect(findSubTotalNode(rowNodes, '浙江省', 'city')).toBeDefined();
+    expect(findSubTotalNode(rowNodes, '四川省', 'city')).toBeUndefined();
+    expect(findSubTotalNode(colNodes, '家具', 'sub_type')).toBeUndefined();
+    expect(findSubTotalNode(colNodes, '办公用品', 'sub_type')).toBeDefined();
   });
 });

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -122,7 +122,12 @@ export interface Total {
   /** 是否显示总计 */
   showGrandTotals: boolean;
   /** 是否显示小计 */
-  showSubTotals: boolean;
+  showSubTotals:
+    | boolean
+    | {
+        /** 当子维度个数 <=1 时，仍然展示小计：默认 true */
+        always: boolean;
+      };
   // 前端计算总计
   calcTotals?: CalcTotals;
   // 前端计算小计

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -522,9 +522,11 @@ export abstract class SpreadSheet extends EE {
       includes(rows, dimension) ? 'row' : 'col',
       {},
     ) as Total;
-    const showSubTotals = totalConfig.showSubTotals
-      ? includes(totalConfig.subTotalsDimensions, dimension)
-      : false;
+    const showSubTotals =
+      totalConfig.showSubTotals &&
+      includes(totalConfig.subTotalsDimensions, dimension)
+        ? totalConfig.showSubTotals
+        : false;
     return {
       showSubTotals,
       showGrandTotals: totalConfig.showGrandTotals,

--- a/packages/s2-core/src/utils/layout/add-totals.ts
+++ b/packages/s2-core/src/utils/layout/add-totals.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { TotalParams } from '@/facet/layout/interface';
 import { TotalClass } from '@/facet/layout/total-class';
 import { EXTRA_FIELD } from '@/common/constant';
@@ -16,7 +17,17 @@ export const addTotals = (params: TotalParams) => {
       action = totalsConfig.reverseLayout ? 'unshift' : 'push';
       totalValue = new TotalClass(totalsConfig.label, false, true);
     }
-  } else if (totalsConfig?.showSubTotals && currentField !== EXTRA_FIELD) {
+  } else if (
+    /**
+     * 是否需要展示小计项
+     * 1. showSubTotals 属性为真
+     * 2. 子维度个数 > 1 或 showSubTotals.always 不为 false（undefined 认为是 true）
+     */
+    totalsConfig?.showSubTotals &&
+    (_.size(fieldValues) > 1 ||
+      _.get(totalsConfig, 'showSubTotals.always') !== false) &&
+    currentField !== EXTRA_FIELD
+  ) {
     action = totalsConfig.reverseSubLayout ? 'unshift' : 'push';
     totalValue = new TotalClass(totalsConfig.subLabel, true);
   }

--- a/s2-site/docs/common/totals.zh.md
+++ b/s2-site/docs/common/totals.zh.md
@@ -19,7 +19,7 @@ object **必选**,_default：null_ 功能描述： 小计总计配置
 | 参数                | 说明                     | 类型         | 默认值  | 必选  |
 | ------------------- | ------------------------ | ------------ | ------- | :---: |
 | showGrandTotals     | 是否显示总计             | `boolean`    | `false` |   ✓   |
-| showSubTotals       | 是否显示小计             | `boolean`    | `false` |   ✓   |
+| showSubTotals       | 是否显示小计。当配置为对象时，always 控制是否在子维度不足 2 个时始终展示小计，默认始终展示             | `boolean | { always: boolean }`    | `false` |   ✓   |
 | subTotalsDimensions | 小计的汇总维度           | `string[]`   | `[]`    |   ✓   |
 | reverseLayout       | 总计布局位置，默认下或右 | `boolean`    | `false` |   ✓   |
 | reverseSubLayout    | 小计布局位置，默认下或右 | `boolean`    | `false` |   ✓   |

--- a/s2-site/docs/manual/basic/totals.zh.md
+++ b/s2-site/docs/manual/basic/totals.zh.md
@@ -69,7 +69,7 @@ object **必选**,_default：null_ 功能描述： 小计总计算配置
 | 参数                | 说明                     | 类型         | 默认值 | 必选 |
 | ------------------- | ------------------------ | ------------ | ------ | ---- |
 | showGrandTotals     | 是否显示总计             | `boolean`    | false  | ✓    |
-| showSubTotals       | 是否显示小计             | `boolean`    | false  | ✓    |
+| showSubTotals       | 是否显示小计。当配置为对象时，always 控制是否在子维度不足 2 个时始终展示小计，默认始终展示。             | `boolean | { always: boolean }`    | false  | ✓    |
 | subTotalsDimensions | 小计的汇总维度           | `string[]`   | []     | ✓    |
 | reverseLayout       | 总计布局位置，默认下或右 | `boolean`    | false  | ✓    |
 | reverseSubLayout    | 小计布局位置，默认下或右 | `boolean`    | false  | ✓    |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

在 #1086 里，全量放开了小计的展示，不在根据子维度个数做判断 `size(fieldValues) > 1`。
实际场景中，还是有少量用户需要控制做更简洁的展示。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-05-11 at 16 47 03@2x](https://user-images.githubusercontent.com/6716092/167809164-7cb8910a-a721-450e-9495-637b3559490e.png)      |    ![CleanShot 2022-05-11 at 16 47 50@2x](https://user-images.githubusercontent.com/6716092/167809305-c832bb4c-7196-4fbc-94c5-2ef3126685f2.png)   |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
