### PR TITLE
fix: 仅配置列头总计时却渲染了行/列头所有总计

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1337-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1337-spec.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * @description spec for issue #1337
+ * https://github.com/antvis/S2/issues/1337
+ * Row with only value field should not render total node
+ */
+import { getContainer } from 'tests/util/helpers';
+import { assembleDataCfg, assembleOptions } from 'tests/util';
+import { PivotSheet } from '@/sheet-type';
+
+describe('Totals Tests', () => {
+  let spreadsheet: PivotSheet;
+  const dataCfg = assembleDataCfg({
+    fields: {
+      rows: [],
+      columns: ['type', 'sub_type'],
+      values: ['number'],
+      valueInCols: false,
+    },
+  });
+
+  beforeEach(() => {
+    spreadsheet = new PivotSheet(getContainer(), dataCfg, assembleOptions());
+  });
+
+  test('should render total nodes correctly', () => {
+    spreadsheet.setOptions({
+      totals: {
+        col: {
+          showGrandTotals: true,
+        },
+      },
+    });
+    spreadsheet.render();
+
+    // 行总计节点
+    const rowTotalNodes = spreadsheet.facet.layoutResult.rowNodes.filter(
+      (node) => node.isTotals,
+    );
+    expect(rowTotalNodes).toHaveLength(0);
+
+    // 列总计节点
+    const columnTotalNodes = spreadsheet.facet.layoutResult.colNodes.filter(
+      (node) => node.isTotals,
+    );
+    expect(columnTotalNodes).toHaveLength(1);
+  });
+});

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -516,7 +516,8 @@ export abstract class SpreadSheet extends EE {
    */
   public getTotalsConfig(dimension: string): Partial<Totals['row']> {
     const { totals } = this.options;
-    const { rows } = this.dataCfg.fields;
+    const { rows } = this.dataSet.fields;
+
     const totalConfig = get(
       totals,
       includes(rows, dimension) ? 'row' : 'col',


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #1337 

🔧 Chore

- [x] Test case

### 📝 Description

当 fields 按如下配置（无行头，所有数值充当 row）
```
{
  columns: ["type"],
  values: ["price", "cost"],
  valueInCols: false
}
```
且开启 col 的总计时
```
{
  totals: {
    col: {
      showGrandTotals: true
    }
  }
}
```
row 的总计也渲染了，期望的是只展示 col 的总计


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|  <img width="628" alt="CleanShot 2022-05-16 at 09 54 38@2x" src="https://user-images.githubusercontent.com/6716092/168507031-effb6e1a-c5da-4cab-a5c2-a7471e2fab3e.png">      |   <img width="626" alt="CleanShot 2022-05-16 at 09 55 34@2x" src="https://user-images.githubusercontent.com/6716092/168507094-bffbe339-0618-4789-aea7-b9d935624610.png">  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
