### PR TITLE
refactor: 优化交叉表渲染性能

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/dataset/pivot-dataset-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/dataset/pivot-dataset-spec.ts
@@ -67,7 +67,6 @@ describe('PivotDataSet util test', () => {
 
   test('for transformDimensionsValues function', () => {
     const rows = ['province', 'city'];
-    const sortedDimensionValues = {};
     const data = {
       city: '杭州市',
       number: 7789,
@@ -75,13 +74,12 @@ describe('PivotDataSet util test', () => {
       sub_type: '桌子',
       type: '家具',
     };
-    const result = transformDimensionsValues(data, rows, sortedDimensionValues);
+    const result = transformDimensionsValues(data, rows);
     expect(result).toEqual(['浙江省', '杭州市']);
   });
 
   test('for return type of transformDimensionsValues function', () => {
     const rows = ['row0', 'row1'];
-    const sortedDimensionValues = {};
     const data = {
       row0: 0,
       number: 7789,
@@ -89,7 +87,7 @@ describe('PivotDataSet util test', () => {
       sub_type: '桌子',
       type: '家具',
     };
-    const result = transformDimensionsValues(data, rows, sortedDimensionValues);
+    const result = transformDimensionsValues(data, rows);
     expect(result).toEqual(['0', '1']);
   });
 

--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -77,3 +77,6 @@ export const IMAGE = 'image';
 
 // 角头最大占整个容器的比例 (0-1)
 export const CORNER_MAX_WIDTH_RATIO = 0.5;
+
+/** 布局采样数 */
+export const LAYOUT_SAMPLE_COUNT = 50;

--- a/packages/s2-core/src/data-set/interface.ts
+++ b/packages/s2-core/src/data-set/interface.ts
@@ -21,6 +21,8 @@ export type DataPathParams = {
   colDimensionValues: string[];
   // first create data path
   isFirstCreate?: boolean;
+  // callback when pivot map create node
+  onFirstCreate?: (dimension, paths) => void;
   // use for multiple data queries（path contains undefined）
   careUndefined?: boolean;
   // use in row tree mode to append fields information

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -1,9 +1,7 @@
-import { get, isEmpty } from 'lodash';
 import { i18n, ID_SEPARATOR, ROOT_ID } from '../../common';
 import type { PivotDataSet } from '../../data-set';
 import type { SpreadSheet } from '../../sheet-type';
 import { filterUndefined, getListBySorted } from '../../utils/data-set-operate';
-import { getDimensionsWithoutPathPre } from '../../utils/dataset/pivot-data-set';
 import { generateId } from '../../utils/layout/generate-id';
 import type { FieldValue, TreeHeaderParams } from '../layout/interface';
 import { layoutArrange, layoutHierarchy } from '../layout/layout-hooks';
@@ -25,6 +23,8 @@ const addTotals = (
   }
 };
 
+const NODE_ID_PREFIX_LEN = (ROOT_ID + ID_SEPARATOR).length;
+
 /**
  * Only row header has tree hierarchy, in this scene:
  * 1、value in rows is not work => valueInCols is ineffective
@@ -35,24 +35,24 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
   const { parentNode, currentField, level, facetCfg, hierarchy, pivotMeta } =
     params;
   const { spreadsheet, dataSet, collapsedRows, hierarchyCollapse } = facetCfg;
-  const { query, id } = parentNode;
+  const { query, id: parentId } = parentNode;
   const isDrillDownItem = spreadsheet.dataCfg.fields.rows?.length <= level;
   const sortedDimensionValues =
     (dataSet as PivotDataSet)?.sortedDimensionValues?.[currentField] || [];
 
-  // 为第一个子层级时，parentNode.id === ROOT_ID 时，不需要通过分割获取当前节点的真实 value
-  const dimensions =
-    ROOT_ID === id
-      ? sortedDimensionValues
-      : sortedDimensionValues?.filter((item) =>
-          item?.includes(id?.split(`${ROOT_ID}${ID_SEPARATOR}`)[1]),
-        );
-
-  const dimValues = filterUndefined(
-    getListBySorted(
-      [...(pivotMeta.keys() || [])],
-      [...getDimensionsWithoutPathPre([...dimensions])],
-    ),
+  const unsortedDimValues = filterUndefined(Array.from(pivotMeta.keys()));
+  const dimValues = getListBySorted(
+    unsortedDimValues,
+    sortedDimensionValues,
+    (dimVal) => {
+      // 根据父节点 id，修改 unsortedDimValues 里用于比较的值，使其格式与 sortedDimensionValues 排序值一致
+      // unsortedDimValues：['成都', '绵阳']
+      // sortedDimensionValues: ['四川[&]成都']
+      if (ROOT_ID === parentId) {
+        return dimVal;
+      }
+      return generateId(parentId, dimVal).slice(NODE_ID_PREFIX_LEN);
+    },
   );
 
   let fieldValues: FieldValue[] = layoutArrange(
@@ -94,8 +94,8 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
         [currentField]: value,
       };
     }
-    const uniqueId = generateId(parentNode.id, value);
-    const isCollapsedRow = get(collapsedRows, uniqueId);
+    const uniqueId = generateId(parentId, value);
+    const isCollapsedRow = collapsedRows?.[uniqueId];
     const isCollapse = isCollapsedRow ?? hierarchyCollapse;
 
     const node = new Node({
@@ -119,7 +119,7 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
       hierarchy.maxLevel = level;
     }
 
-    const emptyChildren = isEmpty(pivotMetaValue?.children);
+    const emptyChildren = !pivotMetaValue.children?.size;
     if (emptyChildren || isTotals) {
       node.isLeaf = true;
     }

--- a/packages/s2-core/src/utils/data-set-operate.ts
+++ b/packages/s2-core/src/utils/data-set-operate.ts
@@ -1,8 +1,17 @@
 import { every, filter, get, isUndefined, keys, reduce } from 'lodash';
 import type { Data, Fields, Totals, TotalsStatus } from '../common/interface';
 
-export const getListBySorted = (list: string[], sorted: string[]) => {
+export const getListBySorted = (
+  list: string[],
+  sorted: string[],
+  mapValue?: (val: string) => string,
+) => {
   return list.sort((a, b) => {
+    if (mapValue) {
+      a = mapValue(a);
+      b = mapValue(b);
+    }
+
     const ia = sorted.indexOf(a);
     const ib = sorted.indexOf(b);
     if (ia === -1 && ib === -1) {
@@ -39,8 +48,8 @@ export const flatten = (data: Record<any, any>[] | Record<any, any>) => {
   if (Array.isArray(data)) {
     keys(data)?.forEach((item) => {
       const current = get(data, item);
-      if (keys(current)?.includes('undefined')) {
-        keys(current)?.forEach((ki) => {
+      if ('undefined' in current) {
+        keys(current).forEach((ki) => {
           result.push(current[ki]);
         });
       } else {

--- a/packages/s2-core/src/utils/dataset/pivot-data-set.ts
+++ b/packages/s2-core/src/utils/dataset/pivot-data-set.ts
@@ -242,12 +242,15 @@ export function transformIndexesData(params: Param) {
       sortedDimensionValues[dimension] ||
       (sortedDimensionValues[dimension] = [])
     ).push(
+      // 拼接维度路径
       // [1, undefined] => ['1', 'undefined'] => '1[&]undefined
-      dimensionPath.map(String).join(ID_SEPARATOR),
+      dimensionPath.map((it) => `${it}`).join(ID_SEPARATOR),
     );
   };
 
-  for (const data of [...originData, ...totalData]) {
+  const allData = originData.concat(totalData);
+  for (let index = 0; index < allData.length; index++) {
+    const data = allData[index];
     const rowDimensionValues = transformDimensionsValues(data, rows);
     const colDimensionValues = transformDimensionsValues(data, columns);
     const path = getDataPath({


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [x] Improve the performance

### 📝 Description

#### 1. 树状结构行头布局排序效率
修改：buildRowTreeHierarchy、getListBySorted
影响：tree 的行头布局

##### 之前
同一层级节点 layout 时，都会全量处理 sortedDimensionValues 的值。
先做筛选、再去掉 `前一层[&]` 的前缀，如有 ['四川[&]成都', '浙江[&]杭州'] -> ['四川[&]成都'] -> ['成都']

##### 现在
无需要做过滤和去前缀，转而在 getListBySorted 做比较时，把维度值 dimValues 补齐，如 `成都` -> `四川[&]成都`。
因为 sortedDimensionValues 数组比较大，包含了同一层级的所有维度值。而 dimValues 只是同级的小分支，数据个数比较少。
且 dimValues 只有 1 个时（单节点），不用调用 sortFunc，进一步节约执行时间。

#### 2. compact 模式列宽采样计算
修改：grid、tree 的 compact 模式布局

##### 之前
使用 getMultiData 取了当前列的所有数据，再 slice 50 个。

##### 现在
直接循环 50 次，按行头叶子节点与当前列的交叉，执行获取50次数据进行采样。



#### 3. sortedDimensionValues 的初始化效率
修改：transformIndexesData、transformIndexesData

##### 之前
在 transformDimensionsValues 遍历所有数据时，反复检查当前维度值是否插入了 sortedDimensionValues，没有就插入。
其中检查函数 'includes' 执行很多次，比较耗时。

##### 现在
transformDimensionsValues 不再包含副作用，仅按配置的维度，返回维度数据。
因为 getDataPath 会遍历生成 pivotMap，所以在遇到创建新节点时构造 sortedDimensionValues 即可，不用检查重复。


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| 约 20s | 约 360ms |
|  ![image](https://user-images.githubusercontent.com/6716092/173274383-72f43a55-f701-45f7-9cb6-662dc77f610e.png)     |  ![image](https://user-images.githubusercontent.com/6716092/173274406-c3554c03-9ced-4650-a0e4-f0c6310b8447.png)   |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
