### PR TITLE
fix: 自定义 flatten 函数未考虑空值情况

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/data-set-operate-spec.tsx
+++ b/packages/s2-core/__tests__/unit/utils/data-set-operate-spec.tsx
@@ -55,6 +55,13 @@ describe('Data Set Operate Test', () => {
     });
   });
 
+  describe('CustomFlatten Tests', () => {
+    it('should handle data contains nil', () => {
+      const result = customFlatten([undefined, null, [1, 2]]);
+      expect(result).toBeArrayOfSize(4);
+    });
+  });
+
   describe('Dataset Operate Test GetListBySorted', () => {
     let list = [];
     beforeEach(() => {

--- a/packages/s2-core/src/utils/data-set-operate.ts
+++ b/packages/s2-core/src/utils/data-set-operate.ts
@@ -48,8 +48,9 @@ export const flatten = (data: Record<any, any>[] | Record<any, any>) => {
   if (Array.isArray(data)) {
     keys(data)?.forEach((item) => {
       const current = get(data, item);
-      if ('undefined' in current) {
-        keys(current).forEach((ki) => {
+      const currentKeys = keys(current);
+      if (currentKeys.includes('undefined')) {
+        currentKeys.forEach((ki) => {
           result.push(current[ki]);
         });
       } else {


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
#1430 引入的 BUG，当 `'undefined' in item` 未考虑 item 可能为空

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
