### PR TITLE
fix: 明细表下range-selection报错

### DIFF
--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -87,9 +87,11 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
         const cellIdSuffix =
           this.spreadsheet.facet.layoutResult.colLeafNodes[col].id;
         return range(start.rowIndex, end.rowIndex + 1).map((row) => {
-          const cellIdPrefix = this.spreadsheet.facet.getSeriesNumberWidth()
-            ? String(row)
-            : this.spreadsheet.facet.layoutResult.rowLeafNodes[row].id;
+          const cellIdPrefix =
+            this.spreadsheet.facet.getSeriesNumberWidth() ||
+            this.spreadsheet.isTableMode()
+              ? String(row)
+              : this.spreadsheet.facet.layoutResult.rowLeafNodes[row].id;
           return {
             id: cellIdPrefix + '-' + cellIdSuffix,
             colIndex: col,


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
明细表下 rowLeafNodes，range-selection 交互从中取 id 会报错。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
