### PR TITLE
fix(tooltip): 减少 tooltip 框重绘

### DIFF
--- a/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
@@ -33,6 +33,21 @@ describe('Tooltip Tests', () => {
       y: 0,
     });
     expect(tooltip.visible).toBeFalsy();
+    expect(container).toBeFalsy();
+    expect(tooltip.container).not.toEqual(container);
+  });
+
+  test('should create tooltip container when call tooltip show method', () => {
+    tooltip.show({
+      position: {
+        x: 10,
+        y: 10,
+      },
+    });
+
+    const container = document.querySelector(
+      `.${TOOLTIP_PREFIX_CLS}-container`,
+    );
     expect(container).toBeDefined();
     expect(tooltip.container).toEqual(container);
   });

--- a/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
@@ -1,7 +1,11 @@
 import { createFakeSpreadSheet, sleep } from 'tests/util/helpers';
 import type { SpreadSheet } from '@/sheet-type/spread-sheet';
 import { BaseTooltip } from '@/ui/tooltip';
-import { TOOLTIP_CONTAINER_CLS, TOOLTIP_POSITION_OFFSET } from '@/common';
+import {
+  TOOLTIP_CONTAINER_CLS,
+  TOOLTIP_POSITION_OFFSET,
+  TOOLTIP_PREFIX_CLS,
+} from '@/common';
 
 jest.mock('@/interaction/event-controller');
 jest.mock('@/interaction/root');
@@ -20,12 +24,17 @@ describe('Tooltip Tests', () => {
   });
 
   test('should init tooltip', () => {
+    const container = document.querySelector(
+      `.${TOOLTIP_PREFIX_CLS}-container`,
+    );
     expect(tooltip).toBeDefined();
     expect(tooltip.position).toEqual({
       x: 0,
       y: 0,
     });
     expect(tooltip.visible).toBeFalsy();
+    expect(container).toBeDefined();
+    expect(tooltip.container).toEqual(container);
   });
 
   test('should show tooltip', () => {

--- a/packages/s2-core/__tests__/unit/utils/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/tooltip-spec.ts
@@ -676,6 +676,7 @@ describe('Tooltip Utils Tests', () => {
 
   test('should set container class name', () => {
     const container = document.createElement('div');
+    container.className = 'a';
 
     setContainerStyle(container, {
       className: 'test',

--- a/packages/s2-core/src/ui/tooltip/index.less
+++ b/packages/s2-core/src/ui/tooltip/index.less
@@ -24,12 +24,6 @@
       Arial,
       sans-serif;
 
-    &-show {
-      opacity: 1;
-      visibility: visible;
-      pointer-events: all;
-    }
-
     &-hide {
       opacity: 0;
       visibility: hidden;
@@ -38,6 +32,12 @@
       * {
         transition: none;
       }
+    }
+
+    &-show {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: all;
     }
   }
 }

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -147,7 +147,7 @@ export const setContainerStyle = (
     });
   }
   if (className) {
-    container.classList.add(className);
+    container.className = className;
   }
 };
 

--- a/packages/s2-react/playground/index.less
+++ b/packages/s2-react/playground/index.less
@@ -14,4 +14,8 @@
   .ant-checkbox-group {
     margin-left: 20px;
   }
+
+  .ant-space {
+    flex-wrap: wrap;
+  }
 }

--- a/s2-site/docs/manual/getting-started.zh.md
+++ b/s2-site/docs/manual/getting-started.zh.md
@@ -289,9 +289,8 @@ import "@antv/s2-vue/dist/style.min.css";
 git clone git@github.com:antvis/S2.git
 cd S2
 
-# 本地启动开发
+# 安装依赖
 yarn
-yarn core:watch
 # 调试 s2-react
 yarn react:playground
 # 调试 s2-vue

--- a/s2-site/docs/manual/introduction.zh.md
+++ b/s2-site/docs/manual/introduction.zh.md
@@ -214,7 +214,6 @@ yarn # 或者 yarn bootstrap
 yarn core:start
 
 # 调试 s2-react
-yarn core:watch
 yarn react:playground
 
 # 调试 s2-vue


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [x] Improve the performance
- [ ] Type optimization

### 📝 Description

tooltip 在调用 `show` 或 `hide` 方法时才创建 container, 而对应的 `getContainer` 会导致一直更新容器的 classname 造成重绘

![image](https://user-images.githubusercontent.com/21015895/172370759-3a343d32-5091-4875-aae3-7463c6fad124.png)


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-06-07 at 19 35 32](https://user-images.githubusercontent.com/21015895/172370009-a4e7f396-579a-4b66-bdd3-d17ea8869b16.gif) | ![Kapture 2022-06-07 at 19 37 33](https://user-images.githubusercontent.com/21015895/172370321-8f80e8a6-584d-4dab-bb80-f87dc50a3e4a.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
