### PR TITLE
fix(interaction): 修复自定义单元格有自定义图片时无法触发点击 close #1360

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -125,6 +125,7 @@ describe('Interaction Row Column Resize Tests', () => {
     s2.render = jest.fn();
     s2.tooltip.container = document.createElement('div');
     s2.hideTooltip = jest.fn();
+    s2.interaction.reset = jest.fn();
   });
 
   test('should register events', () => {
@@ -457,7 +458,7 @@ describe('Interaction Row Column Resize Tests', () => {
     });
   });
 
-  test('should hidden tooltip when resize start', () => {
+  test('should reset interaction and hidden tooltip when resize start', () => {
     const resizeInfo = {
       theme: {},
       type: ResizeDirectionType.Vertical,
@@ -478,6 +479,6 @@ describe('Interaction Row Column Resize Tests', () => {
       },
       resizeInfo,
     );
-    expect(s2.hideTooltip).toHaveBeenCalledTimes(1);
+    expect(s2.interaction.reset).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -6,6 +6,7 @@ import { omit, clone } from 'lodash';
 import { getIcon } from './factory';
 
 const STYLE_PLACEHOLDER = '<svg';
+
 // Image 缓存
 const ImageCache: Record<string, HTMLImageElement> = {};
 
@@ -17,8 +18,10 @@ export interface GuiIconCfg extends ShapeAttrs {
  * 使用 iconfont 上的 svg 来创建 Icon
  */
 export class GuiIcon extends Group {
+  static type = '__GUI_ICON__';
+
   // icon 对应的 GImage 对象
-  private image: Shape.Image;
+  public iconImageShape: Shape.Image;
 
   constructor(cfg: GuiIconCfg) {
     super(cfg);
@@ -85,8 +88,12 @@ export class GuiIcon extends Group {
   private render() {
     const { name, fill } = this.cfg;
     const attrs = clone(this.cfg);
+    const imageShapeAttrs: ShapeAttrs = {
+      ...omit(attrs, 'fill'),
+      type: GuiIcon.type,
+    };
     const image = new Shape.Image({
-      attrs: omit(attrs, 'fill'),
+      attrs: imageShapeAttrs,
     });
 
     const cacheKey = `${name}-${fill}`;
@@ -106,6 +113,6 @@ export class GuiIcon extends Group {
           console.warn(`GuiIcon ${name} load error`, err);
         });
     }
-    this.image = image;
+    this.iconImageShape = image;
   }
 }

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -3,11 +3,12 @@ import {
   Canvas,
   Event as CanvasEvent,
   LooseObject,
+  Shape,
 } from '@antv/g-canvas';
 import { each, get, isEmpty, isNil } from 'lodash';
+import { GuiIcon } from '../common';
 import {
   CellTypes,
-  IMAGE,
   InteractionKeyboardKey,
   InterceptType,
   OriginEventType,
@@ -123,9 +124,10 @@ export class EventController {
     );
   }
 
-  private getTargetType() {
-    return get(this, 'target.cfg.type');
-  }
+  // 不能单独判断是否 Image Shape, 用户如果自定义单元格绘制图片, 会导致判断错误
+  private isGuiIconShape = (target: LooseObject) => {
+    return target instanceof Shape.Image && target.attrs.type === GuiIcon.type;
+  };
 
   private onKeyboardCopy(event: KeyboardEvent) {
     // windows and macos copy
@@ -357,27 +359,28 @@ export class EventController {
     const cell = this.spreadsheet.getCell(event.target);
     if (cell) {
       const cellType = cell.cellType;
-      // target相同，说明是一个cell内的click事件
+      // target相同，说明是一个cell内的 click 事件
       if (this.target === event.target) {
+        const isGuiIconShape = this.isGuiIconShape(event.target);
         switch (cellType) {
           case CellTypes.DATA_CELL:
             this.spreadsheet.emit(S2Event.DATA_CELL_CLICK, event);
             break;
           case CellTypes.ROW_CELL:
-            // 屏蔽 actionIcons的点击，只有HeaderCells 需要， DataCell 有状态类 icon， 不需要屏蔽
-            if (this.getTargetType() === IMAGE) {
+            // 屏蔽 actionIcons 的点击，只有 HeaderCells 需要， DataCell 有状态类 icon， 不需要屏蔽
+            if (isGuiIconShape) {
               break;
             }
             this.spreadsheet.emit(S2Event.ROW_CELL_CLICK, event);
             break;
           case CellTypes.COL_CELL:
-            if (this.getTargetType() === IMAGE) {
+            if (isGuiIconShape) {
               break;
             }
             this.spreadsheet.emit(S2Event.COL_CELL_CLICK, event);
             break;
           case CellTypes.CORNER_CELL:
-            if (this.getTargetType() === IMAGE) {
+            if (isGuiIconShape) {
               break;
             }
             this.spreadsheet.emit(S2Event.CORNER_CELL_CLICK, event);

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -152,7 +152,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
       }
 
       // 鼠标在 resize 热区 按下时, 将 tooltip 关闭, 避免造成干扰
-      this.spreadsheet.hideTooltip();
+      this.spreadsheet.interaction.reset();
       this.spreadsheet.interaction.addIntercepts([InterceptType.RESIZE]);
       this.setResizeTarget(shape);
       this.showResizeGroup();
@@ -423,8 +423,16 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
 
     if (style) {
       this.spreadsheet.setOptions({ style });
-    } else {
-      this.spreadsheet.theme.rowCell.seriesNumberWidth = seriesNumberWidth;
+    }
+
+    if (seriesNumberWidth) {
+      this.spreadsheet.setThemeCfg({
+        theme: {
+          rowCell: {
+            seriesNumberWidth,
+          },
+        },
+      });
     }
 
     this.spreadsheet.store.set('resized', true);

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -95,18 +95,6 @@ export const pivotSheetDataCfg: S2DataConfig = {
   fields,
 };
 
-class CustomRowCell extends RowCell {
-  // 覆盖背景绘制，可覆盖或者增加绘制方法
-  drawBackgroundShape() {
-    this.backgroundShape = this.addShape('image', {
-      attrs: {
-        ...this.getCellArea(),
-        img: 'https://gw.alipayobjects.com/zos/antfincdn/og1XQOMyyj/1e3a8de1-3b42-405d-9f82-f92cb1c10413.png',
-      },
-    });
-  }
-}
-
 export const s2Options: S2Options = {
   debug: true,
   width: 600,
@@ -114,9 +102,6 @@ export const s2Options: S2Options = {
   hierarchyCollapse: false,
   interaction: {
     enableCopy: true,
-  },
-  rowCell: (node, s2, headConfig) => {
-    return new CustomRowCell(node, s2, headConfig);
   },
 };
 

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -1,6 +1,7 @@
 import {
   customMerge,
   isUpDataValue,
+  RowCell,
   S2DataConfig,
   S2Options,
   S2Theme,
@@ -94,6 +95,18 @@ export const pivotSheetDataCfg: S2DataConfig = {
   fields,
 };
 
+class CustomRowCell extends RowCell {
+  // 覆盖背景绘制，可覆盖或者增加绘制方法
+  drawBackgroundShape() {
+    this.backgroundShape = this.addShape('image', {
+      attrs: {
+        ...this.getCellArea(),
+        img: 'https://gw.alipayobjects.com/zos/antfincdn/og1XQOMyyj/1e3a8de1-3b42-405d-9f82-f92cb1c10413.png',
+      },
+    });
+  }
+}
+
 export const s2Options: S2Options = {
   debug: true,
   width: 600,
@@ -101,6 +114,9 @@ export const s2Options: S2Options = {
   hierarchyCollapse: false,
   interaction: {
     enableCopy: true,
+  },
+  rowCell: (node, s2, headConfig) => {
+    return new CustomRowCell(node, s2, headConfig);
   },
 };
 

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -811,6 +811,7 @@ function MainLayout() {
               }}
               onDataCellClick={logHandler('onDataCellClick')}
               onLayoutResizeMouseDown={logHandler('onLayoutResizeMouseDown')}
+              onLayoutResizeMouseUp={logHandler('onLayoutResizeMouseUp')}
               onCopied={logHandler('onCopied')}
               onLayoutColsHidden={logHandler('onLayoutColsHidden')}
               onLayoutColsExpanded={logHandler('onLayoutColsExpanded')}


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1360

### 📝 Description

event controller 事件分发的时候, 会对图表自己的 action icon 做判断, 如果是, 则不触发单元格的点击事件, 判断方式是 根据当前 target 的 type 是不是 `image`

如果是自定义单元格添加了背景图 也是 `image` shape 的场景就会判断错误, 导致单元格事件无法正常触发

修改为实例化 GuiIcon 的时候增加一个标识, 根据这个标识来判断更准确一点

https://codesandbox.io/s/vigilant-bell-iwre10?file=/index.tsx:210-537

```ts
class CustomRowCell extends RowCell {
  // 覆盖背景绘制，可覆盖或者增加绘制方法
  drawBackgroundShape() {
    this.backgroundShape = this.addShape("image", {
      attrs: {
        ...this.getCellArea(),
        img:
          "https://gw.alipayobjects.com/zos/antfincdn/og1XQOMyyj/1e3a8de1-3b42-405d-9f82-f92cb1c10413.png"
      }
    });
  }
}
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-05-24 at 11 48 41](https://user-images.githubusercontent.com/21015895/169944986-adbb50ea-2828-41cf-b9c6-60dc5f5b9571.gif) | ![Kapture 2022-05-24 at 11 47 12](https://user-images.githubusercontent.com/21015895/169944828-92e2e721-ebec-44dc-821e-3a79416630ba.gif)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
