### PR TITLE
fix(copy): 修复字段名带有-导致复制失败的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -457,6 +457,39 @@ describe('Pivot Table Core Data Process', () => {
     const data = getSelectedData(s2New);
     expect(data).toBe(convertString(`7789\n元`));
   });
+
+  it('should get correct data with - string in header name', () => {
+    const s2New = new TableSheet(
+      getContainer(),
+      assembleDataCfg({
+        meta: [
+          { field: 'number', name: 'number-3', formatter: (v) => v + '\n元' },
+        ],
+        fields: {
+          columns: ['number', 'type', 'sub_type'],
+        },
+        data: originalData,
+      }),
+      assembleOptions({
+        interaction: {
+          enableCopy: true,
+          copyWithFormat: true,
+        },
+        showSeriesNumber: false,
+      }),
+    );
+    s2New.render();
+    const cell = s2New.interaction
+      .getAllCells()
+      .filter(({ cellType }) => cellType === CellTypes.DATA_CELL)[0];
+
+    s2New.interaction.changeState({
+      cells: [getCellMeta(cell)],
+      stateName: InteractionStateName.SELECTED,
+    });
+    const data = getSelectedData(s2New);
+    expect(data).toBe(convertString(`7789\n元`));
+  });
 });
 
 describe('List Table getCopyData', () => {

--- a/packages/s2-core/src/utils/export/copy.ts
+++ b/packages/s2-core/src/utils/export/copy.ts
@@ -28,9 +28,11 @@ const getColNodeField = (spreadsheet: SpreadSheet, id: string) => {
   return colNode?.field;
 };
 
-const getFiledIdFromMeta = (meta: CellMeta, spreadsheet: SpreadSheet) => {
-  const ids = meta.id.split('-');
-  return getColNodeField(spreadsheet, ids[ids.length - 1]);
+const getFiledIdFromMeta = (colIndex: number, spreadsheet: SpreadSheet) => {
+  const colNode = spreadsheet
+    .getColumnNodes()
+    .find((col) => col.colIndex === colIndex);
+  return getColNodeField(spreadsheet, colNode.id);
 };
 
 const getHeaderNodeFromMeta = (meta: CellMeta, spreadsheet: SpreadSheet) => {
@@ -41,9 +43,11 @@ const getHeaderNodeFromMeta = (meta: CellMeta, spreadsheet: SpreadSheet) => {
   ];
 };
 
-const getFormat = (cellId: string, spreadsheet: SpreadSheet) => {
-  const ids = cellId.split('-');
-  const fieldId = getColNodeField(spreadsheet, ids[ids.length - 1]);
+const getFormat = (colIndex: number, spreadsheet: SpreadSheet) => {
+  const colNode = spreadsheet
+    .getColumnNodes()
+    .find((col) => col.colIndex === colIndex);
+  const fieldId = getColNodeField(spreadsheet, colNode.id);
   if (spreadsheet.options.interaction.copyWithFormat) {
     return spreadsheet.dataSet.getFieldFormatter(fieldId);
   }
@@ -71,7 +75,7 @@ const getValueFromMeta = (
     });
     return cell[VALUE_FIELD];
   }
-  const fieldId = getFiledIdFromMeta(meta, spreadsheet);
+  const fieldId = getFiledIdFromMeta(meta.colIndex, spreadsheet);
   return displayData[meta.rowIndex]?.[fieldId];
 };
 
@@ -80,7 +84,7 @@ const format = (
   displayData: DataType[],
   spreadsheet: SpreadSheet,
 ) => {
-  const formatter = getFormat(meta.id, spreadsheet);
+  const formatter = getFormat(meta.colIndex, spreadsheet);
   return formatter(getValueFromMeta(meta, displayData, spreadsheet));
 };
 
@@ -174,7 +178,10 @@ const getPivotCopyData = (
               colNode.isTotals ||
               colNode.isTotalMeasure,
           });
-          return getFormat(colNode.id, spreadsheet)(cellData[VALUE_FIELD]);
+          return getFormat(
+            colNode.colIndex,
+            spreadsheet,
+          )(cellData[VALUE_FIELD]);
         })
         .join(newTab),
     )


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1283 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

原来用split('-')去判断ID，有误判的情况，修改成用colIndex去获取当前的colKey

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
