### PR TITLE
feat: sortFunc 支持使用手动排序兜底

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
+++ b/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
@@ -4,6 +4,7 @@ import {
   getSortByMeasureValues,
   sortAction,
   sortByCustom,
+  sortByFunc,
 } from '@/utils/sort-action';
 import { EXTRA_FIELD, S2Options, SortParam, TOTAL_VALUE } from '@/common';
 import { PivotSheet } from '@/sheet-type';
@@ -168,6 +169,66 @@ describe('Sort By Custom Test', () => {
         'Wednesday[&]afternoon',
       ]);
     });
+  });
+});
+
+describe('Sort By Func Tests', () => {
+  test('should return default values', () => {
+    const originValues = ['四川[&]成都', '四川[&]绵阳', '浙江[&]杭州'];
+
+    const result = sortByFunc({
+      originValues,
+      sortParam: {
+        sortFieldId: 'city',
+        sortFunc: () => [],
+      },
+    });
+
+    expect(result).toEqual(originValues);
+  });
+
+  test('should return sortFunc result', () => {
+    const result = sortByFunc({
+      sortParam: {
+        sortFieldId: 'city',
+        sortFunc: () => ['浙江[&]杭州'],
+      },
+      dataSet: {
+        fields: {
+          rows: ['province', 'city'],
+        },
+      } as unknown as PivotDataSet,
+    });
+
+    expect(result).toEqual(['浙江[&]杭州']);
+  });
+
+  test('should return fallback result', () => {
+    const result = sortByFunc({
+      originValues: [
+        '四川[&]成都',
+        '四川[&]绵阳',
+        '浙江[&]杭州',
+        '浙江[&]绍兴',
+      ],
+      sortParam: {
+        sortFieldId: 'city',
+        // 不返回带 [&] 分隔符的结果
+        sortFunc: () => ['绍兴', '绵阳', '杭州', '成都'],
+      },
+      dataSet: {
+        fields: {
+          rows: ['province', 'city'],
+        },
+      } as unknown as PivotDataSet,
+    });
+
+    expect(result).toEqual([
+      '四川[&]绵阳',
+      '四川[&]成都',
+      '浙江[&]绍兴',
+      '浙江[&]杭州',
+    ]);
   });
 });
 

--- a/s2-site/docs/manual/basic/sort/custom.zh.md
+++ b/s2-site/docs/manual/basic/sort/custom.zh.md
@@ -265,26 +265,29 @@ sortParams: [
 
 #### 度量值（数值）
 
-支持度量值自定义，即数值，举例如下：
+支持使用度量值进行自定义计算，举例如下：
 
 ```ts
 sortParams: [
-    {
-        // sortFieldId 为度量值时，需传入 query 定位数值列表，params.data 为带有度量值的 data 列表
-        sortFieldId: 'price',
-        sortByMeasure: 'city',
-        sortFunc: function (params) {
-            const { data, sortByMeasure, sortFieldId } = params || {};
-            return data
-                ?.sort((a, b) => b[sortByMeasure] - a[sortByMeasure])
-                ?.map((item) => item[sortFieldId]);
-        },
-        query: { type: '纸张', [EXTRA_FIELD]: 'price' },
+  {
+    sortFieldId: 'city',
+    sortByMeasure: 'price',
+    // 当使用 sortByMeasure 时，可以传入 query 定位数值列表
+    // 如下方限定 params.data 为 type=纸张, 数值=price 的数据
+    query: { type: '纸张', [EXTRA_FIELD]: 'price' },
+    sortFunc: function (params) {
+      const { data, sortByMeasure, sortFieldId } = params || {};
+      return data
+        // 使用 price 做比较
+        ?.sort((a, b) => b[sortByMeasure] - a[sortByMeasure])
+        // map 出 city 维度的数组
+        ?.map((item) => item[sortFieldId]);
     },
+  },
 ];
 ```
 
-<img src="https://gw.alipayobjects.com/mdn/rms_56cbb2/afts/img/A*H_TESKL1MakAAAAAAAAAAAAAARQnAQ" width = "600"  alt="row" />
+<img src="https://gw.alipayobjects.com/zos/antfincdn/xZbG1ALW0/cd83b502-cde6-4a7b-a581-36aae26b4028.png" width = "600"  alt="row" />
 
 📊 查看demo [自定义排序](/zh/examples/analysis/sort#custom-sort-func)。
 

--- a/s2-site/examples/analysis/sort/demo/custom-sort-func.ts
+++ b/s2-site/examples/analysis/sort/demo/custom-sort-func.ts
@@ -43,9 +43,11 @@ fetch('../data/basic.json')
           },
         },
         {
-          // sortFieldId 为度量值时，需传入 query 定位数值列表，params.data 为带有度量值的 data 列表
-          sortFieldId: 'price',
-          sortByMeasure: 'city',
+          // 支持使用度量值进行自定义计算
+          sortFieldId: 'city',
+          sortByMeasure: 'price',
+          // 当使用 sortByMeasure 时，可以传入 query 定位数值列表
+          // 如下方限定 params.data 为 type=纸张, 数值=price 的数据
           sortFunc: function (params) {
             const { data, sortByMeasure, sortFieldId } = params || {};
             return data


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description
#### 背景
当用户使用 sortFunc 排序时，若回传的排序数组，没有携带 `[&]` 连接符，目前表格无法正常渲染

如交叉表的行维度=[province, city]，当前排序字段 sortFieldId=city
若 sortResult 返回的为 ['成都', '杭州']，则表格无法渲染
期望的返回为 ['浙江[&]杭州', '四川[&]成都']

#### 方案
让用户手动拼接每个维度，不太友好。故使用 sortResult 按照手动排序进行兜底处理。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| <img width="621" alt="CleanShot 2022-05-26 at 16 42 44@2x" src="https://user-images.githubusercontent.com/6716092/170452506-a82a5278-b0c8-46c8-8127-386300b2f656.png">    |  <img width="615" alt="CleanShot 2022-05-26 at 16 42 57@2x" src="https://user-images.githubusercontent.com/6716092/170452535-eb4a2318-3862-4c9a-ab4b-b2cc4dc632a7.png">    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
