### PR TITLE
fix(tooltip): 修复行/列层级超过2级时选中数据统计错误

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,8 +38,9 @@
 
 <!-- close #0 -->
 
-### 🔍 Self Check before Merge
+### 🔍 Self-Check before merge
 
-- [ ] Add or update relevant Docs.
-- [ ] Add or update relevant Demos.
+- [ ] Add or update relevant docs.
+- [ ] Add or update relevant demos.
+- [ ] Add or update test case.
 - [ ] Add or update relevant TypeScript definitions.

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -23,6 +23,8 @@ import {
   type S2Options,
   SelectedCellMove,
   SpreadSheet,
+  Node,
+  type S2CellType,
 } from '@/index';
 import { RootInteraction } from '@/interaction/root';
 import { mergeCell, unmergeCell } from '@/utils/interaction/merge-cell';
@@ -390,6 +392,33 @@ describe('RootInteraction Tests', () => {
       ]);
       rootInteraction.resetState();
       expect(rootInteraction.getActiveCells()).toEqual([]);
+    });
+
+    test('should set selected status after highlight nodes', () => {
+      const belongsCell = createMockCellInfo('test-A').mockCell;
+
+      const mockNodeA = new Node({
+        id: 'test',
+        key: 'test',
+        value: '1',
+        belongsCell,
+      });
+
+      const mockNodeB = new Node({
+        id: 'test',
+        key: 'test',
+        value: '1',
+        belongsCell,
+      });
+
+      rootInteraction.highlightNodes([mockNodeA, mockNodeB]);
+
+      [mockNodeA, mockNodeB].forEach((node) => {
+        expect(node.belongsCell.updateByState).toHaveBeenCalledWith(
+          InteractionStateName.SELECTED,
+          belongsCell,
+        );
+      });
     });
 
     test.each`

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -126,6 +126,7 @@ export const createMockCellInfo = (
     getActualText: jest.fn(),
     getFieldValue: jest.fn(),
     hideInteractionShape: jest.fn(),
+    updateByState: jest.fn(),
   } as unknown as S2CellType;
 
   return {

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -221,6 +221,7 @@ export class EventController {
         event.target,
       );
     }
+
     if (event instanceof MouseEvent) {
       return (
         event.clientX >= x &&

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -251,7 +251,7 @@ export class RootInteraction {
     });
   };
 
-  public getCellLeafNodes = (cell: S2CellType): Node[] => {
+  public getCellChildrenNodes = (cell: S2CellType): Node[] => {
     const meta = cell?.getMeta?.() as Node;
     const isRowCell = cell?.cellType === CellTypes.ROW_CELL;
     const isHierarchyTree = this.spreadsheet.isHierarchyTreeType();
@@ -290,18 +290,18 @@ export class RootInteraction {
       selectHeaderCellInfo?.isMultiSelection && this.isSelectedState();
 
     // 如果是已选中的单元格, 则取消选中, 兼容行列多选 (含叶子节点)
-    let leafNodes = isSelectedCell ? [] : this.getCellLeafNodes(cell);
+    let childrenNodes = isSelectedCell ? [] : this.getCellChildrenNodes(cell);
     let selectedCells = isSelectedCell ? [] : [getCellMeta(cell)];
 
     if (isMultiSelected) {
       selectedCells = concat(lastState?.cells, selectedCells);
-      leafNodes = concat(lastState?.nodes, leafNodes);
+      childrenNodes = concat(lastState?.nodes, childrenNodes);
 
       if (isSelectedCell) {
         selectedCells = selectedCells.filter(
           ({ id }) => id !== currentCellMeta.id,
         );
-        leafNodes = leafNodes.filter(
+        childrenNodes = childrenNodes.filter(
           (node) => !node?.id.includes(currentCellMeta.id),
         );
       }
@@ -313,28 +313,35 @@ export class RootInteraction {
       return;
     }
 
+    // 高亮所有的子节点, 但是只有叶子节点需要参与数据计算
+    const needCalcNodes = childrenNodes.filter((node) => node.isLeaf);
     // 兼容行列多选 (高亮 行/列头 以及相对应的数值单元格)
     this.changeState({
       cells: selectedCells,
-      nodes: leafNodes,
+      nodes: needCalcNodes,
       stateName: InteractionStateName.SELECTED,
     });
 
     const selectedCellIds = selectedCells.map(({ id }) => id);
     this.updateCells(this.getRowColActiveCells(selectedCellIds));
 
-    // 平铺模式或者是树状模式下的列头单元格, 选中子节点
+    // 平铺模式或者是树状模式下的列头单元格, 高亮子节点
     if (!isHierarchyTree || isColCell) {
-      leafNodes.forEach((node) => {
-        node?.belongsCell?.updateByState(
-          InteractionStateName.SELECTED,
-          node.belongsCell,
-        );
-      });
+      this.highlightNodes(childrenNodes);
     }
+
     this.spreadsheet.emit(S2Event.GLOBAL_SELECTED, this.getActiveCells());
 
     return true;
+  };
+
+  public highlightNodes = (nodes: Node[] = []) => {
+    nodes.forEach((node) => {
+      node?.belongsCell?.updateByState(
+        InteractionStateName.SELECTED,
+        node.belongsCell,
+      );
+    });
   };
 
   public mergeCells = (cellsInfo?: MergedCellInfo[], hideData?: boolean) => {

--- a/packages/s2-react/__tests__/data/mock-dataset.json
+++ b/packages/s2-react/__tests__/data/mock-dataset.json
@@ -1,7 +1,7 @@
 {
   "describe": "标准交叉表数据。注意：不能随意改动！会影响单测结果！",
   "fields": {
-    "rows": ["province", "city"],
+    "rows": ["country", "province", "city"],
     "columns": ["type", "sub_type"],
     "values": ["number"],
     "valueInCols": true

--- a/packages/s2-react/__tests__/data/mock-dataset.json
+++ b/packages/s2-react/__tests__/data/mock-dataset.json
@@ -1,7 +1,7 @@
 {
   "describe": "标准交叉表数据。注意：不能随意改动！会影响单测结果！",
   "fields": {
-    "rows": ["country", "province", "city"],
+    "rows": ["province", "city"],
     "columns": ["type", "sub_type"],
     "values": ["number"],
     "valueInCols": true

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -14,7 +14,6 @@ import {
   type ThemeCfg,
   type TooltipAutoAdjustBoundary,
   getLang,
-  setLang,
   type InteractionOptions,
 } from '@antv/s2';
 import type { Adaptive, SheetType } from '@antv/s2-shared';
@@ -60,7 +59,9 @@ import {
 import './index.less';
 import { ResizeConfig } from './resize';
 
-// setLang('en_US');
+pivotSheetDataCfg.data.forEach((item) => {
+  item.country = '中国';
+});
 
 const { TabPane } = Tabs;
 

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -59,10 +59,6 @@ import {
 import './index.less';
 import { ResizeConfig } from './resize';
 
-pivotSheetDataCfg.data.forEach((item) => {
-  item.country = '中国';
-});
-
 const { TabPane } = Tabs;
 
 const fieldMap = {

--- a/packages/s2-react/src/components/tooltip/components/summary.tsx
+++ b/packages/s2-react/src/components/tooltip/components/summary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { size, reduce } from 'lodash';
+import { size, sumBy } from 'lodash';
 import { i18n, type SummaryProps, TOOLTIP_PREFIX_CLS } from '@antv/s2';
 import cls from 'classnames';
 
@@ -7,11 +7,7 @@ export const TooltipSummary: React.FC<SummaryProps> = React.memo((props) => {
   const { summaries = [] } = props;
 
   const renderSelected = () => {
-    const count = reduce(
-      summaries,
-      (pre, next) => pre + size(next?.selectedData),
-      0,
-    );
+    const count = sumBy(summaries, (item) => size(item?.selectedData));
     return (
       <div className={`${TOOLTIP_PREFIX_CLS}-summary-item`}>
         <span className={`${TOOLTIP_PREFIX_CLS}-selected`}>

--- a/s2-site/docs/api/basic-class/interaction.zh.md
+++ b/s2-site/docs/api/basic-class/interaction.zh.md
@@ -40,16 +40,17 @@ s2.interaction.xx()
 | getRowColActiveCells | 获取行头和列头激活的单元格 | `() => RowCell[] | ColCell[]` |
 | getAllCells | 获取所有单元格 | `() => S2CellType[]` |
 | selectAll | 选中所有单元格 | `() => void` |
-| selectHeaderCell | 选中指定行列头单元格 | `(selectHeaderCellInfo: SelectHeaderCellInfo) => boolean` |
+| selectHeaderCell | 选中指定行列头单元格 | (selectHeaderCellInfo: [SelectHeaderCellInfo](#selectheadercellinfo)) => boolean |
 | getCellLeafNodes | 获取当前单元格的叶子节点 | `(cell: S2CellType[]) => Node[]` |
 | hideColumns | 隐藏列 (forceRender 为 `false` 时，隐藏列为空的情况下，不再触发表格更新） | `(hiddenColumnFields: string[], forceRender?: boolean = true) => void` |
 | mergeCells | 合并单元格 | `(cellsInfo?: MergedCellInfo[], hideData?: boolean) => void` |
-| unmergeCells | 取消合并单元格 | `(removedCells: MergedCell) => void` |
+| unmergeCells | 取消合并单元格 | `(removedCells: MergedCell[]) => void` |
 | updatePanelGroupAllDataCells | 更新所有数值单元格 | `() => void` |
 | updateCells | 更新指定单元格 | `(cells: S2CellType[]) => void` |
-| addIntercepts | 新增交互拦截 | `(interceptTypes: InterceptType[]) => void` |
-| hasIntercepts | 是否有指定拦截的交互 | `(interceptTypes: InterceptType[]) => boolean` |
-| removeIntercepts | 移除指定交互拦截 | `(interceptTypes: InterceptType[]) => void` |
+| addIntercepts | 新增交互拦截 | (interceptTypes: [InterceptType](#intercepttype)[]) => void |
+| hasIntercepts | 是否有指定拦截的交互 | (interceptTypes: [InterceptType](#intercepttype)[]) => boolean |
+| removeIntercepts | 移除指定交互拦截 | (interceptTypes: [InterceptType](#intercepttype)[]) => void |
+| highlightNodes | 高亮节点对应的单元格 | (nodes: [Node](/zh/docs/api/basic-class/node)[]) => void |
 
 `markdown:docs/common/interaction.zh.md`
 

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -114,6 +114,7 @@ const s2Options = {
 
 ```ts
 const content = document.createElement('div')
+content.innerHTML = '我是自定义内容'
 
 const s2Options = {
   tooltip: {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

当行/列层级 >=3 时, 在单选/多选行头时, 统计的已选中个数和汇总数据是错误的, 原因是当前所有的子节点参与了计算, 预期应该是当前点击的单元格对应的叶子节点

- 参与计算: 所有叶子节点
- 高亮: 当前节点 + 所有子节点

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/173789963-59eaa48c-41de-401f-a816-264a603d2ce6.png) | ![image](https://user-images.githubusercontent.com/21015895/173789845-ed6aa9fe-e162-486a-9c88-f6e825df9bb1.png) | 


### 🔗 Related issue link

<!-- close #0 -->

close #1419 

### 🔍 Self-Check before Merge

- [ ] Add or update relevant Docs.
- [ ] Add or update relevant Demos.
- [ ] Add or update relevant TypeScript definitions.
