### PR TITLE
fix(strategysheet): 修复趋势分析表多列头时叶子节点未和数值单元格对齐

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
@@ -5,7 +5,12 @@ import { ShapeAttrs } from '@antv/g-canvas';
 import { S2DataConfig } from './../../esm/common/interface/s2DataConfig.d';
 import { TextTheme } from '@/common/interface/theme';
 import { PivotSheet } from '@/sheet-type';
-import { CellTypes, EXTRA_FIELD, TextAlign } from '@/common';
+import {
+  CellTypes,
+  EXTRA_COLUMN_FIELD,
+  EXTRA_FIELD,
+  TextAlign,
+} from '@/common';
 import { RowCell } from '@/cell';
 import { Node } from '@/facet/layout/node';
 
@@ -328,5 +333,39 @@ describe('SpreadSheet Theme Tests', () => {
         fontWight: 'normal',
       });
     });
+
+    // https://github.com/antvis/S2/pull/1371
+    it.each(['left', 'center', 'right'] as TextAlign[])(
+      'should render %s text align for column nodes',
+      (textAlign) => {
+        s2.setThemeCfg({
+          theme: {
+            colCell: {
+              measureText: {
+                textAlign,
+              },
+            },
+          },
+        });
+
+        s2.setDataCfg({
+          fields: {
+            columns: [...s2.dataCfg.fields.columns, EXTRA_COLUMN_FIELD],
+          },
+        } as S2DataConfig);
+
+        s2.setOptions({
+          style: {
+            colCfg: {
+              hideMeasureColumn: true,
+            },
+          },
+        });
+
+        s2.render(true);
+
+        expectTextAlign({ textAlign, fontWight: 'normal' });
+      },
+    );
   });
 });

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -13,7 +13,7 @@ import {
 import { BaseHeaderConfig } from '@/facet/header/base';
 import { Node } from '@/facet/layout/node';
 import { includeCell } from '@/utils/cell/data-cell';
-import { EXTRA_FIELD, S2Event } from '@/common/constant';
+import { EXTRA_COLUMN_FIELD, EXTRA_FIELD, S2Event } from '@/common/constant';
 import { CellTypes } from '@/common/constant';
 import { getSortTypeIcon } from '@/utils/sort-action';
 import { SortParam } from '@/common/interface';
@@ -301,6 +301,6 @@ export abstract class HeaderCell extends BaseCell<Node> {
   }
 
   public isMeasureField() {
-    return this.meta.field === EXTRA_FIELD;
+    return [EXTRA_FIELD, EXTRA_COLUMN_FIELD].includes(this.meta.field);
   }
 }

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -3,16 +3,7 @@ import { GestureEvent, Wheel } from '@antv/g-gesture';
 import { interpolateArray } from 'd3-interpolate';
 import { timer, Timer } from 'd3-timer';
 import { Group } from '@antv/g-canvas';
-import {
-  getColsForGrid,
-  getFrozenRowsForGrid,
-  getRowsForGrid,
-} from 'src/utils/grid';
 import { debounce, each, find, get, isUndefined, last, reduce } from 'lodash';
-import {
-  getAdjustedRowScrollX,
-  getAdjustedScrollOffset,
-} from 'src/utils/facet';
 import { CornerBBox } from './bbox/cornerBBox';
 import { PanelBBox } from './bbox/panelBBox';
 import {
@@ -21,6 +12,8 @@ import {
   optimizeScrollXY,
   translateGroup,
 } from './utils';
+import { getAdjustedRowScrollX, getAdjustedScrollOffset } from '@/utils/facet';
+import { getColsForGrid, getRowsForGrid } from '@/utils/grid';
 import {
   S2Event,
   KEY_GROUP_COL_RESIZE_AREA,

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -1,4 +1,4 @@
-import type { S2DataConfig } from '@antv/s2';
+import { EXTRA_COLUMN_FIELD, S2DataConfig } from '@antv/s2';
 
 export const customTree: S2DataConfig = {
   data: [
@@ -28,7 +28,7 @@ export const customTree: S2DataConfig = {
         values: [[377, 324, '0.02']],
       },
       date: '2021',
-      sub_type: JSON.stringify(['数值', '环比', '同比']),
+      [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比', '同比']),
     },
     {
       'measure-a': {
@@ -53,7 +53,7 @@ export const customTree: S2DataConfig = {
         values: [[377, 324, '0.02']],
       },
       date: '2022',
-      sub_type: JSON.stringify(['数值', '环比', '同比']),
+      [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比', '同比']),
     },
   ],
   meta: [
@@ -64,7 +64,7 @@ export const customTree: S2DataConfig = {
   ],
   fields: {
     rows: [],
-    columns: ['date', 'sub_type'],
+    columns: ['date', EXTRA_COLUMN_FIELD],
     values: [
       'measure-a',
       'measure-b',

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -823,11 +823,28 @@ function MainLayout() {
           />
         </TabPane>
         <TabPane tab="趋势分析表" key="strategy">
+          <Switch
+            checkedChildren="单列头"
+            unCheckedChildren="多列头"
+            checked={strategyDataCfg.fields.columns.length === 1}
+            onChange={(checked) => {
+              setStrategyDataCfg(
+                customMerge(customTree, {
+                  fields: {
+                    columns: customTree.fields.columns.slice(
+                      0,
+                      checked ? 1 : 2,
+                    ),
+                  },
+                }),
+              );
+            }}
+          />
           <SheetComponent
             sheetType="strategy"
             dataCfg={strategyDataCfg}
             options={strategyOptions}
-            onRowCellClick={(v) => console.log(v)}
+            onRowCellClick={logHandler('onRowCellClick')}
             header={{ exportCfg: { open: true } }}
             themeCfg={{
               theme: strategyTheme,

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -57,6 +57,7 @@ export const BaseSheet = React.forwardRef(
   },
 );
 
+BaseSheet.displayName = 'BaseSheet';
 BaseSheet.defaultProps = {
   options: {} as S2Options,
   adaptive: false,

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -73,6 +73,7 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
           autoResetSheetStyle: true,
           // 趋势分析表禁用 刷选, 多选, 区间多选
           brushSelection: false,
+          selectedCellMove: false,
           multiSelection: false,
           rangeSelection: false,
         },


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. #1364 重构后, 列头数值配置和 dataCell 解耦, 趋势分析表的虚拟数值列头命中了 `textAlign: 'center'`, 由于 `drawObjectText` 这个方法使用 dataCell 的 textAlign 做的坐标计算, 一个是 `right`, 一个是 `center` 导致坐标计算错误

2. 未兼容趋势分析表, 虚拟数值列头也应该命中 `measureText` 主题配置

![image](https://user-images.githubusercontent.com/21015895/170411128-d88e36bb-434e-4a99-9fa3-13ff2c71b464.png)

![image](https://user-images.githubusercontent.com/21015895/170411647-1802eb86-d8cf-4b26-8504-ba9ad327ea92.png)



### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/170411541-4fb9380e-5712-4d37-ab31-3efa3f48f04b.png) | ![image](https://user-images.githubusercontent.com/21015895/170411186-290a721d-2dbd-4020-8ca2-b1237253efab.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
