### PR TITLE
fix: 下钻数据没有按照用户数据展示

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/layout/build-row-tree-hierarchy-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/build-row-tree-hierarchy-spec.ts
@@ -1,0 +1,67 @@
+import { sortData } from 'tests/data/sort-advanced';
+import { getContainer } from 'tests/util/helpers';
+import { PivotSheet } from '@/sheet-type';
+import { EXTRA_FIELD, S2DataConfig, S2Options } from '@/common';
+
+const s2Options: S2Options = {
+  width: 400,
+  height: 400,
+  hierarchyType: 'tree',
+};
+describe('build row tree hierarchy', () => {
+  // https://stackblitz.com/edit/react-ts-aj2r8w?file=data.ts
+  test('should get order hierarchy when order is group ascend', () => {
+    const s2DataConfig: S2DataConfig = {
+      ...sortData,
+      // 城市根据纸张价格进行组内升序
+      sortParams: [
+        {
+          sortFieldId: 'city',
+          sortByMeasure: 'price',
+          sortMethod: 'asc',
+          query: {
+            type: '纸张',
+            [EXTRA_FIELD]: 'price',
+          },
+        },
+      ],
+    };
+    const s2 = new PivotSheet(getContainer(), s2DataConfig, s2Options);
+    s2.render();
+    const rowLeafNodes = s2.facet.layoutResult.rowLeafNodes;
+    expect(rowLeafNodes.length).toBe(6);
+    expect(rowLeafNodes[0].label).toEqual('浙江');
+    expect(rowLeafNodes[1].label).toEqual('杭州');
+    expect(rowLeafNodes[2].label).toEqual('舟山');
+    expect(rowLeafNodes[3].label).toEqual('吉林');
+    expect(rowLeafNodes[4].label).toEqual('丹东');
+    expect(rowLeafNodes[5].label).toEqual('白山');
+  });
+  test('should get order hierarchy when order is group desc', () => {
+    const s2DataConfig: S2DataConfig = {
+      ...sortData,
+      // 城市根据笔价格进行组内升序
+      sortParams: [
+        {
+          sortFieldId: 'city',
+          sortByMeasure: 'price',
+          sortMethod: 'desc',
+          query: {
+            type: '笔',
+            [EXTRA_FIELD]: 'price',
+          },
+        },
+      ],
+    };
+    const s2 = new PivotSheet(getContainer(), s2DataConfig, s2Options);
+    s2.render();
+    const rowLeafNodes = s2.facet.layoutResult.rowLeafNodes;
+    expect(rowLeafNodes.length).toBe(6);
+    expect(rowLeafNodes[0].label).toEqual('浙江');
+    expect(rowLeafNodes[1].label).toEqual('舟山');
+    expect(rowLeafNodes[2].label).toEqual('杭州');
+    expect(rowLeafNodes[3].label).toEqual('吉林');
+    expect(rowLeafNodes[4].label).toEqual('丹东');
+    expect(rowLeafNodes[5].label).toEqual('白山');
+  });
+});

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -40,12 +40,15 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
   const isDrillDownItem = spreadsheet.dataCfg.fields.rows?.length <= level;
   const sortedDimensionValues =
     (dataSet as PivotDataSet)?.sortedDimensionValues?.[currentField] || [];
+
+  // 为第一个子层级时，parentNode.id === ROOT_ID 时，不需要通过分割获取当前节点的真实 value
   const dimensions =
     ROOT_ID === id
       ? sortedDimensionValues
       : sortedDimensionValues?.filter((item) =>
           item?.includes(id?.split(`${ROOT_ID}${ID_SEPARATOR}`)[1]),
         );
+
   const dimValues = filterUndefined(
     getListBySorted(
       [...(pivotMeta.keys() || [])],

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -9,6 +9,7 @@ import { SpreadSheet } from '@/sheet-type';
 import { getListBySorted, filterUndefined } from '@/utils/data-set-operate';
 import { getDimensionsWithoutPathPre } from '@/utils/dataset/pivot-data-set';
 import { PivotDataSet } from '@/data-set';
+import { ID_SEPARATOR, ROOT_ID } from '@/common';
 
 const addTotals = (
   spreadsheet: SpreadSheet,
@@ -39,11 +40,16 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
   const isDrillDownItem = spreadsheet.dataCfg.fields.rows?.length <= level;
   const sortedDimensionValues =
     (dataSet as PivotDataSet)?.sortedDimensionValues?.[currentField] || [];
-
+  const dimensions =
+    ROOT_ID === id
+      ? sortedDimensionValues
+      : sortedDimensionValues?.filter((item) =>
+          item?.includes(id?.split(`${ROOT_ID}${ID_SEPARATOR}`)[1]),
+        );
   const dimValues = filterUndefined(
     getListBySorted(
       [...(pivotMeta.keys() || [])],
-      [...getDimensionsWithoutPathPre([...sortedDimensionValues])],
+      [...getDimensionsWithoutPathPre([...dimensions])],
     ),
   );
 

--- a/packages/s2-react/__tests__/data/mock-drill-down-dataset.json
+++ b/packages/s2-react/__tests__/data/mock-drill-down-dataset.json
@@ -32,5 +32,201 @@
       "type": "办公用品",
       "sub_type": "纸张"
     }
+  ],
+  "HZDrillDownData": [
+    {
+      "number": 11,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "西湖区",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "number": 22,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "西湖区",
+      "type": "家具",
+      "sub_type": "沙发"
+    },
+    {
+      "number": 33,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "西湖区",
+      "type": "办公用品",
+      "sub_type": "笔"
+    },
+    {
+      "number": 44,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "西湖区",
+      "type": "办公用品",
+      "sub_type": "纸张"
+    },
+    {
+      "number": 111,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "下沙区",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "number": 222,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "下沙区",
+      "type": "家具",
+      "sub_type": "沙发"
+    },
+    {
+      "number": 333,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "下沙区",
+      "type": "办公用品",
+      "sub_type": "笔"
+    },
+    {
+      "number": 444,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "下沙区",
+      "type": "办公用品",
+      "sub_type": "纸张"
+    },
+    {
+      "number": 100,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "余杭区",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "number": 200,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "余杭区",
+      "type": "家具",
+      "sub_type": "沙发"
+    },
+    {
+      "number": 300,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "余杭区",
+      "type": "办公用品",
+      "sub_type": "笔"
+    },
+    {
+      "number": 400,
+      "province": "浙江省",
+      "city": "杭州市",
+      "district": "余杭区",
+      "type": "办公用品",
+      "sub_type": "纸张"
+    }
+  ],
+  "SXDrillDownData": [
+    {
+      "number": 111,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "下沙区",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "number": 222,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "下沙区",
+      "type": "家具",
+      "sub_type": "沙发"
+    },
+    {
+      "number": 333,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "下沙区",
+      "type": "办公用品",
+      "sub_type": "笔"
+    },
+    {
+      "number": 444,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "下沙区",
+      "type": "办公用品",
+      "sub_type": "纸张"
+    },
+    {
+      "number": 100,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "余杭区",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "number": 200,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "余杭区",
+      "type": "家具",
+      "sub_type": "沙发"
+    },
+    {
+      "number": 300,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "余杭区",
+      "type": "办公用品",
+      "sub_type": "笔"
+    },
+    {
+      "number": 400,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "余杭区",
+      "type": "办公用品",
+      "sub_type": "纸张"
+    },
+    {
+      "number": 11,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "西湖区",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "number": 22,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "西湖区",
+      "type": "家具",
+      "sub_type": "沙发"
+    },
+    {
+      "number": 33,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "西湖区",
+      "type": "办公用品",
+      "sub_type": "笔"
+    },
+    {
+      "number": 44,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "district": "西湖区",
+      "type": "办公用品",
+      "sub_type": "纸张"
+    }
   ]
 }

--- a/packages/s2-react/__tests__/unit/utils/drill-down-spec.ts
+++ b/packages/s2-react/__tests__/unit/utils/drill-down-spec.ts
@@ -9,7 +9,11 @@ import {
 } from '@antv/s2';
 import { sleep, getContainer } from '../../util/helpers';
 import { data as originData } from '../../data/mock-dataset.json';
-import { data as drillDownData } from '../../data/mock-drill-down-dataset.json';
+import {
+  data as drillDownData,
+  HZDrillDownData,
+  SXDrillDownData,
+} from '../../data/mock-drill-down-dataset.json';
 import {
   handleActionIconClick,
   handleDrillDown,
@@ -141,5 +145,65 @@ describe('Drill Down Test', () => {
     );
     expect(drillDownDataCache).not.toBeEmpty();
     expect(drillDownCurrentCache).toEqual(mockDrillDownDataCache);
+  });
+
+  test('should order drill down items by drillConfig.fetchData', async () => {
+    // 测试第二次下钻的数据，按照第一次下钻的顺序排序的问题。 https://github.com/antvis/S2/pull/1353
+    // 准备数据
+    const mockFetchData = () =>
+      new Promise<PartDrillDownInfo>((resolve) => {
+        resolve({
+          drillField: 'district',
+          drillData: HZDrillDownData,
+        });
+      });
+
+    mockInstance.store.set('drillDownNode', cityNode);
+    const drillDownCfg = {
+      rows: mockDataCfg.fields.rows,
+      drillFields: ['district'],
+      fetchData: mockFetchData,
+      spreadsheet: mockInstance,
+    };
+
+    // 执行测试
+    handleDrillDown(drillDownCfg);
+    await sleep(1000);
+    const rowLeftNodes = mockInstance.facet.layoutResult.rowLeafNodes;
+
+    expect(rowLeftNodes).toHaveLength(13);
+    expect(rowLeftNodes[1].label).toEqual('杭州市');
+    expect(rowLeftNodes[2].label).toEqual('西湖区');
+    expect(rowLeftNodes[3].label).toEqual('下沙区');
+    expect(rowLeftNodes[4].label).toEqual('余杭区');
+
+    // 准备数据
+    const SXCityNode = new Node({
+      id: `root[&]浙江省[&]绍兴市`,
+      key: '',
+      value: '',
+      field: 'city',
+      parent: provinceNode,
+    });
+    mockInstance.store.set('drillDownNode', SXCityNode);
+    drillDownCfg.fetchData = () =>
+      new Promise<PartDrillDownInfo>((resolve) => {
+        resolve({
+          drillField: 'district',
+          drillData: SXDrillDownData,
+        });
+      });
+
+    // 执行操作
+    handleDrillDown(drillDownCfg);
+    await sleep(1000);
+    const secondDrillDownRowLeftNodes =
+      mockInstance.facet.layoutResult.rowLeafNodes;
+
+    expect(secondDrillDownRowLeftNodes).toHaveLength(16);
+    expect(secondDrillDownRowLeftNodes[5].label).toEqual('绍兴市');
+    expect(secondDrillDownRowLeftNodes[6].label).toEqual('下沙区');
+    expect(secondDrillDownRowLeftNodes[7].label).toEqual('余杭区');
+    expect(secondDrillDownRowLeftNodes[8].label).toEqual('西湖区');
   });
 });

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -86,7 +86,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
     }, [drillFields]);
 
     React.useEffect(() => {
-      if (isEmpty(partDrillDown?.clearDrillDown)) {
+      if (typeof partDrillDown?.clearDrillDown !== 'object') {
         return;
       }
       clearDrillDownInfo(partDrillDown?.clearDrillDown?.rowId);

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, isObject } from 'lodash';
 import React from 'react';
 import { SpreadSheet, getTooltipOptions } from '@antv/s2';
 import { useLatest } from 'ahooks';
@@ -86,7 +86,7 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
     }, [drillFields]);
 
     React.useEffect(() => {
-      if (typeof partDrillDown?.clearDrillDown !== 'object') {
+      if (!isObject(partDrillDown?.clearDrillDown)) {
         return;
       }
       clearDrillDownInfo(partDrillDown?.clearDrillDown?.rowId);

--- a/s2-site/docs/api/components/drill-down.zh.md
+++ b/s2-site/docs/api/components/drill-down.zh.md
@@ -34,10 +34,10 @@ order: 2
 
 <description>功能描述：下钻数据请求参数配置</description>
 
-| 参数       | 说明              | 类型            | 必选  | 默认值 |
-| --- | --- | --- | --- | ---  |
-| drillData | 下钻的数据 |  <code class="language-text">Record<string, string \| number> </code> | ✓ |   |
-| drillField | 下钻维度 value 值 | `string` | ✓ |  |
+| 参数       | 说明              | 类型            | 必选                | 默认值 |
+| --- | --- | --- |-------------------| ---  |
+| drillData | 下钻的数据 |  <code class="language-text">Record<string, string \| number>[] </code> | ✓ |   |
+| drillField | 下钻维度 value 值 | `string` | ✓                 |  |
 
 ### DrillDownProps
 

--- a/s2-site/examples/custom/custom-cell/demo/col-cell.ts
+++ b/s2-site/examples/custom/custom-cell/demo/col-cell.ts
@@ -1,6 +1,6 @@
 import { PivotSheet, ColCell } from '@antv/s2';
 
-// 自定义角头单元格，实现特有功能
+// 自定义列头单元格，实现特有功能
 class CustomColCell extends ColCell {
   // 覆盖背景绘制，可覆盖或者增加绘制方法
   drawBackgroundShape() {

--- a/s2-site/examples/custom/custom-cell/demo/row-cell.ts
+++ b/s2-site/examples/custom/custom-cell/demo/row-cell.ts
@@ -1,6 +1,6 @@
 import { PivotSheet, RowCell } from '@antv/s2';
 
-// 自定义角头单元格，实现特有功能
+// 自定义行头单元格，实现特有功能
 class CustomRowCell extends RowCell {
   // 覆盖背景绘制，可覆盖或者增加绘制方法
   drawBackgroundShape() {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #0
[1. fix: clearDrillDown 无法全量清空的问题。 - 用户传入 clearDrillDown = {} 无法全量清空下钻](https://github.com/antvis/S2/commit/48baee30c8f4bef0a8841a1256e20884096b6e8a)
[2. fix: 树状结构下多层级排序失效的问题](https://github.com/antvis/S2/commit/834c99b388683ddb8269ae172c1286f41e6f7641)
🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|<img width="580" alt="image" src="https://user-images.githubusercontent.com/20497176/169036062-cfecc605-b090-4f57-b1b3-61a1760a869c.png"> | <img width="456" alt="image" src="https://user-images.githubusercontent.com/20497176/169036359-3e7c437c-7a86-45f4-bd81-b187befc0933.png">|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
