### PR TITLE
fix: fieldValue精度过高时intervalShape未绘制

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -18,6 +18,7 @@ describe('data cell formatter test', () => {
   } as unknown as ViewMeta;
 
   let s2: SpreadSheet;
+
   beforeEach(() => {
     const container = document.createElement('div');
 
@@ -25,6 +26,7 @@ describe('data cell formatter test', () => {
     const dataSet: PivotDataSet = new MockPivotDataSet(s2);
     s2.dataSet = dataSet;
   });
+
   test('should pass complete data into formater', () => {
     const formatter = jest.fn();
     jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
@@ -48,5 +50,43 @@ describe('data cell formatter test', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(dataCell.textShape.attr('text')).toEqual('120');
+  });
+
+  test('should draw condition interval shape', () => {
+    const cellWidth = 120;
+    const fieldValue = 27.334666666666667;
+    const anthorMeta = {
+      width: cellWidth,
+      valueField: 'value',
+      fieldValue,
+      data: {
+        city: 'chengdu',
+        value: fieldValue,
+        [VALUE_FIELD]: 'value',
+        [EXTRA_FIELD]: fieldValue,
+      },
+    } as unknown as ViewMeta;
+
+    jest.spyOn(s2.dataSet, 'getValueRangeByField').mockReturnValue({
+      minValue: fieldValue,
+      maxValue: fieldValue,
+    });
+
+    s2.setOptions({
+      conditions: {
+        interval: [
+          {
+            field: 'value',
+            mapping: () => ({ fill: 'red' }),
+          },
+        ],
+      },
+    });
+
+    const dataCell = new DataCell(anthorMeta, s2);
+
+    expect(get(dataCell, 'conditionIntervalShape.attrs.width')).toEqual(
+      cellWidth,
+    );
   });
 });

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -302,9 +302,13 @@ export class DataCell extends BaseCell<ViewMeta> {
       if (!attrs) {
         return;
       }
-      const { minValue, maxValue } = attrs.isCompare
+
+      const valueRange = attrs.isCompare
         ? attrs
         : this.spreadsheet.dataSet.getValueRangeByField(this.meta.valueField);
+      const minValue = parseNumberWithPrecision(valueRange.minValue);
+      const maxValue = parseNumberWithPrecision(valueRange.maxValue);
+
       const fieldValue = parseNumberWithPrecision(
         this.meta.fieldValue as number,
       );


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
#### 说明
当配置的 `condition. interval` mapping 未提供范围时，s2 会从数据集找到数值字段的 max、min。
计算百分比前，fieldValue 被 parseNumberWithPrecision 格式化了，但 max、min 没有。

如 fieldValue 取 `27.334666666666667`，经格式化成 `27.33466666666667`，少了一个 6。
导致 `fieldValue < minValue || fieldValue > maxValue` 为 true
进而无法绘制图案。

#### 方案
统一格式化


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
