### PR TITLE
fix: 修复表格卸载后调用实例方法报错的问题 close #1349

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -62,6 +62,7 @@ jest.mock('src/sheet-type', () => {
         facet: {
           getFreezeCornerDiffWidth: jest.fn(),
         },
+        getCanvasElement: () => container.get('el'),
       };
     }),
   };

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -44,6 +44,7 @@ jest.mock('src/sheet-type', () => {
         isScrollContainsRowHeader: jest.fn(),
         getColumnLeafNodes: jest.fn().mockReturnValue([]),
         isHierarchyTreeType: jest.fn(),
+        getCanvasElement: () => container.get('el'),
       };
     }),
   };

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -76,6 +76,7 @@ export const createFakeSpreadSheet = () => {
   s2.showTooltipWithInfo = jest.fn();
   s2.isTableMode = jest.fn();
   s2.isPivotMode = jest.fn();
+  s2.getCanvasElement = () => s2.container.get('el');
 
   const interaction = new RootInteraction(s2 as unknown as SpreadSheet);
   s2.interaction = interaction;

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -158,7 +158,7 @@ export abstract class BaseFacet {
   };
 
   onContainerWheelForPc = () => {
-    const canvas = this.spreadsheet.container.get('el') as HTMLCanvasElement;
+    const canvas = this.spreadsheet.getCanvasElement();
     canvas?.addEventListener('wheel', this.onWheel);
   };
 
@@ -307,7 +307,7 @@ export abstract class BaseFacet {
   };
 
   private unbindEvents = () => {
-    const canvas = this.spreadsheet.container.get('el') as HTMLElement;
+    const canvas = this.spreadsheet.getCanvasElement();
     canvas?.removeEventListener('wheel', this.onWheel);
     this.mobileWheel.destroy();
   };

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -180,7 +180,11 @@ export class EventController {
 
   private isMouseOnTheCanvasContainer(event: Event) {
     if (event instanceof MouseEvent) {
-      const canvas = this.spreadsheet.container.get('el') as HTMLCanvasElement;
+      const canvas = this.spreadsheet.getCanvasElement();
+      if (!canvas) {
+        return false;
+      }
+
       const { x, y } = canvas.getBoundingClientRect() || {};
       // 这里不能使用 bounding rect 的 width 和 height, 高清适配后 canvas 实际宽高会变
       // 比如实际 400 * 300 => hd (800 * 600)

--- a/packages/s2-core/src/ui/hd-adapter/index.ts
+++ b/packages/s2-core/src/ui/hd-adapter/index.ts
@@ -83,9 +83,10 @@ export class HdAdapter {
       container,
       options: { width, height, devicePixelRatio },
     } = this.spreadsheet;
-
+    const canvas = this.spreadsheet.getCanvasElement();
     const lastRatio = container.get('pixelRatio');
-    if (lastRatio === ratio) {
+
+    if (lastRatio === ratio || !canvas) {
       return;
     }
 

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -85,7 +85,7 @@ export const getAutoAdjustPosition = ({
   const { width, height } = spreadsheet.options;
 
   const { top: canvasOffsetTop, left: canvasOffsetLeft } =
-    canvas?.getBoundingClientRect?.() || {};
+    canvas.getBoundingClientRect();
   const { width: tooltipWidth, height: tooltipHeight } =
     tooltipContainer.getBoundingClientRect();
   const { width: viewportWidth, height: viewportHeight } =

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -68,10 +68,12 @@ export const getAutoAdjustPosition = ({
   tooltipContainer,
   autoAdjustBoundary,
 }: AutoAdjustPositionOptions): TooltipPosition => {
+  const canvas = spreadsheet.getCanvasElement();
+
   let x = position.x + TOOLTIP_POSITION_OFFSET.x;
   let y = position.y + TOOLTIP_POSITION_OFFSET.y;
 
-  if (!autoAdjustBoundary) {
+  if (!autoAdjustBoundary || !canvas) {
     return {
       x,
       y,
@@ -81,10 +83,9 @@ export const getAutoAdjustPosition = ({
   const isAdjustBodyBoundary = autoAdjustBoundary === 'body';
   const { maxX, maxY } = spreadsheet.facet.panelBBox;
   const { width, height } = spreadsheet.options;
-  const canvas = spreadsheet.container.get('el') as HTMLCanvasElement;
 
   const { top: canvasOffsetTop, left: canvasOffsetLeft } =
-    canvas.getBoundingClientRect();
+    canvas?.getBoundingClientRect?.() || {};
   const { width: tooltipWidth, height: tooltipHeight } =
     tooltipContainer.getBoundingClientRect();
   const { width: viewportWidth, height: viewportHeight } =

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -412,6 +412,16 @@ function MainLayout() {
                     主题色调整
                   </Button>
                 </Popover>
+                <Button
+                  danger
+                  size="small"
+                  onClick={() => {
+                    s2Ref.current?.destroy();
+                    s2Ref.current?.render();
+                  }}
+                >
+                  卸载组件 (s2.destroy)
+                </Button>
               </Space>
               <Space style={{ margin: '20px 0', display: 'flex' }}>
                 <Tooltip title="tooltip 自动调整: 显示的tooltip超过指定区域时自动调整, 使其不遮挡">
@@ -446,6 +456,15 @@ function MainLayout() {
                   prefix="高度"
                   size="small"
                 />
+                <Button
+                  size="small"
+                  onClick={() => {
+                    s2Ref.current?.changeSheetSize(400, 400);
+                    s2Ref.current?.render(false);
+                  }}
+                >
+                  改变表格大小 (s2.changeSheetSize)
+                </Button>
                 <Popover
                   placement="bottomRight"
                   content={

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -67,6 +67,7 @@ s2.xx()
 | getCellType | 根据 event.target 获取当前 单元格类型 | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [CellTypes](/zh/docs/api/basic-class/base-cell#celltypes) |
 | getTotalsConfig | 获取总计小计配置 | (dimension: string) => [Total](/zh/docs/api/general/S2Options#totals) |
 | getInitColumnLeafNodes | 获取初次渲染的列头叶子节点 （比如：隐藏列头前） | () => [Node[]](/zh/docs/api/basic-class/node/) |
+| getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素 | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |
 
 ### S2MountContainer
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1349 

### 📝 Description

目前表格卸载后 `s2.destroy()`, 调用 `s2.render()` 或 `s2.changeSheetSize()` 会有不同的报错 (g 导致的), 解决办法是添加容错处理, 当找不到 `canvas` 后不执行相关逻辑

> changeSheetSize

这个错误原因是 卸载后 `canvas` 节点已经被移除了, g 内部的 `setDOMSize` 方法没有做容错, 所以只有我们来处理

![image](https://user-images.githubusercontent.com/21015895/171376465-bdf0e094-775a-4d1d-ba4b-9d07cde0d5b6.png)

> render

这个错误原因是 卸载后 所有的 Group 节点被移除, 再次调用 `render` => `buildFacet`

> node_modules/@antv/g-base/lib/abstract/container.js

![image](https://user-images.githubusercontent.com/21015895/171377433-593e4e79-50b4-46f6-8423-2d3421ae6338.png)

![image](https://user-images.githubusercontent.com/21015895/171376530-78e3b807-6532-4b94-9967-73718f800653.png)


### 🔗 Related issue link

close #1349 

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
