### PR TITLE
feat: 丰富tooltip关闭的验证逻辑

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -532,7 +532,9 @@ describe('Interaction Event Controller Tests', () => {
     );
     cTooltipChild.innerHTML = '我是”弹出层“元素';
     cTooltipParent.appendChild(cTooltipChild);
+    document.body.appendChild(cTooltipParent);
 
+    spreadsheet.tooltip.visible = true;
     spreadsheet.tooltip.container = cTooltipParent;
     spreadsheet.tooltip.container.getBoundingClientRect = () =>
       ({
@@ -546,6 +548,7 @@ describe('Interaction Event Controller Tests', () => {
       new MouseEvent('click', {
         clientX: 233,
         clientY: 233,
+        bubbles: true,
       } as MouseEventInit),
     );
 

--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -514,6 +514,45 @@ describe('Interaction Event Controller Tests', () => {
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
+  test('should not reset if current mouse not on the tooltip container but on the tooltip children container', () => {
+    const reset = jest.fn();
+    spreadsheet.on(S2Event.GLOBAL_RESET, reset);
+
+    // https://github.com/antvis/S2/pull/1352
+    const cTooltipParent = document.createElement('div');
+    const cTooltipChild = document.createElement('div');
+    cTooltipParent.setAttribute(
+      'style',
+      'position: relative; width: 200px; height: 200px;',
+    );
+    cTooltipParent.innerHTML = '创建一个div 模拟tooltip装载了一个”弹出层“元素';
+    cTooltipChild.setAttribute(
+      'style',
+      'position: absolute; top: 0; left: 0; width: 300px; height: 300px;',
+    );
+    cTooltipChild.innerHTML = '我是”弹出层“元素';
+    cTooltipParent.appendChild(cTooltipChild);
+
+    spreadsheet.tooltip.container = cTooltipParent;
+    spreadsheet.tooltip.container.getBoundingClientRect = () =>
+      ({
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      } as DOMRect);
+
+    cTooltipChild.dispatchEvent(
+      new MouseEvent('click', {
+        clientX: 233,
+        clientY: 233,
+      } as MouseEventInit),
+    );
+
+    expect(reset).not.toHaveBeenCalled();
+    expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
+  });
+
   // https://github.com/antvis/S2/issues/363
   test('should reset if current mouse outside the canvas container and disable tooltip', () => {
     const reset = jest.fn();

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -18,7 +18,7 @@ import { EmitterType } from '@/common/interface/emitter';
 import { ResizeInfo } from '@/common/interface';
 import { SpreadSheet } from '@/sheet-type';
 import { getSelectedData, keyEqualTo } from '@/utils/export/copy';
-import { getTooltipOptions } from '@/utils/tooltip';
+import { getTooltipOptions, verifyTheElementInTooltip } from '@/utils/tooltip';
 
 interface EventListener {
   target: EventTarget;
@@ -210,6 +210,12 @@ export class EventController {
     const { x, y, width, height } =
       this.spreadsheet.tooltip?.container?.getBoundingClientRect?.() || {};
 
+    if (event.target instanceof Node && this.spreadsheet.tooltip.visible) {
+      return verifyTheElementInTooltip(
+        this.spreadsheet.tooltip?.container,
+        event.target,
+      );
+    }
     if (event instanceof MouseEvent) {
       return (
         event.clientX >= x &&

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -575,3 +575,19 @@ export const getTooltipVisibleOperator = (
     menus: compact([...defaultMenus, ...displayMenus]),
   };
 };
+
+export const verifyTheElementInTooltip = (
+  parent: HTMLElement,
+  child: Node,
+): boolean => {
+  let result = false;
+  let currentNode: Node = child;
+  while (currentNode !== document.body) {
+    if (parent === currentNode) {
+      result = true;
+      break;
+    }
+    currentNode = currentNode.parentElement;
+  }
+  return result;
+};

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -150,7 +150,7 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({ name: 'default' });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
-  const [showCustomTooltip, setShowCustomTooltip] = React.useState(true);
+  const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
     React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -13,6 +13,7 @@ import {
   Collapse,
   Tag,
   Tabs,
+  DatePicker,
 } from 'antd';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -134,6 +135,7 @@ const CustomTooltip = () => (
   <div>
     自定义 Tooltip <div>1</div>
     <div>2</div>
+    <DatePicker.RangePicker getPopupContainer={(t) => t.parentElement} />
   </div>
 );
 
@@ -148,7 +150,7 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({ name: 'default' });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
-  const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
+  const [showCustomTooltip, setShowCustomTooltip] = React.useState(true);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
     React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
当前场景：tooltip模块关闭逻辑，只会通过鼠标位置进行验证。

不满足的场景：**tooltip包含弹出层的场景**。比如：日期选择器这种类型，在操作日期选择器模块的时候，因为鼠标并不能保证一定会在tooltip区域，所以就会触发关闭逻辑。

增强：在`tooltip.visible`为`true`且事件元素为`Node`为的情况下，进行节点匹配，只要是tooltip模块下的元素都不会触发tooltip关闭逻辑
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
