### PR TITLE
fix: 构造含总计的 tree 行头布局时报错

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/layout/build-row-tree-hierarchy-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/build-row-tree-hierarchy-spec.ts
@@ -8,7 +8,14 @@ const s2Options: S2Options = {
   width: 400,
   height: 400,
   hierarchyType: 'tree',
+  // 测试总计行节点分支
+  totals: {
+    row: {
+      showGrandTotals: true,
+    },
+  },
 };
+
 describe('build row tree hierarchy', () => {
   // https://stackblitz.com/edit/react-ts-aj2r8w?file=data.ts
   test('should get order hierarchy when order is group ascend', () => {
@@ -30,13 +37,14 @@ describe('build row tree hierarchy', () => {
     const s2 = new PivotSheet(getContainer(), s2DataConfig, s2Options);
     s2.render();
     const rowLeafNodes = s2.facet.layoutResult.rowLeafNodes;
-    expect(rowLeafNodes.length).toBe(6);
+    expect(rowLeafNodes.length).toBe(7);
     expect(rowLeafNodes[0].label).toEqual('浙江');
     expect(rowLeafNodes[1].label).toEqual('杭州');
     expect(rowLeafNodes[2].label).toEqual('舟山');
     expect(rowLeafNodes[3].label).toEqual('吉林');
     expect(rowLeafNodes[4].label).toEqual('丹东');
     expect(rowLeafNodes[5].label).toEqual('白山');
+    expect(rowLeafNodes[6].label).toEqual('总计');
   });
   test('should get order hierarchy when order is group desc', () => {
     const s2DataConfig: S2DataConfig = {
@@ -57,12 +65,13 @@ describe('build row tree hierarchy', () => {
     const s2 = new PivotSheet(getContainer(), s2DataConfig, s2Options);
     s2.render();
     const rowLeafNodes = s2.facet.layoutResult.rowLeafNodes;
-    expect(rowLeafNodes.length).toBe(6);
+    expect(rowLeafNodes.length).toBe(7);
     expect(rowLeafNodes[0].label).toEqual('浙江');
     expect(rowLeafNodes[1].label).toEqual('舟山');
     expect(rowLeafNodes[2].label).toEqual('杭州');
     expect(rowLeafNodes[3].label).toEqual('吉林');
     expect(rowLeafNodes[4].label).toEqual('丹东');
     expect(rowLeafNodes[5].label).toEqual('白山');
+    expect(rowLeafNodes[6].label).toEqual('总计');
   });
 });

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -119,7 +119,7 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
       hierarchy.maxLevel = level;
     }
 
-    const emptyChildren = !pivotMetaValue.children?.size;
+    const emptyChildren = !pivotMetaValue?.children?.size;
     if (emptyChildren || isTotals) {
       node.isLeaf = true;
     }


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
#1430  引入的 BUG，当树状模式开启总计时，总计节点的循环里，pivotMetaValue 是 `null`

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
