### PR TITLE
fix(vue): 统一表组件变量名保持和 react 版本一致 Sheet => SheetComponent

### DIFF
--- a/packages/s2-vue/README.md
+++ b/packages/s2-vue/README.md
@@ -339,8 +339,9 @@ const rawOptions: S2Options = {
 // App.vue
 <script lang="ts">
 import type { S2DataConfig, S2Options } from '@antv/s2';
-import { Sheet } from '@antv/s2-vue';
+import { SheetComponent } from '@antv/s2-vue';
 import { defineComponent, onMounted, reactive, shallowRef } from 'vue';
+import "@antv/s2-vue/dist/style.min.css";
 
 export default defineComponent({
   setup() {
@@ -360,13 +361,13 @@ export default defineComponent({
   },
 
   components: {
-    Sheet,
+    SheetComponent,
   },
 });
 </script>
 
 <template>
-  <Sheet ref="s2" :dataCfg="dataCfg" :options="options" />
+  <SheetComponent ref="s2" :dataCfg="dataCfg" :options="options" />
 </template>
 
 <style lang="less">

--- a/packages/s2-vue/playground/App.vue
+++ b/packages/s2-vue/playground/App.vue
@@ -3,7 +3,7 @@
 import type { S2DataConfig, S2Options } from '@antv/s2';
 import type { SheetType } from '@antv/s2-shared';
 import { defineComponent, onMounted, reactive, ref, shallowRef } from 'vue';
-import { Sheet } from '../src';
+import { SheetComponent } from '../src';
 
 const dataCfg1: S2DataConfig = {
   fields: {
@@ -607,7 +607,7 @@ export default defineComponent({
     };
   },
   components: {
-    Sheet,
+    SheetComponent,
   },
 });
 </script>
@@ -646,7 +646,7 @@ export default defineComponent({
       </label>
     </div>
   </div>
-  <Sheet
+  <SheetComponent
     ref="s2"
     :sheetType="sheetType"
     :dataCfg="dataCfgFlag === 1 ? dataCfg1 : dataCfg2"

--- a/packages/s2-vue/src/components/index.ts
+++ b/packages/s2-vue/src/components/index.ts
@@ -1,4 +1,4 @@
 export { default as BaseSheet } from './sheets/base-sheet.vue';
 export { default as PivotSheet } from './sheets/pivot-sheet.vue';
 export { default as TableSheet } from './sheets/table-sheet.vue';
-export { default as Sheet } from './sheets/index.vue';
+export { default as SheetComponent } from './sheets/index.vue';

--- a/s2-site/docs/manual/advanced/adaptive.zh.md
+++ b/s2-site/docs/manual/advanced/adaptive.zh.md
@@ -148,12 +148,12 @@ const containerId = 'containerId';
 
 ```tsx
 <template>
-  <Sheet
+  <SheetComponent
     :dataCfg="your-dataCfg"
     :options="your-options"
     :adaptive="true"
   />
-  <Sheet
+  <SheetComponent
     :dataCfg="your-dataCfg"
     :options="your-options"
     :adaptive="false"
@@ -165,12 +165,12 @@ const containerId = 'containerId';
 
 ```tsx
 <template>
-  <Sheet
+  <SheetComponent
     :dataCfg="your-dataCfg"
     :options="your-options"
     :adaptive="{ width: true, height: true }"
   />
-  <Sheet
+  <SheetComponent
     :dataCfg="your-dataCfg"
     :options="your-options"
     :adaptive="{ width: false, height: false }"
@@ -194,7 +194,7 @@ const adaptive = {
     id="containerId"
     style="width:600px;height:400px"
   >
-    <Sheet
+    <SheetComponent
       :dataCfg="your-dataCfg"
       :options="your-options"
       :adaptive="adaptive"

--- a/s2-site/docs/manual/advanced/get-instance.zh.md
+++ b/s2-site/docs/manual/advanced/get-instance.zh.md
@@ -145,7 +145,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <Sheet ref="s2" :dataCfg="your-dataCfg" :options="your-options" />
+  <SheetComponent ref="s2" :dataCfg="your-dataCfg" :options="your-options" />
 </template>
 ```
 
@@ -178,7 +178,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <Sheet :dataCfg="your-dataCfg" :options="your-options"  @getSpreadSheet="getSpreadSheet"/>
+  <SheetComponent :dataCfg="your-dataCfg" :options="your-options"  @getSpreadSheet="getSpreadSheet"/>
 </template>
 ```
 
@@ -202,7 +202,7 @@ export default defineComponent({
 });
 </script>
 <template>
-  <Sheet ref="s2Ref" />
+  <SheetComponent ref="s2Ref" />
 </template>
 ```
 

--- a/s2-site/docs/manual/getting-started.zh.md
+++ b/s2-site/docs/manual/getting-started.zh.md
@@ -220,8 +220,9 @@ ReactDOM.render(
 // App.vue
 <script lang="ts">
 import type { S2DataConfig, S2Options } from '@antv/s2';
-import { Sheet } from '@antv/s2-vue';
+import { SheetComponent } from '@antv/s2-vue';
 import { defineComponent, onMounted, reactive, ref, shallowRef } from 'vue';
+import "@antv/s2-vue/dist/style.min.css";
 
 export default defineComponent({
   setup() {
@@ -236,13 +237,13 @@ export default defineComponent({
   },
 
   components: {
-    Sheet,
+    SheetComponent,
   },
 });
 </script>
 
 <template>
-  <Sheet :dataCfg="dataCfg" :options="options" />
+  <SheetComponent :dataCfg="dataCfg" :options="options" />
 </template>
 
 <style lang="less">


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [x] Other (<!-- what? -->)

### 📝 Description
Vue 表组件重命名  Sheet => SheetComponent


### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
