### PR TITLE
fix(strategysheet): 修复趋势分析表多列头切换为单列头后, 隐藏列头功能失效

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -593,6 +593,14 @@ describe('PivotSheet Tests', () => {
     expect(s2.getInitColumnLeafNodes()).toHaveLength(2);
   });
 
+  test('should clear init column nodes', () => {
+    s2.store.set('initColumnLeafNodes', [null, null]);
+
+    s2.clearColumnLeafNodes();
+
+    expect(s2.store.get('initColumnLeafNodes')).toBeFalsy();
+  });
+
   test('should get pivot mode', () => {
     expect(s2.isPivotMode()).toBeTruthy();
     expect(s2.isTableMode()).toBeFalsy();

--- a/packages/s2-core/src/common/store/index.ts
+++ b/packages/s2-core/src/common/store/index.ts
@@ -8,7 +8,7 @@ export class Store {
   private store = new Map<keyof StoreKey, unknown>();
 
   public set<T extends keyof StoreKey>(key: T, value: StoreKey[T]) {
-    this.store.set(key, value);
+    return this.store.set(key, value);
   }
 
   public get<T extends keyof StoreKey>(

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -655,6 +655,10 @@ export abstract class SpreadSheet extends EE {
     return this.store.get('initColumnLeafNodes', []);
   }
 
+  public clearColumnLeafNodes() {
+    this.store.set('initColumnLeafNodes', undefined);
+  }
+
   // 初次渲染时, 如果配置了隐藏列, 则生成一次相关配置信息
   private initHiddenColumnsDetail = () => {
     const { hiddenColumnFields } = this.options.interaction;

--- a/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
@@ -1,7 +1,8 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { PivotSheet, type S2Options } from '@antv/s2';
+import { PivotSheet, type S2DataConfig, type S2Options } from '@antv/s2';
 import { getContainer } from 'tests/util/helpers';
 import * as mockDataConfig from 'tests/data/simple-data.json';
+import { cloneDeep } from 'lodash';
 import { useSpreadSheet } from '@/hooks';
 import type { SheetComponentsProps } from '@/components';
 
@@ -13,22 +14,29 @@ const s2Options: S2Options = {
 
 describe('useSpreadSheet tests', () => {
   const container = getContainer();
-  const props: SheetComponentsProps = {
-    spreadsheet: () => new PivotSheet(container, mockDataConfig, s2Options),
-    options: s2Options,
-    dataCfg: mockDataConfig,
+  const getConfig = (
+    fields: S2DataConfig['fields'] = mockDataConfig.fields,
+  ): SheetComponentsProps => {
+    return {
+      spreadsheet: () => new PivotSheet(container, mockDataConfig, s2Options),
+      options: s2Options,
+      dataCfg: {
+        fields,
+        data: mockDataConfig.data,
+      },
+    };
   };
 
   test('should build spreadSheet', () => {
     const { result } = renderHook(() =>
-      useSpreadSheet({ ...props, sheetType: 'pivot' }),
+      useSpreadSheet({ ...getConfig(), sheetType: 'pivot' }),
     );
     expect(result.current.s2Ref).toBeDefined();
   });
 
   test('should cannot change table size when width or height updated and disable adaptive', () => {
     const { result } = renderHook(() =>
-      useSpreadSheet({ ...props, sheetType: 'pivot', adaptive: false }),
+      useSpreadSheet({ ...getConfig(), sheetType: 'pivot', adaptive: false }),
     );
     const s2 = result.current.s2Ref.current;
 
@@ -44,5 +52,40 @@ describe('useSpreadSheet tests', () => {
 
     expect(canvas.style.width).toEqual(`200px`);
     expect(canvas.style.height).toEqual(`200px`);
+  });
+
+  test('should clear init column leaf nodes when column fields changed', () => {
+    const defaultFields: S2DataConfig['fields'] = {
+      rows: ['province'],
+      columns: ['type', 'city'],
+      values: ['price'],
+      valueInCols: true,
+    };
+
+    const { result, rerender } = renderHook(() =>
+      useSpreadSheet(
+        cloneDeep({
+          ...getConfig(defaultFields),
+          sheetType: 'strategy',
+        }),
+      ),
+    );
+    const s2 = result.current.s2Ref.current;
+
+    expect(s2.getInitColumnLeafNodes()).toHaveLength(2);
+
+    // 很奇怪, rerender 之后始终拿到的两次 dataCfg 是一样的, 暂时先注释了
+    // act(() => {
+    //   const fields: S2DataConfig['fields'] = {
+    //     rows: ['province', 'city'],
+    //     columns: ['type'],
+    //     values: ['price'],
+    //     valueInCols: false,
+    //   };
+
+    //   rerender(getConfig(fields));
+    // });
+
+    // expect(s2.store.get('initColumnLeafNodes')).toEqual([]);
   });
 });

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -81,6 +81,14 @@ export function useSpreadSheet(props: SheetComponentsProps) {
     let reloadData = false;
     let reBuildDataSet = false;
     if (!Object.is(prevDataCfg, dataCfg)) {
+      // 列头变化需要重新计算初始叶子节点
+      if (
+        prevDataCfg?.fields?.columns?.length !==
+        dataCfg?.fields?.columns?.length
+      ) {
+        s2Ref.current?.clearColumnLeafNodes();
+      }
+
       reloadData = true;
       s2Ref.current?.setDataCfg(dataCfg);
     }
@@ -95,6 +103,7 @@ export function useSpreadSheet(props: SheetComponentsProps) {
       s2Ref.current?.setOptions(options);
       s2Ref.current?.changeSheetSize(options.width, options.height);
     }
+
     if (!Object.is(prevThemeCfg, themeCfg)) {
       s2Ref.current?.setThemeCfg(themeCfg);
     }

--- a/packages/s2-vue/src/hooks/useSheetUpdate.ts
+++ b/packages/s2-vue/src/hooks/useSheetUpdate.ts
@@ -34,7 +34,13 @@ export const useSheetUpdate = (
 
   watch(
     () => props.dataCfg!,
-    (dataCfg) => {
+    (dataCfg, prevDataCfg) => {
+      if (
+        prevDataCfg?.fields?.columns?.length !==
+        dataCfg?.fields?.columns?.length
+      ) {
+        s2Ref.value?.clearColumnLeafNodes();
+      }
       updateFlag.rerender = true;
       updateFlag.reloadData = true;
       s2Ref.value?.setDataCfg(dataCfg);

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -68,6 +68,7 @@ s2.xx()
 | getTotalsConfig | 获取总计小计配置 | (dimension: string) => [Total](/zh/docs/api/general/S2Options#totals) |
 | getInitColumnLeafNodes | 获取初次渲染的列头叶子节点 （比如：隐藏列头前） | () => [Node[]](/zh/docs/api/basic-class/node/) |
 | getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素 | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |
+| clearColumnLeafNodes | 清空存储在 store 中的初始叶子节点 | () => void |
 
 ### S2MountContainer
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

对于 React 和 Vue 版本 的 `SheetComponent`, dataCfg.fields.columns 切换为单列头后, 未清空保存在 store 中的叶子节点, 导致点击隐藏列头后还是拿到上一次的叶子节点, 隐藏失效

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-06-21 at 11 14 44](https://user-images.githubusercontent.com/21015895/174708811-9e9a363d-47ca-4ebe-87a8-b0d3d5821391.gif) | ![Kapture 2022-06-21 at 11 13 35](https://user-images.githubusercontent.com/21015895/174708697-3f7f4c31-3411-4636-b3fa-b83ab50c1043.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
