### PR TITLE
feat(theme): 新增度量值的主题配置, 修复小计总计主题配置不生效 close #1357

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
@@ -1,20 +1,20 @@
-import { getContainer } from 'tests/util/helpers';
-import { assembleDataCfg, assembleOptions } from 'tests/util';
+/* eslint-disable jest/expect-expect */
+import { createPivotSheet } from 'tests/util/helpers';
 import { get } from 'lodash';
 import { ShapeAttrs } from '@antv/g-canvas';
+import { S2DataConfig } from './../../esm/common/interface/s2DataConfig.d';
+import { TextTheme } from '@/common/interface/theme';
 import { PivotSheet } from '@/sheet-type';
-import { CellTypes, TextAlign } from '@/common';
+import { CellTypes, EXTRA_FIELD, TextAlign } from '@/common';
 import { RowCell } from '@/cell';
+import { Node } from '@/facet/layout/node';
 
 describe('SpreadSheet Theme Tests', () => {
   let s2: PivotSheet;
-  const dataCfg = assembleDataCfg();
 
   beforeAll(() => {
-    s2 = new PivotSheet(
-      getContainer(),
-      dataCfg,
-      assembleOptions({
+    s2 = createPivotSheet(
+      {
         headerActionIcons: [
           {
             iconNames: ['DrillDownIcon'],
@@ -23,8 +23,11 @@ describe('SpreadSheet Theme Tests', () => {
             action: () => {},
           },
         ],
-      }),
+      },
+      { useSimpleData: false },
     );
+
+    s2.render();
   });
 
   afterAll(() => {
@@ -134,5 +137,196 @@ describe('SpreadSheet Theme Tests', () => {
         );
       },
     );
+  });
+
+  describe('Measure Fields Theme Tests', () => {
+    const expectTextAlign = (options: {
+      textAlign: TextAlign;
+      fontWight: TextTheme['fontWeight'];
+      containsDataCells?: boolean;
+      customNodes?: Node[];
+    }) => {
+      const {
+        textAlign,
+        fontWight,
+        containsDataCells = false,
+        customNodes,
+      } = options;
+      const targetNodes = customNodes || s2.getColumnLeafNodes();
+      const dataCells = s2.interaction.getPanelGroupAllDataCells();
+
+      expect(targetNodes).not.toHaveLength(0);
+
+      if (!containsDataCells) {
+        expect(
+          targetNodes.every((node) => {
+            const nodeTextShape = node.belongsCell.getTextShape();
+            return (
+              nodeTextShape.attr('textAlign') === textAlign &&
+              nodeTextShape.attr('fontWeight') === fontWight
+            );
+          }),
+        ).toBeTruthy();
+        return;
+      }
+
+      targetNodes.forEach((node) => {
+        const nodeTextShape = node.belongsCell.getTextShape();
+        const isEqualTextAlign = dataCells.every((cell) => {
+          return (
+            cell.getTextShape().attr('textAlign') ===
+            nodeTextShape.attr('textAlign')
+          );
+        });
+        expect(isEqualTextAlign).toBeTruthy();
+        expect(nodeTextShape.attr('fontWeight')).toStrictEqual(fontWight);
+      });
+      expect(dataCells[0].getTextShape().attr('textAlign')).toEqual(textAlign);
+    };
+
+    it('should default align column headers with data cells', () => {
+      expectTextAlign({
+        textAlign: 'right',
+        fontWight: 'normal',
+        containsDataCells: true,
+      });
+    });
+
+    it('should render normal font wight and left text align text with row cells', () => {
+      s2.setDataCfg({
+        fields: {
+          valueInCols: false,
+        },
+      } as S2DataConfig);
+
+      s2.render();
+
+      const rowMeasureFields = s2
+        .getRowNodes()
+        .filter((node) => node.field === EXTRA_FIELD);
+
+      expectTextAlign({
+        textAlign: 'left',
+        fontWight: 'normal',
+        containsDataCells: false,
+        customNodes: rowMeasureFields,
+      });
+    });
+
+    it('should render normal font wight and left text align text with col cell', () => {
+      s2.setDataCfg({
+        fields: {
+          valueInCols: true,
+        },
+      } as S2DataConfig);
+
+      s2.render();
+
+      const colMeasureFields = s2
+        .getColumnNodes()
+        .filter((node) => node.field === EXTRA_FIELD);
+
+      expectTextAlign({
+        textAlign: 'right',
+        fontWight: 'normal',
+        containsDataCells: false,
+        customNodes: colMeasureFields,
+      });
+    });
+
+    it.each(['left', 'center', 'right'] as TextAlign[])(
+      'should render %s text align for column nodes',
+      (textAlign) => {
+        s2.setThemeCfg({
+          theme: {
+            colCell: {
+              measureText: {
+                textAlign,
+              },
+            },
+          },
+        });
+
+        s2.render(true);
+
+        expectTextAlign({ textAlign, fontWight: 'normal' });
+      },
+    );
+
+    it.each([
+      { isRowCell: true, textAlign: 'left' },
+      { isRowCell: true, textAlign: 'center' },
+      { isRowCell: true, textAlign: 'right' },
+      { isRowCell: false, textAlign: 'left' },
+      { isRowCell: false, textAlign: 'center' },
+      { isRowCell: false, textAlign: 'right' },
+    ] as Array<{ isRowCell: boolean; textAlign: TextAlign }>)(
+      'should render %s text align for totals nodes',
+      ({ isRowCell, textAlign }) => {
+        s2.setOptions({
+          totals: {
+            col: {
+              showGrandTotals: true,
+              showSubTotals: true,
+              reverseLayout: true,
+              reverseSubLayout: false,
+            },
+            row: {
+              showGrandTotals: true,
+              showSubTotals: true,
+              reverseLayout: true,
+              reverseSubLayout: false,
+            },
+          },
+        });
+
+        s2.setThemeCfg({
+          theme: {
+            colCell: {
+              // 小计/总计是加粗字体
+              bolderText: {
+                textAlign,
+              },
+            },
+            rowCell: {
+              bolderText: {
+                textAlign,
+              },
+            },
+          },
+        });
+
+        s2.render();
+
+        const rowTotalNodes = s2.getRowNodes().filter((node) => node.isTotals);
+
+        const colTotalNodes = s2
+          .getColumnNodes()
+          .filter((node) => node.isTotals);
+
+        expectTextAlign({
+          textAlign,
+          fontWight: 520,
+          customNodes: isRowCell ? rowTotalNodes : colTotalNodes,
+        });
+      },
+    );
+
+    it('should not align column headers with data cells and render normal font wight leaf node text if hideMeasureColumn', () => {
+      s2.setOptions({
+        style: {
+          colCfg: {
+            hideMeasureColumn: true,
+          },
+        },
+        totals: null,
+      });
+      s2.render();
+
+      expectTextAlign({
+        textAlign: 'center',
+        fontWight: 'normal',
+      });
+    });
   });
 });

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -306,4 +306,8 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     updateShapeAttr(this.textShape, SHAPE_STYLE_MAP.textOpacity, 1);
     updateShapeAttr(this.linkFieldShape, SHAPE_STYLE_MAP.opacity, 1);
   }
+
+  public getTextShape() {
+    return this.textShape;
+  }
 }

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -15,8 +15,6 @@ import {
   CellBorderPosition,
   DefaultCellTheme,
   IconTheme,
-  TextAlign,
-  TextBaseline,
   TextTheme,
 } from '@/common/interface';
 import { AreaRange } from '@/common/interface/scroll';
@@ -26,7 +24,7 @@ import {
   getTextAndFollowingIconPosition,
   getTextAreaRange,
   adjustColHeaderScrollingViewport,
-  adjustColHeaderScrollingTextPostion,
+  adjustColHeaderScrollingTextPosition,
 } from '@/utils/cell/cell';
 import { renderIcon, renderLine, renderRect } from '@/utils/g-renders';
 import { isLastColumnAfterHidden } from '@/utils/hide-columns';
@@ -88,29 +86,19 @@ export class ColCell extends HeaderCell {
     );
   }
 
-  private getOriginalTextStyle(): TextTheme {
-    const { isLeaf, isTotals } = this.meta;
-    const { text, bolderText } = this.getStyle();
-    return isLeaf && !isTotals ? text : bolderText;
-  }
-
   protected getTextStyle(): TextTheme {
-    const { isLeaf } = this.meta;
-    const textStyle = this.getOriginalTextStyle();
-    const hideMeasureColumn =
-      this.spreadsheet.options.style.colCfg.hideMeasureColumn;
-    let textAlign: TextAlign;
-    let textBaseline: TextBaseline;
-    if (isLeaf && !hideMeasureColumn) {
-      textAlign = this.theme.dataCell.text.textAlign;
-      textBaseline = this.theme.dataCell.text.textBaseline;
-    } else {
-      // 为方便 getTextAreaRange 计算文字位置
-      // textAlign 固定为 center
-      textAlign = 'center';
-      textBaseline = 'middle';
+    const { isLeaf, isTotals } = this.meta;
+    const { text, bolderText, measureText } = this.getStyle();
+
+    if (this.isMeasureField()) {
+      return measureText || bolderText;
     }
-    return { ...textStyle, textAlign, textBaseline };
+
+    if (isTotals || !isLeaf) {
+      return bolderText;
+    }
+
+    return text;
   }
 
   protected getMaxTextWidth(): number {
@@ -121,9 +109,11 @@ export class ColCell extends HeaderCell {
   protected getIconPosition(): Point {
     const { isLeaf } = this.meta;
     const iconStyle = this.getIconStyle();
+
     if (isLeaf) {
       return super.getIconPosition(this.getActionIconsCount());
     }
+
     const position = this.textAreaPosition;
 
     const totalSpace =
@@ -131,6 +121,7 @@ export class ColCell extends HeaderCell {
       this.getActionIconsWidth() -
       iconStyle.margin.right;
     const startX = position.x - totalSpace / 2;
+
     return {
       x: startX + this.actualTextWidth + iconStyle.margin.left,
       y: position.y - iconStyle.size / 2,
@@ -175,7 +166,7 @@ export class ColCell extends HeaderCell {
       width: width + (scrollContainsRowHeader ? cornerWidth : 0),
     };
 
-    const { textAlign } = this.getOriginalTextStyle();
+    const { textAlign } = this.getTextStyle();
     const adjustedViewport = adjustColHeaderScrollingViewport(
       viewport,
       textAlign,
@@ -196,7 +187,7 @@ export class ColCell extends HeaderCell {
 
     // textAreaRange.start 是以文字样式为 center 计算出的文字绘制点
     // 此处按实际样式(left or right)调整
-    const startX = adjustColHeaderScrollingTextPostion(
+    const startX = adjustColHeaderScrollingTextPosition(
       textAreaRange.start,
       textAreaRange.width - textAndIconSpace,
       textAlign,

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -91,7 +91,7 @@ export class ColCell extends HeaderCell {
     const { text, bolderText, measureText } = this.getStyle();
 
     if (this.isMeasureField()) {
-      return measureText || bolderText;
+      return measureText || text;
     }
 
     if (isTotals || !isLeaf) {

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -13,11 +13,10 @@ import {
 import { BaseHeaderConfig } from '@/facet/header/base';
 import { Node } from '@/facet/layout/node';
 import { includeCell } from '@/utils/cell/data-cell';
-import { S2Event } from '@/common/constant';
+import { EXTRA_FIELD, S2Event } from '@/common/constant';
 import { CellTypes } from '@/common/constant';
 import { getSortTypeIcon } from '@/utils/sort-action';
 import { SortParam } from '@/common/interface';
-import { TableColCell } from '@/cell/table-col-cell';
 
 export abstract class HeaderCell extends BaseCell<Node> {
   protected headerConfig: BaseHeaderConfig;
@@ -299,5 +298,9 @@ export abstract class HeaderCell extends BaseCell<Node> {
 
   public hideInteractionShape() {
     super.hideInteractionShape();
+  }
+
+  public isMeasureField() {
+    return this.meta.field === EXTRA_FIELD;
   }
 }

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -362,7 +362,7 @@ export class RowCell extends HeaderCell {
     const { text, bolderText, measureText } = this.getStyle();
 
     if (this.isMeasureField()) {
-      return measureText || bolderText;
+      return measureText || text;
     }
 
     if (this.isBolderText()) {

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -359,13 +359,17 @@ export class RowCell extends HeaderCell {
   }
 
   protected getTextStyle(): TextTheme {
-    const { text, bolderText } = this.getStyle();
-    const style = this.isBolderText() ? bolderText : text;
+    const { text, bolderText, measureText } = this.getStyle();
 
-    return {
-      ...style,
-      textBaseline: 'top',
-    };
+    if (this.isMeasureField()) {
+      return measureText || bolderText;
+    }
+
+    if (this.isBolderText()) {
+      return bolderText;
+    }
+
+    return text;
   }
 
   protected getIconPosition() {

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -213,6 +213,8 @@ export interface DefaultCellTheme extends GridAnalysisCellTheme {
   bolderText?: TextTheme;
   /* 文本样式 */
   text?: TextTheme;
+  /* 度量值文本样式 */
+  measureText?: TextTheme;
   /* 单元格样式 */
   cell?: CellTheme;
   /* 图标样式 */

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -452,7 +452,7 @@ export abstract class SpreadSheet extends EE {
   }
 
   public getRowLeafNodes(): Node[] {
-    return this.getRowNodes().filter((node) => node.isLeaf);
+    return this.facet.layoutResult.rowLeafNodes;
   }
 
   /**
@@ -468,7 +468,7 @@ export abstract class SpreadSheet extends EE {
   }
 
   public getColumnLeafNodes(): Node[] {
-    return this.getColumnNodes().filter((node) => node.isLeaf);
+    return this.facet.layoutResult.colLeafNodes;
   }
 
   /**

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -451,6 +451,10 @@ export abstract class SpreadSheet extends EE {
     );
   }
 
+  public getRowLeafNodes(): Node[] {
+    return this.getRowNodes().filter((node) => node.isLeaf);
+  }
+
   /**
    * get columnNode in levels,
    * @param level -1 = get all

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -452,7 +452,7 @@ export abstract class SpreadSheet extends EE {
   }
 
   public getRowLeafNodes(): Node[] {
-    return this.facet.layoutResult.rowLeafNodes;
+    return this.facet?.layoutResult.rowLeafNodes || [];
   }
 
   /**
@@ -468,7 +468,7 @@ export abstract class SpreadSheet extends EE {
   }
 
   public getColumnLeafNodes(): Node[] {
-    return this.facet.layoutResult.colLeafNodes;
+    return this.facet?.layoutResult.colLeafNodes || [];
   }
 
   /**

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -70,6 +70,16 @@ export const getTheme = (
       },
     },
     rowCell: {
+      measureText: {
+        fontFamily: FONT_FAMILY,
+        fontSize: 12,
+        fontWeight: 'normal',
+        fill: basicColors[14],
+        linkTextFill: basicColors[6],
+        opacity: 1,
+        textAlign: isTable ? 'center' : 'left',
+        textBaseline: 'top',
+      },
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
@@ -78,7 +88,7 @@ export const getTheme = (
         linkTextFill: basicColors[6],
         opacity: 1,
         textAlign: isTable ? 'center' : 'left',
-        textBaseline: 'middle',
+        textBaseline: 'top',
       },
       text: {
         fontFamily: FONT_FAMILY,
@@ -87,7 +97,7 @@ export const getTheme = (
         fill: basicColors[14],
         linkTextFill: basicColors[6],
         opacity: 1,
-        textBaseline: 'middle',
+        textBaseline: 'top',
         textAlign: isTable ? 'center' : 'left', // default align center for row cell in table mode
       },
       cell: {
@@ -150,6 +160,16 @@ export const getTheme = (
       seriesNumberWidth: 80,
     },
     colCell: {
+      measureText: {
+        fontFamily: FONT_FAMILY,
+        fontSize: 12,
+        fontWeight: isWindows() ? 'bold' : 520,
+        fill: basicColors[0],
+        opacity: 1,
+        // 默认数值字段和 dataCell 数值对齐
+        textAlign: 'right',
+        textBaseline: 'middle',
+      },
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -163,7 +163,7 @@ export const getTheme = (
       measureText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 520,
+        fontWeight: 'normal',
         fill: basicColors[0],
         opacity: 1,
         // 默认数值字段和 dataCell 数值对齐

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -382,7 +382,7 @@ export const adjustColHeaderScrollingViewport = (
  * @param textAlign
  * @returns
  */
-export const adjustColHeaderScrollingTextPostion = (
+export const adjustColHeaderScrollingTextPosition = (
   startX: number,
   restWidth: number,
   textAlign: TextAlign,

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -102,6 +102,14 @@ export const s2Options: S2Options = {
   interaction: {
     enableCopy: true,
   },
+  // totals: {
+  //   col: {
+  //     showGrandTotals: true,
+  //     showSubTotals: true,
+  //     reverseLayout: true,
+  //     reverseSubLayout: false,
+  //   },
+  // },
 };
 
 export const sliderOptions: SliderSingleProps = {

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -150,19 +150,6 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({
     name: 'default',
-    theme: {
-      colCell: {
-        // bolderText: {
-        //   textAlign: 'right',
-        // },
-        // text: {
-        //   textAlign: 'center',
-        // },
-        measureText: {
-          textAlign: 'right',
-        },
-      },
-    },
   });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -148,7 +148,22 @@ function MainLayout() {
   const [sheetType, setSheetType] = React.useState<SheetType>('pivot');
   const [showPagination, setShowPagination] = React.useState(false);
   const [showTotals, setShowTotals] = React.useState(false);
-  const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({ name: 'default' });
+  const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({
+    name: 'default',
+    theme: {
+      colCell: {
+        // bolderText: {
+        //   textAlign: 'right',
+        // },
+        // text: {
+        //   textAlign: 'center',
+        // },
+        measureText: {
+          textAlign: 'right',
+        },
+      },
+    },
+  });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -59,7 +59,9 @@ s2.xx()
 | changeSheetSize （别名：changeSize) | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |
 | getLayoutWidthType | 获取单元格宽度布局类型（LayoutWidthType: `adaptive（自适应）` \| `colAdaptive（列自适应）` \| `compact（紧凑）`） | () => `LayoutWidthType`|
 | getRowNodes | 获取行头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |
+| getRowLeafNodes | 获取行头叶子节点 | () => [Node[]](/zh/docs/api/basic-class/node/) |
 | getColumnNodes | 获取列头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |
+| getColumnLeafNodes | 获取列头叶子节点 | () => [Node[]](/zh/docs/api/basic-class/node/) |
 | updateScrollOffset | 更新滚动偏移 | (config: [OffsetConfig](#offsetconfig)) => void |
 | getCell | 根据 event.target 获取当前 单元格 | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [S2CellType](/zh/docs/api/basic-class/base-cell#s2celltype) |
 | getCellType | 根据 event.target 获取当前 单元格类型 | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [CellTypes](/zh/docs/api/basic-class/base-cell#celltypes) |

--- a/s2-site/docs/api/general/S2Theme.zh.md
+++ b/s2-site/docs/api/general/S2Theme.zh.md
@@ -58,6 +58,7 @@ order: 2
 | :---------------- | :----------- | :---------------------- | :----- | :--: |
 | bolderText        | 加粗文本样式 | [TextTheme](#texttheme) | -      |      |
 | text              | 文本样式     | [TextTheme](#texttheme) | -      |      |
+| measureText       | 度量值文本样式 | [TextTheme](#texttheme) | -      |      |
 | cell              | 单元格样式   | [CellTheme](#celltheme) | -      |      |
 | icon              | 图标样式     | [IconTheme](#icontheme) | -      |      |
 | seriesNumberWidth | 序号列宽     | `number`                | 80     |      |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 新增 measureText 度量值的文字主题配置, 由于有数值置于行头/列头, rowCell, colCell 都需要适配, 列头数值默认和 dataCell 对齐

> 之前是根据 `isLeaf` 和 `hideMeasureColumns`, 来判断

![image](https://user-images.githubusercontent.com/21015895/169789152-df92beaf-e069-4d6e-8b5f-3cb1aeab7bf1.png)

现在改为配置, 更加灵活, 而不是代码写死

```ts
   colCell: {
      measureText: {
        textAlign: s2.theme.dataCell.text.textAlign,
      },
    },
```

3. 去除 colCell 写死的配置
4. 修复小计/总计 主题配置不生效的问题
5. 修改 列头和数值对齐方式

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [X] Add or update relevant Docs.
- [X] Add or update relevant Demos.
- [X] Add or update relevant TypeScript definitions.
