### PR TITLE
fix: 出现 tooltip 后点击画布外面的空白区域可能抛出错误

### DIFF
--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -640,7 +640,7 @@ export const verifyTheElementInTooltip = (
 ): boolean => {
   let result = false;
   let currentNode: Node = child;
-  while (currentNode !== document.body) {
+  while (currentNode !==null && currentNode !== document.body) {
     if (parent === currentNode) {
       result = true;
       break;

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -640,7 +640,7 @@ export const verifyTheElementInTooltip = (
 ): boolean => {
   let result = false;
   let currentNode: Node = child;
-  while (currentNode !==null && currentNode !== document.body) {
+  while (currentNode && currentNode !== document.body) {
     if (parent === currentNode) {
       result = true;
       break;


### PR DESCRIPTION
当文档的高度未被  body 元素完全占满的时候，tooltip 显示以后点击“外部空白区域”触发 click 事件的 event.target 可能是 html 元素，执行到该函数会抛出错误  Cannot read properties of null (reading 'parentElement')

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
