### PR TITLE
fix: 解决父元素缩放时,自适应无法充满父元素bug

### DIFF
--- a/packages/s2-shared/src/utils/resize.ts
+++ b/packages/s2-shared/src/utils/resize.ts
@@ -39,7 +39,7 @@ export const createResizeObserver = (params: ResizeEffectParams) => {
 
   const onResize = () => {
     //取dom的大小，解决scale问题
-    const { width: nodeWidth, height: nodeHeight } =
+    const { clientWidth: nodeWidth, clientHeight: nodeHeight } =
       container;
 
     const width = adaptiveWidth

--- a/packages/s2-shared/src/utils/resize.ts
+++ b/packages/s2-shared/src/utils/resize.ts
@@ -38,8 +38,9 @@ export const createResizeObserver = (params: ResizeEffectParams) => {
   const debounceRender = debounce(render, RESIZE_RENDER_DELAY);
 
   const onResize = () => {
+    //取dom的大小，解决scale问题
     const { width: nodeWidth, height: nodeHeight } =
-      container?.getBoundingClientRect();
+      container;
 
     const width = adaptiveWidth
       ? Math.floor(nodeWidth ?? s2.options.width)

--- a/packages/s2-shared/src/utils/resize.ts
+++ b/packages/s2-shared/src/utils/resize.ts
@@ -38,9 +38,8 @@ export const createResizeObserver = (params: ResizeEffectParams) => {
   const debounceRender = debounce(render, RESIZE_RENDER_DELAY);
 
   const onResize = () => {
-    //取dom的大小，解决scale问题
-    const { clientWidth: nodeWidth, clientHeight: nodeHeight } =
-      container;
+    // 取dom的大小，解决scale问题
+    const { clientWidth: nodeWidth, clientHeight: nodeHeight } = container;
 
     const width = adaptiveWidth
       ? Math.floor(nodeWidth ?? s2.options.width)


### PR DESCRIPTION
getBoundingClientRect()获取到的是缩放后的实际大小，去掉这个直接取dom元素大小

### 👀 PR includes
🐛 Bugfix

- [x] close #1411 

