### PR TITLE
fix(interaction): 修复禁用多选后, 未对行/列头生效

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -255,4 +255,29 @@ describe('Pivot Mode Facet Test', () => {
       expect(get(sampleDataCell, 'meta.data.number')).toBe(7789);
     });
   });
+
+  it.each(['updateScrollOffset', 'scrollWithAnimation', 'scrollImmediately'])(
+    'should not throw "Cannot read property \'value\' of undefined" error if called with single offset config',
+    (method) => {
+      const onlyOffsetYFn = () => {
+        facet[method]({
+          offsetY: {
+            value: 10,
+          },
+        });
+      };
+
+      const onlyOffsetXFn = () => {
+        facet[method]({
+          offsetX: {
+            value: 10,
+          },
+        });
+      };
+
+      [onlyOffsetXFn, onlyOffsetYFn].forEach((handler) => {
+        expect(handler).not.toThrowError();
+      });
+    },
+  );
 });

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -14,7 +14,7 @@ import type { Node } from '@/facet/layout/node';
 
 jest.mock('@/interaction/event-controller');
 
-describe('Interaction Data Cell Click Tests', () => {
+describe('Interaction Row & Column Cell Click Tests', () => {
   let rowColumnClick: RowColumnClick;
   let s2: SpreadSheet;
 
@@ -147,6 +147,52 @@ describe('Interaction Data Cell Click Tests', () => {
         stopPropagation() {},
       } as unknown as GEvent);
       expect(selected).toHaveBeenCalledWith([mockCell]);
+    },
+  );
+
+  test.each([
+    {
+      event: S2Event.ROW_CELL_CLICK,
+      enableMultiSelection: false,
+      result: false,
+    },
+    {
+      event: S2Event.COL_CELL_CLICK,
+      enableMultiSelection: false,
+      result: false,
+    },
+    {
+      event: S2Event.ROW_CELL_CLICK,
+      enableMultiSelection: true,
+      result: true,
+    },
+    {
+      event: S2Event.COL_CELL_CLICK,
+      enableMultiSelection: true,
+      result: true,
+    },
+  ])(
+    'should emit cell selected event when %s clicked111',
+    ({ event, enableMultiSelection, result }) => {
+      s2.options.interaction.multiSelection = enableMultiSelection;
+
+      const selectHeaderCellSpy = jest
+        .spyOn(s2.interaction, 'selectHeaderCell')
+        .mockImplementation(() => true);
+
+      Object.defineProperty(rowColumnClick, 'isMultiSelection', {
+        value: true,
+        writable: true,
+      });
+
+      s2.emit(event, {
+        stopPropagation() {},
+      } as unknown as GEvent);
+
+      expect(selectHeaderCellSpy).toHaveBeenCalledWith({
+        cell: expect.anything(),
+        isMultiSelection: result,
+      });
     },
   );
 

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -59,7 +59,7 @@ export interface S2BasicOptions<T = Element | string> {
   // register custom svg icons
   customSVGIcons?: CustomSVGIcon[];
   // extra styles
-  style?: Partial<Style>;
+  style?: Style;
   hdAdapter?: boolean;
   // the collection of row id and column id of cells which to be merged
   mergedCellsInfo?: MergedCellInfo[][];

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -423,14 +423,14 @@ export abstract class BaseFacet {
   };
 
   scrollWithAnimation = (
-    offsetConfig: OffsetConfig,
+    offsetConfig: OffsetConfig = {},
     duration = 200,
     cb?: () => void,
   ) => {
     const { scrollX: adjustedScrollX, scrollY: adjustedScrollY } =
       this.getAdjustedScrollOffset({
-        scrollX: offsetConfig.offsetX.value || 0,
-        scrollY: offsetConfig.offsetY.value || 0,
+        scrollX: offsetConfig.offsetX?.value || 0,
+        scrollY: offsetConfig.offsetY?.value || 0,
       });
     if (this.timer) {
       this.timer.stop();
@@ -453,10 +453,10 @@ export abstract class BaseFacet {
     });
   };
 
-  scrollImmediately = (offsetConfig: OffsetConfig) => {
+  scrollImmediately = (offsetConfig: OffsetConfig = {}) => {
     const { scrollX, scrollY } = this.getAdjustedScrollOffset({
-      scrollX: offsetConfig.offsetX.value || 0,
-      scrollY: offsetConfig.offsetY.value || 0,
+      scrollX: offsetConfig.offsetX?.value || 0,
+      scrollY: offsetConfig.offsetY?.value || 0,
     });
     this.setScrollOffset({ scrollX, scrollY });
     this.startScroll(scrollX, scrollY);

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -72,12 +72,17 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
 
   private handleRowColClick = (event: CanvasEvent) => {
     event.stopPropagation();
-    const { interaction } = this.spreadsheet;
+
+    const { interaction, options } = this.spreadsheet;
     const cell = this.spreadsheet.getCell(event.target);
+
+    const { multiSelection: enableMultiSelection } = options.interaction;
+    // 关闭了多选就算按下了 Ctrl/Commend, 行/列也按单选处理
+    const isMultiSelection = !!(enableMultiSelection && this.isMultiSelection);
 
     const success = interaction.selectHeaderCell({
       cell,
-      isMultiSelection: this.isMultiSelection,
+      isMultiSelection,
     });
 
     if (success) {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -523,7 +523,7 @@ export abstract class SpreadSheet extends EE {
    * default offsetX(horizontal scroll need animation)
    * but offsetY(vertical scroll don't need animation)
    */
-  public updateScrollOffset(offsetConfig: OffsetConfig): void {
+  public updateScrollOffset(offsetConfig: OffsetConfig) {
     this.facet.updateScrollOffset(
       customMerge(
         {

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -97,6 +97,9 @@ export const s2Options: S2Options = {
     enableCopy: true,
   },
   style: {
+    cellCfg: {
+      height: 50,
+    },
     hierarchyCollapse: false,
   },
 };

--- a/s2-site/docs/common/interaction.zh.md
+++ b/s2-site/docs/common/interaction.zh.md
@@ -19,7 +19,7 @@ order: 5
 | autoResetSheetStyle    | 用于控制点击表格外区域和按下 esc 键时是否重置交互状态 | `boolean`                                                                                | `true`  |       |
 | resize                 | 用于控制 resize 热区是否显示                          | `boolean`   \| [ResizeActiveOptions](/zh/docs/api/general/S2Options#resizeactiveoptions) | `true`  |       |
 | brushSelection                 | 是否允许刷选                         | `boolean` | `true`  |       |
-| multiSelection                 | 是否允许多选                         | `boolean` | `true`  |       |
+| multiSelection                 | 是否允许多选 （包含行头，列头，数值单元格）                         | `boolean` | `true`  |       |
 | rangeSelection                 | 是否允许区间快捷多选                         | `boolean` | `true`  |       |
 | scrollbarPosition | 用于控制滚动条展示在内容区边缘还是画布边缘 | `content`\| `canvas`  | `content`  |   |
 | eventListenerOptions | 事件监听函数 `addEventListener` 的 [可选项配置](https://developer.mozilla.org/zh-CN/docs/Web/API/EventTarget/addEventListener), 可控制事件从冒泡阶段还是捕获阶段触发 | `false`  |   |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复关闭多选配置后, 行列点击时未读取该配置, 导致依然可以进行多选的问题 (尤其对于趋势分析表, 多选没有任何意义)

```ts
const s2Options = {
  interaction: {
    multiSelection: false
  }
}
```

2. 对 `facet.updateScrollOffset` 的内部两个方法进行兜底, `scrollWithAnimation` 和 `scrollImmediately`

避免只传递 `offsetX: {}` 和 `offsetY: {}` 报错的情况

```ts
![image](https://user-images.githubusercontent.com/21015895/174566807-a1ecc60e-3dea-42fd-a9eb-d35fda2267f4.png)

```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-06-20 at 17 06 37](https://user-images.githubusercontent.com/21015895/174566986-3b4221dc-a4bf-497d-8a7c-e428ba2729e9.gif) | ![Kapture 2022-06-20 at 17 03 53](https://user-images.githubusercontent.com/21015895/174566383-35dff868-b197-4f81-b5f6-9661711c71e7.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
