### PR TITLE
fix(interaction): 修复默认隐藏列的配置更新为空数组时, 未触发表格更新

### DIFF
--- a/.github/ISSUE_TEMPLATE/ask-for-question.md
+++ b/.github/ISSUE_TEMPLATE/ask-for-question.md
@@ -5,7 +5,6 @@ title: '🤔'
 labels: ❔question
 ---
 
-
 ### 🖋 Description
 
 ### 😊 Expected Behavior

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,11 +7,19 @@ title: '🐛'
 ### 🏷 Version
 
 <!-- Required! -->
+<!-- eg. `1.16.0` 🙅🏻‍♀️🚫 `latest`, `1.x` -->
 
 | Package      | Version |
 | -------------- | --------- |
 | @antv/s2       | -         |
 | @antv/s2-react | -         |
+
+### Sheet Type
+
+- [ ] PivotSheet
+- [ ] TableSheet
+- [ ] GridAnalysisSheet
+- [ ] StrategySheet
 
 ### 🖋 Description
 
@@ -19,9 +27,12 @@ title: '🐛'
 
 ### ⌨️ Code Snapshots
 
+<!-- Required! -->
 <!-- eg. `s2Options` and `s2DataCfg`, or `<SheetComponent {...} />` -->
 
 ### 🔗 Reproduce Link
+
+<!-- eg. use S2 code sandbox template https://codesandbox.io/s/29zle -->
 
 ### 🤔 Steps to Reproduce
 

--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -236,6 +236,38 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       );
     });
 
+    test('should not rerender after hidden empty column fields if disable force render', () => {
+      const defaultHiddenColumnsDetail = [null];
+      pivotSheet.store.set('hiddenColumnsDetail', defaultHiddenColumnsDetail);
+
+      const renderSpy = jest
+        .spyOn(pivotSheet, 'render')
+        .mockImplementationOnce(() => {});
+
+      pivotSheet.interaction.hideColumns([], false);
+
+      const hiddenColumnsDetail = pivotSheet.store.get('hiddenColumnsDetail');
+
+      expect(renderSpy).not.toHaveBeenCalled();
+      expect(hiddenColumnsDetail).toEqual(defaultHiddenColumnsDetail);
+    });
+
+    test('should rerender after hidden empty column fields if enable force render', () => {
+      const defaultHiddenColumnsDetail = [null];
+      pivotSheet.store.set('hiddenColumnsDetail', defaultHiddenColumnsDetail);
+
+      const renderSpy = jest
+        .spyOn(pivotSheet, 'render')
+        .mockImplementationOnce(() => {});
+
+      pivotSheet.interaction.hideColumns([], true);
+
+      const hiddenColumnsDetail = pivotSheet.store.get('hiddenColumnsDetail');
+
+      expect(renderSpy).toHaveBeenCalledTimes(1);
+      expect(hiddenColumnsDetail).toEqual([]);
+    });
+
     test('should default hidden columns by interaction hiddenColumnFields config', () => {
       const hiddenColumns = [typePriceColumnId];
       const sheet = new PivotSheet(getContainer(), pivotDataCfg, {
@@ -245,6 +277,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
         },
       });
       sheet.render();
+
       const hiddenColumnsDetail = sheet.store.get('hiddenColumnsDetail', []);
       const [priceDetail] = hiddenColumnsDetail;
       expect(sheet.options.interaction.hiddenColumnFields).toEqual(

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -22,6 +22,13 @@ import { customMerge, getSafetyDataConfig } from '@/utils';
 import { BaseTooltip } from '@/ui/tooltip';
 import { CornerCell } from '@/cell/corner-cell';
 
+jest.mock('@/utils/hide-columns');
+
+import { hideColumnsByThunkGroup } from '@/utils/hide-columns';
+
+const mockHideColumnsByThunkGroup =
+  hideColumnsByThunkGroup as jest.Mock<PivotSheet>;
+
 const originalDataCfg = cloneDeep(dataCfg);
 
 describe('PivotSheet Tests', () => {
@@ -599,6 +606,25 @@ describe('PivotSheet Tests', () => {
 
   test('should get value is in columns', () => {
     expect(s2.isValueInCols()).toBeTruthy();
+  });
+
+  test('should rebuild hidden columns detail by status', () => {
+    // 重新更新, 但是没有隐藏列信息
+    s2.render(false, { reBuildHiddenColumnsDetail: true });
+
+    expect(mockHideColumnsByThunkGroup).toHaveBeenCalledTimes(0);
+
+    s2.store.set('hiddenColumnsDetail', [null]);
+
+    // 重新更新, 有隐藏列信息, 但是 reBuildHiddenColumnsDetail 为 false
+    s2.render(false, { reBuildHiddenColumnsDetail: false });
+
+    expect(mockHideColumnsByThunkGroup).toHaveBeenCalledTimes(0);
+
+    // 重新更新, 有隐藏列信息, 且 reBuildHiddenColumnsDetail 为 true
+    s2.render(false, { reBuildHiddenColumnsDetail: true });
+
+    expect(mockHideColumnsByThunkGroup).toHaveBeenCalledTimes(1);
   });
 
   test('should clear drill down data', () => {

--- a/packages/s2-core/__tests__/unit/utils/hide-columns-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/hide-columns-spec.ts
@@ -202,6 +202,21 @@ describe('hide-columns test', () => {
     expect(mockSpreadSheetInstance.render).not.toHaveBeenCalled();
   });
 
+  test('should clear hidden columns detail and options if hidden column fields isEmpty and enable force update', () => {
+    mockSpreadSheetInstance.store.set('hiddenColumnsDetail', [null]);
+
+    hideColumns(mockSpreadSheetInstance, [], true);
+
+    expect(mockSpreadSheetInstance.render).toHaveReturnedTimes(1);
+    expect(mockSpreadSheetInstance.interaction.reset).toHaveBeenCalledTimes(1);
+    expect(mockSpreadSheetInstance.store.get('hiddenColumnsDetail')).toEqual(
+      [],
+    );
+    expect(
+      mockSpreadSheetInstance.options.interaction.hiddenColumnFields,
+    ).toEqual([]);
+  });
+
   test('should hidden columns correct', () => {
     hideColumns(mockSpreadSheetInstance, ['3']);
 
@@ -318,6 +333,21 @@ describe('hide-columns test', () => {
     hideColumnsByThunkGroup(mockSpreadSheetInstance, []);
 
     expect(mockSpreadSheetInstance.render).not.toHaveBeenCalled();
+  });
+
+  test('should clear hidden group columns detail and options if hidden column fields isEmpty and enable force update', () => {
+    mockSpreadSheetInstance.store.set('hiddenColumnsDetail', [null]);
+
+    hideColumnsByThunkGroup(mockSpreadSheetInstance, [], true);
+
+    expect(mockSpreadSheetInstance.render).toHaveReturnedTimes(1);
+    expect(mockSpreadSheetInstance.interaction.reset).toHaveBeenCalledTimes(1);
+    expect(mockSpreadSheetInstance.store.get('hiddenColumnsDetail')).toEqual(
+      [],
+    );
+    expect(
+      mockSpreadSheetInstance.options.interaction.hiddenColumnFields,
+    ).toEqual([]);
   });
 
   describe('Valid Display Sibling Node Tests', () => {

--- a/packages/s2-core/__tests__/unit/utils/text-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/text-spec.ts
@@ -7,6 +7,8 @@ import {
   getEmptyPlaceholder,
 } from '@/utils/text';
 
+const isHD = window.devicePixelRatio >= 2;
+
 describe('Text Utils Tests', () => {
   const font = {
     fontFamily: 'Roboto',
@@ -74,14 +76,7 @@ describe('Text Utils Tests', () => {
 
   test('should get correct text width', () => {
     const width = measureTextWidth('test', font);
-    // 如果没改逻辑，16不要改，本地挂了也别改，机器分辨率不同，以 github ci 结果为准
-    expect(Math.floor(width)).toEqual(16);
-  });
-
-  test('should get correct text width roughly', () => {
-    const width = measureTextWidth('test', font);
-    // 同上
-    expect(Math.floor(width)).toEqual(16);
+    expect(Math.floor(width)).toEqual(isHD ? 21 : 16);
   });
 
   test('should get correct ellipsis text inner', () => {

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -129,3 +129,8 @@ export interface S2Options<T = Element | string>
   // custom data set
   readonly dataSet?: (spreadsheet: SpreadSheet) => BaseDataSet;
 }
+
+export interface S2RenderOptions {
+  reBuildDataSet?: boolean;
+  reBuildHiddenColumnsDetail?: boolean;
+}

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -201,6 +201,6 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     });
     this.spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
     this.spreadsheet.interaction.reset();
-    this.spreadsheet.render(false);
+    this.spreadsheet.render(false, false, false);
   }
 }

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -201,6 +201,6 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     });
     this.spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
     this.spreadsheet.interaction.reset();
-    this.spreadsheet.render(false, false, false);
+    this.spreadsheet.render(false);
   }
 }

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -343,8 +343,8 @@ export class RootInteraction {
     unmergeCell(this.spreadsheet, removedCells);
   };
 
-  public hideColumns(hiddenColumnFields: string[] = []) {
-    hideColumnsByThunkGroup(this.spreadsheet, hiddenColumnFields, true);
+  public hideColumns(hiddenColumnFields: string[] = [], forceRender = true) {
+    hideColumnsByThunkGroup(this.spreadsheet, hiddenColumnFields, forceRender);
   }
 
   private getDefaultInteractions() {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -8,7 +8,6 @@ import {
   isEmpty,
   isFunction,
   isString,
-  once,
 } from 'lodash';
 import { hideColumnsByThunkGroup } from '@/utils/hide-columns';
 import { BaseCell } from '@/cell';
@@ -336,7 +335,11 @@ export abstract class SpreadSheet extends EE {
     this.registerIcons();
   }
 
-  public render(reloadData = true, reBuildDataSet = false) {
+  public render(
+    reloadData = true,
+    reBuildDataSet = false,
+    reBuildHiddenColumnsDetail = true,
+  ) {
     this.emit(S2Event.LAYOUT_BEFORE_RENDER);
     if (reBuildDataSet) {
       this.dataSet = this.getDataSet(this.options);
@@ -346,7 +349,9 @@ export abstract class SpreadSheet extends EE {
       this.dataSet.setDataCfg(this.dataCfg);
     }
     this.buildFacet();
-    this.initHiddenColumnsDetail();
+    if (reBuildHiddenColumnsDetail) {
+      this.initHiddenColumnsDetail();
+    }
     this.emit(S2Event.LAYOUT_AFTER_RENDER);
   }
 
@@ -599,13 +604,15 @@ export abstract class SpreadSheet extends EE {
   }
 
   // 初次渲染时, 如果配置了隐藏列, 则生成一次相关配置信息
-  private initHiddenColumnsDetail = once(() => {
+  private initHiddenColumnsDetail = () => {
     const { hiddenColumnFields } = this.options.interaction;
-    if (isEmpty(hiddenColumnFields)) {
+    const lastHiddenColumnsDetail = this.store.get('hiddenColumnsDetail');
+    // 隐藏列为空, 并且没有操作的情况下, 不需要再往下走
+    if (isEmpty(hiddenColumnFields) && isEmpty(lastHiddenColumnsDetail)) {
       return;
     }
     hideColumnsByThunkGroup(this, hiddenColumnFields, true);
-  });
+  };
 
   private clearCanvasEvent() {
     const canvasEvents = this.getEvents();

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -33,6 +33,7 @@ import {
   S2DataConfig,
   S2MountContainer,
   S2Options,
+  S2RenderOptions,
   SpreadSheetFacetCfg,
   ThemeCfg,
   TooltipContentType,
@@ -335,11 +336,9 @@ export abstract class SpreadSheet extends EE {
     this.registerIcons();
   }
 
-  public render(
-    reloadData = true,
-    reBuildDataSet = false,
-    reBuildHiddenColumnsDetail = true,
-  ) {
+  public render(reloadData = true, options: S2RenderOptions = {}) {
+    const { reBuildDataSet = false, reBuildHiddenColumnsDetail = true } =
+      options;
     this.emit(S2Event.LAYOUT_BEFORE_RENDER);
     if (reBuildDataSet) {
       this.dataSet = this.getDataSet(this.options);
@@ -607,7 +606,7 @@ export abstract class SpreadSheet extends EE {
   private initHiddenColumnsDetail = () => {
     const { hiddenColumnFields } = this.options.interaction;
     const lastHiddenColumnsDetail = this.store.get('hiddenColumnsDetail');
-    // 隐藏列为空, 并且没有操作的情况下, 不需要再往下走
+    // 隐藏列为空, 并且没有操作的情况下, 则无需生成
     if (isEmpty(hiddenColumnFields) && isEmpty(lastHiddenColumnsDetail)) {
       return;
     }

--- a/packages/s2-core/src/utils/hide-columns.ts
+++ b/packages/s2-core/src/utils/hide-columns.ts
@@ -105,6 +105,25 @@ export const hideColumns = (
   selectedColumnFields: string[] = [],
   forceRender = false,
 ) => {
+  const renderByHiddenColumns = (
+    hiddenColumnFields: string[] = [],
+    hiddenColumnsDetail: HiddenColumnsInfo[] = [],
+  ) => {
+    spreadsheet.setOptions({
+      interaction: {
+        hiddenColumnFields,
+      },
+    });
+    spreadsheet.interaction.reset();
+    spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
+    spreadsheet.render(false, false, false);
+  };
+
+  if (isEmpty(selectedColumnFields) && forceRender) {
+    renderByHiddenColumns();
+    return;
+  }
+
   const lastHiddenColumnDetail = spreadsheet.store.get(
     'hiddenColumnsDetail',
     [],
@@ -120,11 +139,6 @@ export const hideColumns = (
     ...selectedColumnFields,
     ...lastHiddenColumnFields,
   ]);
-  spreadsheet.setOptions({
-    interaction: {
-      hiddenColumnFields,
-    },
-  });
 
   const displaySiblingNode = getHiddenColumnDisplaySiblingNode(
     spreadsheet,
@@ -146,9 +160,8 @@ export const hideColumns = (
     currentHiddenColumnsInfo,
     hiddenColumnsDetail,
   );
-  spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
-  spreadsheet.interaction.reset();
-  spreadsheet.render(false);
+
+  renderByHiddenColumns(hiddenColumnFields, hiddenColumnsDetail);
 };
 
 /**
@@ -168,12 +181,20 @@ export const getColumns = (spreadsheet: SpreadSheet) => {
 /**
  * @name 根据分组隐藏指定列
  * @description 根据配置的隐藏列自动分组, 批量隐藏
+ * @param spreadsheet
+ * @param hiddenColumnFields 隐藏的列头字段
+ * @param forceRender 隐藏的列头字段为空时, 是否强制更新
  */
 export const hideColumnsByThunkGroup = (
   spreadsheet: SpreadSheet,
   hiddenColumnFields: string[] = [],
   forceRender = false,
 ) => {
+  // 隐藏列为空时, 有可能是隐藏后又展开 ( [] => ['A'] => []), 所以需要更新一次, 将渲染的展开icon, 隐藏列信息等清空
+  if (isEmpty(hiddenColumnFields) && forceRender) {
+    hideColumns(spreadsheet, hiddenColumnFields, true);
+  }
+
   const columns = getColumns(spreadsheet);
   const hiddenColumnsGroup = getHiddenColumnsThunkGroup(
     columns,

--- a/packages/s2-core/src/utils/hide-columns.ts
+++ b/packages/s2-core/src/utils/hide-columns.ts
@@ -116,7 +116,7 @@ export const hideColumns = (
     });
     spreadsheet.interaction.reset();
     spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
-    spreadsheet.render(false, false, false);
+    spreadsheet.render(false, { reBuildHiddenColumnsDetail: false });
   };
 
   if (isEmpty(selectedColumnFields) && forceRender) {

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -31,10 +31,10 @@ import {
   DataType,
   generatePalette,
   getPalette,
-  InterceptType,
 } from '@antv/s2';
 import corePkg from '@antv/s2/package.json';
 import { debounce, forEach, random } from 'lodash';
+import { useUpdateEffect } from 'ahooks';
 import { customTreeFields } from '../__tests__/data/custom-tree-fields';
 import { dataCustomTrees } from '../__tests__/data/data-custom-trees';
 import { mockGridAnalysisDataCfg } from '../__tests__/data/grid-analysis-data';
@@ -253,7 +253,7 @@ function MainLayout() {
     });
   }, [sheetType]);
 
-  React.useEffect(() => {
+  useUpdateEffect(() => {
     switch (sheetType) {
       case 'table':
         setDataCfg(tableSheetDataCfg);

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -30,13 +30,6 @@ export const BaseSheet = React.forwardRef(
       }
     }, [ref, s2Ref]);
 
-    // 默认隐藏列
-    React.useEffect(() => {
-      s2Ref.current?.interaction.hideColumns(
-        options.interaction?.hiddenColumnFields,
-      );
-    }, [options.interaction?.hiddenColumnFields, s2Ref]);
-
     return (
       <React.StrictMode>
         <Spin spinning={loading} wrapperClassName={`${S2_PREFIX_CLS}-spin`}>

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -2,7 +2,6 @@ import { isEmpty } from 'lodash';
 import React from 'react';
 import { SpreadSheet, getTooltipOptions } from '@antv/s2';
 import { useLatest } from 'ahooks';
-import { useMemo } from 'react';
 import { BaseSheet } from '../base-sheet';
 import { DrillDown } from '@/components/drill-down';
 import { SheetComponentsProps } from '@/components/sheets/interface';
@@ -50,7 +49,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
     );
 
     /** 基于 props.options 来构造新的 options 传递给 base-sheet */
-    const options = useMemo(() => {
+    const options = React.useMemo(() => {
       return buildDrillDownOptions(pivotOptions, partDrillDown, (params) =>
         onDrillDownIconClick.current(params),
       );

--- a/packages/s2-react/src/components/sheets/table-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/table-sheet/index.tsx
@@ -5,14 +5,7 @@ import { SheetComponentsProps } from '@/components/sheets/interface';
 
 export const TableSheet: React.FC<SheetComponentsProps> = React.memo(
   (props) => {
-    const { options } = props;
     const s2Ref = React.useRef<SpreadSheet>();
-
-    React.useEffect(() => {
-      s2Ref.current?.interaction.hideColumns(
-        options.interaction?.hiddenColumnFields,
-      );
-    }, [options.interaction?.hiddenColumnFields, s2Ref]);
 
     return <BaseSheet {...props} ref={s2Ref} />;
   },

--- a/packages/s2-react/src/components/switcher/header.tsx
+++ b/packages/s2-react/src/components/switcher/header.tsx
@@ -1,5 +1,6 @@
-import React, { FC, useEffect, useState } from 'react';
+import React from 'react';
 import { S2DataConfig, S2Options, SpreadSheet } from '@antv/s2';
+import { useUpdateEffect } from 'ahooks';
 import {
   generateSheetConfig,
   generateSwitcherFields,
@@ -30,13 +31,13 @@ export interface SwitcherHeaderProps extends SwitcherBasicCfg {
   options: S2Options;
 }
 
-export const SwitcherHeader: FC<SwitcherHeaderProps> = ({
+export const SwitcherHeader: React.FC<SwitcherHeaderProps> = ({
   sheet,
   dataCfg,
   options,
   ...props
 }) => {
-  const [fields, setFields] = useState(() =>
+  const [fields, setFields] = React.useState(() =>
     generateSwitcherFields(
       sheet,
       dataCfg,
@@ -44,7 +45,7 @@ export const SwitcherHeader: FC<SwitcherHeaderProps> = ({
     ),
   );
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     setFields(
       generateSwitcherFields(
         sheet,
@@ -52,22 +53,24 @@ export const SwitcherHeader: FC<SwitcherHeaderProps> = ({
         options?.interaction?.hiddenColumnFields,
       ),
     );
-  }, [
-    sheet,
-    JSON.stringify(dataCfg?.fields),
-    JSON.stringify(dataCfg?.meta),
-    JSON.stringify(options?.interaction?.hiddenColumnFields),
-  ]);
+  }, [sheet, dataCfg, options?.interaction?.hiddenColumnFields]);
 
   const onSubmit = (result: SwitcherResult) => {
-    const { fields, hiddenColumnFields } = generateSheetConfig(sheet, result);
+    const { fields: currentFields, hiddenColumnFields } = generateSheetConfig(
+      sheet,
+      result,
+    );
+
     sheet.setDataCfg({
-      fields: { ...sheet.dataCfg.fields, ...fields },
+      fields: { ...sheet.dataCfg.fields, ...currentFields },
     } as S2DataConfig);
+
     if (hiddenColumnFields) {
       sheet.setOptions({ interaction: { hiddenColumnFields } });
     }
+
     sheet.render();
+
     setFields(
       generateSwitcherFieldsCfgFromResult(
         sheet,

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -131,10 +131,9 @@ export function useSpreadSheet(
       reBuildDataSet,
     });
 
-    s2Ref.current?.render(
-      renderOptions.reloadData,
-      renderOptions.reBuildDataSet,
-    );
+    s2Ref.current?.render(renderOptions.reloadData, {
+      reBuildDataSet: renderOptions.reBuildDataSet,
+    });
   }, [dataCfg, options, themeCfg, onSheetUpdate]);
 
   useResize({

--- a/s2-site/docs/api/basic-class/interaction.zh.md
+++ b/s2-site/docs/api/basic-class/interaction.zh.md
@@ -27,7 +27,7 @@ s2.interaction.xx()
 | isEqualStateName | 是否是相同的状态名 | `(name: InteractionStateName) => void` |
 | isSelectedState | 是否是选中状态 | `() => void` |
 | isHoverState | 是否是悬停状态 | `() => void` |
-| isHoverFocusState | 是否是悬停聚焦状态 （悬停在单元格 `focusTime`: 默认800ms 后） | `() => void` |
+| isHoverFocusState | 是否是悬停聚焦状态 （悬停在单元格 `focusTime`: 默认 800ms 后） | `() => void` |
 | isSelectedCell | 是否是选中的单元格 | `(cell: S2CellType) => void` |
 | isActiveCell | 是否是激活的单元格 | `(cell: S2CellType) => void` |
 | getCells | 获取当前 interaction 记录的 Cells 元信息列表，包括不在视口内的格子 | `() => Partial<ViewMeta>[]` |
@@ -42,7 +42,7 @@ s2.interaction.xx()
 | selectAll | 选中所有单元格 | `() => void` |
 | selectHeaderCell | 选中指定行列头单元格 | `(selectHeaderCellInfo: SelectHeaderCellInfo) => boolean` |
 | getCellLeafNodes | 获取当前单元格的叶子节点 | `(cell: S2CellType[]) => Node[]` |
-| hideColumns | 隐藏列 | `(hiddenColumnFields: string[]) => void` |
+| hideColumns | 隐藏列 (forceRender 为 `false` 时，隐藏列为空的情况下，不再触发表格更新） | `(hiddenColumnFields: string[], forceRender?: boolean = true) => void` |
 | mergeCells | 合并单元格 | `(cellsInfo?: MergedCellInfo[], hideData?: boolean) => void` |
 | unmergeCells | 取消合并单元格 | `(removedCells: MergedCell) => void` |
 | updatePanelGroupAllDataCells | 更新所有数值单元格 | `() => void` |

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -51,7 +51,7 @@ s2.xx()
 | registerIcons | 注册 自定义 svg 图标 （根据 `options.customSVGIcons`) | `() => void` |
 | setDataCfg | 更新数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig) ) => void |
 | setOptions | 更新表格配置 | (options: [S2Options](/zh/docs/api/general/S2Options)) => void |
-| render | 重新渲染表格，如果 reloadData = true, 则会重新计算数据 | `(reloadData: boolean) => void` |
+| render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据, `reBuildDataSet` = true, 重新构建数据集, `reBuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean, { reBuildDataSet?: boolean; reBuildHiddenColumnsDetail?: boolean }) => void` |
 | destroy | 销毁表格 | `() => void` |
 | setThemeCfg | 更新主题配置 | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme)) => void |
 | updatePagination | 更新分页 | (pagination: [Pagination](/zh/docs/api/general/S2Options#pagination)) => void |

--- a/s2-site/docs/manual/advanced/interaction/hide-columns.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/hide-columns.zh.md
@@ -3,13 +3,13 @@ title: 隐藏列头
 order: 2
 ---
 
-当你想降低不重要信息干扰时，可以隐藏列头，方便你更直观的查看数据，有两种方式隐藏列头
+当你想降低不重要信息干扰时，可以隐藏列头，方便你更直观的查看数据，有三种方式隐藏列头
 
 <playground path='interaction/advanced/demo/pivot-hide-columns.ts' rid='pivot-hide-columns' height='400'></playground>
 
-## 手动隐藏 - 通过点击
+## 1. 手动隐藏 - 通过点击
 
-点击列头，弹出 tooltip, 点击 `隐藏` 按钮即可
+点击列头在弹出的 `tooltip` 里, 点击 `隐藏` 按钮即可
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/pBa8%24Q1gG/15a1cdef-a4b1-4fcf-a2cf-b6f4a39f710b.png" width="400" alt="preview" />
 
@@ -25,7 +25,7 @@ const s2Options = {
 }
 ```
 
-## 自动隐藏 - 通过配置
+## 2. 自动隐藏 - 通过配置
 
 可配置默认隐藏的列头，透视表和明细表
 
@@ -114,12 +114,23 @@ const s2Options = {
 
 <img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*a0uHRZ70hDcAAAAAAAAAAAAAARQnAQ" height="300" alt="preview" />
 
-## 事件监听
+## 3. 手动隐藏 - 通过实例方法
+
+[查看所有API](/zh/docs/api/basic-class/interaction)
+
+```ts
+const s2 = new PivotSheet(...)
+
+const hiddenColumnFields = ['province', 'type', 'price']
+s2.interaction.hideColumns(hiddenColumnFields)
+```
+
+## 获取隐藏列头数据
 
 可通过 `S2Event` 透出的 `LAYOUT_COLS_EXPANDED` 和 `LAYOUT_COLS_HIDDEN` 分别监听列头的展开和隐藏
 
 ```ts
-const s2 = new PivotSheet(container, dataCfg, s2Options);
+const s2 = new PivotSheet(...);
 
 s2.on(S2Event.LAYOUT_COLS_EXPANDED, (cell) => {
   console.log('列头展开', cell);
@@ -131,4 +142,11 @@ s2.on(
     console.log('列头隐藏', currentHiddenColumnsInfo, hiddenColumnsDetail);
   },
 );
+```
+
+也可以访问存储在 [`store`](/zh/docs/api/basic-class/store) 的 `hiddenColumnsDetail` 主动获取
+
+```ts
+const hiddenColumnsDetail = s2.store.get('hiddenColumnsDetail')
+console.log(hiddenColumnsDetail)
 ```

--- a/s2-site/docs/manual/basic/sheet-type/table-mode.zh.md
+++ b/s2-site/docs/manual/basic/sheet-type/table-mode.zh.md
@@ -77,9 +77,9 @@ const s2Options = {
 // 4, 渲染
 ReactDOM.render(
   <SheetComponent
+    sheetType="table"
     dataCfg={s2DataCfg}
     options={s2Options}
-    sheetType={"table"}
   />,
   document.getElementById('container')
 );
@@ -93,19 +93,19 @@ ReactDOM.render(
 import { TableSheet } from "@antv/s2";
 
 const container = document.getElementById('container');
-const sheet = new TableSheet(container, dataCfg, options);
-sheet.render();
+const tableSheet = new TableSheet(container, dataCfg, options);
+tableSheet.render();
 ```
 
 ## 特性
 
 ### 序号
 
-在 `s2Options` 中传入 `showSeriesNumber` 即可展示内置的序号。
+在 `s2Options` 中传入 `showSeriesNumber` 即可展示内置的序号。[查看 demo](https://s2.antv.vision/zh/examples/basic/table#table)
 
 ### 行列冻结
 
-行列冻结让特定行列在滚动时保持固定，从而一直保持在视口范围内，提供信息的对照和参考。
+行列冻结让特定行列在滚动时保持固定，从而一直保持在视口范围内，提供信息的对照和参考。[查看 demo](https://s2.antv.vision/zh/examples/interaction/basic#frozen)
 
 行列冻结通过在 `s2Options` 中传入这些属性控制：
 
@@ -121,3 +121,5 @@ sheet.render();
 效果如图：
 
 <img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*tZkOSqYWVFQAAAAAAAAAAAAAARQnAQ" width="600" alt="preview" />
+
+<playground path='interaction/basic/demo/frozen.ts' rid='container' height='300'></playground>


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

比如: 先隐藏 `A`, 再展开 `A`, `hiddenColumnFields` 为空时也应该重新渲染, 清空上一次渲染的展开icon 和 详情信息

```ts
sheet.setOptions({
  interaction: {
    hiddenColumnFields: ['A']
  }
})

sheet.setOptions({
  interaction: {
    hiddenColumnFields: []
  }
})
```

其他:

1. 去除 React 层多余的一次更新
2. 去掉 `Switcher` 组件的 `JSON.stringify` 比较

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-05-18 at 17 51 44](https://user-images.githubusercontent.com/21015895/169011805-63a3fef6-d843-4bf3-8d03-c50f9dc57fa8.gif) | ![Kapture 2022-05-18 at 17 48 33](https://user-images.githubusercontent.com/21015895/169011116-7a613567-d348-4d19-b705-0b6bc0abf9e8.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
