### PR TITLE
feat: canvas 未聚焦时不触发选中格子的键盘 move 行为

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
@@ -62,6 +62,7 @@ describe('Interaction Keyboard Move Tests', () => {
     s2.interaction.intercepts.clear();
     s2.interaction.isEqualStateName = () => false;
     s2.interaction.getInteractedCells = () => [mockCell];
+    s2.interaction.eventController.isCanvasEffect = true;
   });
 
   test('should bind events', () => {
@@ -286,5 +287,22 @@ describe('Interaction Keyboard Move Tests', () => {
       ],
       stateName: 'selected',
     });
+  });
+
+  test('should not move selected cell down when isCanvasEffect is false', () => {
+    s2.interaction.changeState = jest.fn((state) => {});
+    s2.interaction.getCells = () => [mockCell01.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell01.mockCell;
+    keyboardMove.endCell = mockCell01.mockCell;
+
+    s2.interaction.eventController.isCanvasEffect = false;
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_DOWN,
+    } as KeyboardEvent);
+    expect(s2.interaction.changeState).not.toBeCalled();
+
+    s2.interaction.eventController.isCanvasEffect = true;
   });
 });

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -49,7 +49,7 @@ export class EventController {
 
   public domEventListeners: EventListener[] = [];
 
-  private isCanvasEffect = false;
+  public isCanvasEffect = false;
 
   constructor(spreadsheet: SpreadSheet) {
     this.spreadsheet = spreadsheet;

--- a/packages/s2-core/src/interaction/selected-cell-move.ts
+++ b/packages/s2-core/src/interaction/selected-cell-move.ts
@@ -24,7 +24,7 @@ export class SelectedCellMove extends BaseEvent implements BaseEventImplement {
     super(spreadsheet);
   }
 
-  private getIsCanvasEffect() {
+  private isCanvasEffect() {
     return this.spreadsheet.interaction.eventController.isCanvasEffect;
   }
 
@@ -32,7 +32,7 @@ export class SelectedCellMove extends BaseEvent implements BaseEventImplement {
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
-        if (!this.getIsCanvasEffect()) {
+        if (!this.isCanvasEffect()) {
           return;
         }
         const isShift = event.shiftKey;

--- a/packages/s2-core/src/interaction/selected-cell-move.ts
+++ b/packages/s2-core/src/interaction/selected-cell-move.ts
@@ -24,10 +24,17 @@ export class SelectedCellMove extends BaseEvent implements BaseEventImplement {
     super(spreadsheet);
   }
 
+  private getIsCanvasEffect() {
+    return this.spreadsheet.interaction.eventController.isCanvasEffect;
+  }
+
   public bindEvents() {
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
+        if (!this.getIsCanvasEffect()) {
+          return;
+        }
         const isShift = event.shiftKey;
         const isMeta = event.metaKey;
         const hasDirection = SelectedCellMoveMap.includes(


### PR DESCRIPTION
### 👀 PR includes

canvas 未聚焦时不触发选中格子的键盘上下左右行为。