### PR TITLE
fix(sort): 透视表/明细表 排序菜单文案显示错误

### DIFF
--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -1,0 +1,17 @@
+name: Issue Check Inactive
+
+on:
+  schedule:
+    - cron: "0 0 */15 * *"
+
+
+jobs:
+  issue-check-inactive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Inactive
+        uses: actions-cool/issues-helper@main
+        with:
+          actions: 'check-inactive'
+          inactive-label: '💤 inactive'
+          inactive-day: 30

--- a/.github/workflows/issue-remove-inactive.yml
+++ b/.github/workflows/issue-remove-inactive.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           actions: 'remove-labels'
           issue-number: ${{ github.event.issue.number }}
-          labels: '🤔 need reproduce, 👀 need more info'
+          labels: '💤 inactive,🤔 need reproduce,👀 need more info'

--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -2,7 +2,7 @@ import { getContainer } from 'tests/util/helpers';
 import type { Event as GEvent } from '@antv/g-canvas';
 import * as dataCfg from 'tests/data/simple-table-data.json';
 import { TableSheet } from '@/sheet-type';
-import type { S2Options } from '@/common';
+import { setLang, type LangType, type S2Options } from '@/common';
 import { Node } from '@/facet/layout/node';
 
 describe('TableSheet Tests', () => {
@@ -137,5 +137,48 @@ describe('TableSheet Tests', () => {
         },
       ]);
     });
+
+    // https://github.com/antvis/S2/issues/1421
+    test.each(['zh_CN', 'en_US'])(
+      'should render group sort menu',
+      (lang: LangType) => {
+        setLang(lang);
+
+        const sheet = new TableSheet(container, dataCfg, s2Options);
+        sheet.render();
+
+        const showTooltipWithInfoSpy = jest
+          .spyOn(sheet, 'showTooltipWithInfo')
+          .mockImplementation(() => {});
+
+        const event = {
+          stopPropagation() {},
+        } as GEvent;
+
+        sheet.handleGroupSort(event, null);
+
+        const isEnUS = lang === 'en_US';
+        const groupAscText = isEnUS ? 'ASC' : '升序';
+        const groupDescText = isEnUS ? 'DESC' : '降序';
+        const groupNoneText = isEnUS ? 'No order' : '不排序';
+
+        expect(showTooltipWithInfoSpy).toHaveBeenLastCalledWith(
+          expect.anything(),
+          expect.anything(),
+          {
+            onlyMenu: true,
+            operator: {
+              menus: [
+                { icon: 'groupAsc', key: 'asc', text: groupAscText },
+                { icon: 'groupDesc', key: 'desc', text: groupDescText },
+                { key: 'none', text: groupNoneText },
+              ],
+              onClick: expect.anything(),
+            },
+          },
+        );
+        sheet.destroy();
+      },
+    );
   });
 });

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -1,4 +1,4 @@
-import { find, get } from 'lodash';
+import { find } from 'lodash';
 import type { Group } from '@antv/g-canvas';
 import { ColCell } from '../cell/col-cell';
 import {
@@ -72,7 +72,7 @@ export class TableColCell extends ColCell {
 
   protected getTextStyle() {
     const style = this.getStyle();
-    return get(style, 'bolderText');
+    return style?.bolderText;
   }
 
   public getContentArea() {

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -6,6 +6,7 @@ import {
   InterceptType,
   S2Event,
   getTooltipOperatorTableSortMenus,
+  getTooltipOperatorSortMenus,
 } from '../common/constant';
 import type {
   RowCellCollapseTreeRowsType,
@@ -197,14 +198,12 @@ export class PivotSheet extends SpreadSheet {
     event.stopPropagation();
     this.interaction.addIntercepts([InterceptType.HOVER]);
 
-    const TOOLTIP_OPERATOR_SORT_MENUS = getTooltipOperatorTableSortMenus();
     const operator: TooltipOperatorOptions = {
       onClick: ({ key }) => {
         this.groupSortByMethod(key as unknown as SortMethod, meta);
-        // 排序事件完成触发
         this.emit(S2Event.RANGE_SORTED, event);
       },
-      menus: TOOLTIP_OPERATOR_SORT_MENUS,
+      menus: getTooltipOperatorSortMenus(),
     };
 
     this.showTooltipWithInfo(event, [], {

--- a/packages/s2-core/src/sheet-type/table-sheet.ts
+++ b/packages/s2-core/src/sheet-type/table-sheet.ts
@@ -10,7 +10,7 @@ import {
   KEY_GROUP_PANEL_FROZEN_TRAILING_ROW,
   PANEL_GROUP_FROZEN_GROUP_Z_INDEX,
   S2Event,
-  getTooltipOperatorSortMenus,
+  getTooltipOperatorTableSortMenus,
 } from '../common/constant';
 import type {
   S2Options,
@@ -169,11 +169,10 @@ export class TableSheet extends SpreadSheet {
     event.stopPropagation();
     this.interaction.addIntercepts([InterceptType.HOVER]);
 
-    const TOOLTIP_OPERATOR_TABLE_SORT_MENUS = getTooltipOperatorSortMenus();
     const operator: TooltipOperatorOptions = {
       onClick: (params: { key: string }) =>
         this.onSortTooltipClick(params, meta),
-      menus: TOOLTIP_OPERATOR_TABLE_SORT_MENUS,
+      menus: getTooltipOperatorTableSortMenus(),
     };
 
     this.showTooltipWithInfo(event, [], {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1421 

### 📝 Description

在 https://github.com/antvis/S2/pull/1397 的修复中, 不小心把明细表/透视表的排序文案写反了

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/172798885-72574c92-43bf-4e54-afd7-211f167c63d3.png) | ![image](https://user-images.githubusercontent.com/21015895/172798723-82b11c00-3a67-428c-b664-64b5ce05e9bd.png) |
| ![image](https://user-images.githubusercontent.com/21015895/172798838-145ae8e7-8ee5-49c5-8709-d8002abb3b89.png) | ![image](https://user-images.githubusercontent.com/21015895/172798772-9466b3be-4951-46c2-9fe2-7c66216f463d.png) |

### 🔗 Related issue link

ref https://github.com/antvis/S2/pull/1397 https://github.com/antvis/S2/issues/1394

<!-- close #0 -->

### 🔍 Self Check before Merge

- [x] Add or update relevant Docs.
- [x] Add or update relevant Demos.
- [x] Add or update relevant TypeScript definitions.
