### PR TITLE
fix: 增加tooltip允许复制的样式防止被外部覆盖

### DIFF
--- a/packages/s2-core/src/ui/tooltip/index.less
+++ b/packages/s2-core/src/ui/tooltip/index.less
@@ -3,6 +3,7 @@
 .@{tooltip-prefix-cls} {
   &-container {
     position: fixed;
+    user-select: text;
     min-width: 200px;
     max-width: 640px;
     z-index: 1024;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [x] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

### 📝 Description
默认是允许用户复制 tooltip 信息的，底表样式增加一个，防止不必要的样式覆盖
