### PR TITLE
feat(tooltip): 支持额外的样式和类名 & 修复内容过长 tooltip 展示不全的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
@@ -3,6 +3,8 @@ import type { SpreadSheet } from '@/sheet-type/spread-sheet';
 import { BaseTooltip } from '@/ui/tooltip';
 import {
   TOOLTIP_CONTAINER_CLS,
+  TOOLTIP_CONTAINER_HIDE_CLS,
+  TOOLTIP_CONTAINER_SHOW_CLS,
   TOOLTIP_POSITION_OFFSET,
   TOOLTIP_PREFIX_CLS,
 } from '@/common';
@@ -24,9 +26,7 @@ describe('Tooltip Tests', () => {
   });
 
   test('should init tooltip', () => {
-    const container = document.querySelector(
-      `.${TOOLTIP_PREFIX_CLS}-container`,
-    );
+    const container = document.querySelector(`.${TOOLTIP_CONTAINER_CLS}`);
     expect(tooltip).toBeDefined();
     expect(tooltip.position).toEqual({
       x: 0,
@@ -45,9 +45,7 @@ describe('Tooltip Tests', () => {
       },
     });
 
-    const container = document.querySelector(
-      `.${TOOLTIP_PREFIX_CLS}-container`,
-    );
+    const container = document.querySelector(`.${TOOLTIP_CONTAINER_CLS}`);
     expect(container).toBeDefined();
     expect(tooltip.container).toEqual(container);
   });
@@ -71,7 +69,7 @@ describe('Tooltip Tests', () => {
     });
     // add class
     expect(tooltip.container.className).toEqual(
-      `${TOOLTIP_CONTAINER_CLS} ${TOOLTIP_CONTAINER_CLS}-show`,
+      `${TOOLTIP_CONTAINER_CLS} ${TOOLTIP_CONTAINER_SHOW_CLS}`,
     );
     // visible status
     expect(tooltip.visible).toBeTruthy();
@@ -102,7 +100,7 @@ describe('Tooltip Tests', () => {
     expect(tooltip.visible).toBeFalsy();
     // add class
     expect(tooltip.container.className).toEqual(
-      `${TOOLTIP_CONTAINER_CLS} ${TOOLTIP_CONTAINER_CLS}-hide`,
+      `${TOOLTIP_CONTAINER_CLS} ${TOOLTIP_CONTAINER_HIDE_CLS}`,
     );
     // add pointer events
     expect(style.pointerEvents).toEqual('none');
@@ -316,5 +314,74 @@ describe('Tooltip Tests', () => {
     });
 
     expect(tooltip.container.innerHTML).toEqual('custom content');
+  });
+
+  test('should render max container size if content size more than container size', () => {
+    const contentSize = {
+      width: 9999,
+      height: 9999,
+    };
+
+    const MAX_HEIGHT = window.innerHeight;
+    const MAX_WIDTH = 640;
+
+    const node = document.createElement('div');
+    node.innerHTML = '我很宽,很长';
+    node.style.width = `${contentSize.width}px`;
+    node.style.height = `${contentSize.height}px`;
+
+    tooltip.show({
+      position: {
+        x: 10,
+        y: 10,
+      },
+      content: node,
+    });
+
+    const tooltipRect = tooltip.container.getBoundingClientRect();
+
+    // Tooltip 最大宽度/高度
+    expect(tooltipRect.width).toStrictEqual(MAX_WIDTH);
+    expect(tooltipRect.height).toStrictEqual(MAX_HEIGHT);
+
+    // Tooltip 容器应该有滚动条
+    expect(tooltip.container.scrollWidth).toStrictEqual(contentSize.width);
+    expect(tooltip.container.scrollHeight).toStrictEqual(contentSize.height);
+    expect(tooltip.container.clientWidth).toBeLessThan(
+      tooltip.container.scrollWidth,
+    );
+  });
+
+  test('should set custom container style', () => {
+    s2.options.tooltip.containerStyle = {
+      fontSize: '20px',
+      color: 'red',
+    };
+
+    tooltip = new BaseTooltip(s2);
+
+    tooltip.show({
+      position: {
+        x: 10,
+        y: 10,
+      },
+    });
+
+    expect(tooltip.container.style.fontSize).toEqual('20px');
+  });
+
+  test('should set custom container class name', () => {
+    s2.options.tooltip.containerClassName = 'custom';
+
+    tooltip = new BaseTooltip(s2);
+
+    tooltip.show({
+      position: {
+        x: 10,
+        y: 10,
+      },
+    });
+
+    expect(tooltip.container.classList.contains('custom')).toBeTruthy();
   });
 });

--- a/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
@@ -353,7 +353,7 @@ describe('Tooltip Tests', () => {
   });
 
   test('should set custom container style', () => {
-    s2.options.tooltip.containerStyle = {
+    s2.options.tooltip.style = {
       fontSize: '20px',
       color: 'red',
     };
@@ -371,7 +371,7 @@ describe('Tooltip Tests', () => {
   });
 
   test('should set custom container class name', () => {
-    s2.options.tooltip.containerClassName = 'custom';
+    s2.options.tooltip.className = 'custom';
 
     tooltip = new BaseTooltip(s2);
 

--- a/packages/s2-core/__tests__/unit/utils/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/tooltip-spec.ts
@@ -7,7 +7,7 @@ import type { BBox } from '@antv/g-canvas';
 import { omit } from 'lodash';
 import {
   getAutoAdjustPosition,
-  setContainerStyle,
+  setTooltipContainerStyle,
   getTooltipOptions,
   getTooltipData,
 } from '@/utils/tooltip';
@@ -25,6 +25,8 @@ import {
   type Total,
   type Totals,
   VALUE_FIELD,
+  TOOLTIP_CONTAINER_SHOW_CLS,
+  TOOLTIP_CONTAINER_HIDE_CLS,
 } from '@/index';
 import type { BaseFacet } from '@/facet/base-facet';
 
@@ -663,7 +665,7 @@ describe('Tooltip Utils Tests', () => {
   test('should set container style', () => {
     const container = document.createElement('div');
 
-    setContainerStyle(container, {
+    setTooltipContainerStyle(container, {
       style: {
         width: '100px',
         pointerEvents: 'none',
@@ -678,10 +680,38 @@ describe('Tooltip Utils Tests', () => {
     const container = document.createElement('div');
     container.className = 'a';
 
-    setContainerStyle(container, {
-      className: 'test',
+    setTooltipContainerStyle(container, {
+      className: ['test'],
     });
 
-    expect(container.className).toEqual('test');
+    expect(container.classList.contains('test')).toBeTruthy();
+
+    setTooltipContainerStyle(container, {
+      className: ['test', null, undefined, ''],
+    });
+
+    expect(container.classList.contains('null')).toBeFalsy();
+    expect(container.classList.contains('undefined')).toBeFalsy();
+  });
+
+  test('should set container class name by visible', () => {
+    const container = document.createElement('div');
+    container.className = 'visible';
+
+    setTooltipContainerStyle(container, {
+      visible: true,
+    });
+
+    expect(container.className).toEqual(
+      `visible ${TOOLTIP_CONTAINER_SHOW_CLS}`,
+    );
+
+    setTooltipContainerStyle(container, {
+      visible: false,
+    });
+
+    expect(container.className).toEqual(
+      `visible ${TOOLTIP_CONTAINER_HIDE_CLS}`,
+    );
   });
 });

--- a/packages/s2-core/src/common/constant/tooltip.ts
+++ b/packages/s2-core/src/common/constant/tooltip.ts
@@ -8,6 +8,8 @@ import type {
 export const TOOLTIP_PREFIX_CLS = `${S2_PREFIX_CLS}-tooltip`;
 
 export const TOOLTIP_CONTAINER_CLS = `${TOOLTIP_PREFIX_CLS}-container`;
+export const TOOLTIP_CONTAINER_SHOW_CLS = `${TOOLTIP_CONTAINER_CLS}-show`;
+export const TOOLTIP_CONTAINER_HIDE_CLS = `${TOOLTIP_CONTAINER_CLS}-hide`;
 
 export const TOOLTIP_OPERATION_PREFIX_CLS = `${TOOLTIP_PREFIX_CLS}-operation`;
 

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -161,10 +161,10 @@ export interface BaseTooltipConfig<T = TooltipContentType> {
   adjustPosition?: (positionInfo: TooltipPositionInfo) => TooltipPosition;
   // Custom tooltip mount container
   getContainer?: () => HTMLElement;
-  // Extra tooltip class name
-  containerClassName?: string;
-  // Extra tooltip style
-  containerStyle?: CSS.Properties;
+  // Extra tooltip container class name
+  className?: string;
+  // Extra tooltip container style
+  style?: CSS.Properties;
 }
 
 export interface TooltipPositionInfo {

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -1,4 +1,5 @@
 import type { Event as CanvasEvent } from '@antv/g-canvas';
+import type * as CSS from 'csstype';
 import type { SpreadSheet } from '../../sheet-type';
 import type { S2CellType, SortParam } from '../../common/interface';
 import type { BaseTooltip } from '../../ui/tooltip';
@@ -160,6 +161,10 @@ export interface BaseTooltipConfig<T = TooltipContentType> {
   adjustPosition?: (positionInfo: TooltipPositionInfo) => TooltipPosition;
   // Custom tooltip mount container
   getContainer?: () => HTMLElement;
+  // Extra tooltip class name
+  containerClassName?: string;
+  // Extra tooltip style
+  containerStyle?: CSS.Properties;
 }
 
 export interface TooltipPositionInfo {

--- a/packages/s2-core/src/ui/tooltip/index.less
+++ b/packages/s2-core/src/ui/tooltip/index.less
@@ -5,6 +5,8 @@
     position: fixed;
     min-width: 200px;
     max-width: 640px;
+    max-height: 100vh;
+    overflow: auto;
     z-index: 1024;
     display: inline-block;
     background: rgba(255, 255, 255, 0.96);

--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -154,8 +154,8 @@ export class BaseTooltip {
       const container = document.createElement('div');
 
       setTooltipContainerStyle(container, {
-        style: tooltip.containerStyle,
-        className: [TOOLTIP_CONTAINER_CLS, tooltip.containerClassName],
+        style: tooltip.style,
+        className: [TOOLTIP_CONTAINER_CLS, tooltip.className],
       });
 
       rootContainer.appendChild(container);

--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -12,8 +12,9 @@ import type { SpreadSheet } from '../../sheet-type';
 import {
   getAutoAdjustPosition,
   getTooltipDefaultOptions,
-  setContainerStyle,
+  setTooltipContainerStyle,
 } from '../../utils/tooltip';
+
 import './index.less';
 
 /**
@@ -57,13 +58,13 @@ export class BaseTooltip {
       y,
     };
 
-    setContainerStyle(container, {
+    setTooltipContainerStyle(container, {
       style: {
         left: `${this.position?.x}px`,
         top: `${this.position?.y}px`,
         pointerEvents: enterable ? 'all' : 'none',
       },
-      className: `${TOOLTIP_PREFIX_CLS}-container ${TOOLTIP_CONTAINER_CLS}-show`,
+      visible: true,
     });
   }
 
@@ -74,11 +75,11 @@ export class BaseTooltip {
       return;
     }
 
-    setContainerStyle(this.container, {
+    setTooltipContainerStyle(this.container, {
       style: {
         pointerEvents: 'none',
       },
-      className: `${TOOLTIP_PREFIX_CLS}-container ${TOOLTIP_CONTAINER_CLS}-hide`,
+      visible: false,
     });
     this.resetPosition();
   }
@@ -135,7 +136,7 @@ export class BaseTooltip {
     if (this.container.style.pointerEvents === 'none') {
       return;
     }
-    setContainerStyle(this.container, {
+    setTooltipContainerStyle(this.container, {
       style: {
         pointerEvents: 'none',
       },
@@ -148,10 +149,15 @@ export class BaseTooltip {
 
   private getContainer(): HTMLElement {
     if (!this.container) {
-      const rootContainer =
-        this.spreadsheet.options.tooltip.getContainer?.() || document.body;
+      const { tooltip } = this.spreadsheet.options;
+      const rootContainer = tooltip.getContainer?.() || document.body;
       const container = document.createElement('div');
-      container.className = `${TOOLTIP_PREFIX_CLS}-container`;
+
+      setTooltipContainerStyle(container, {
+        style: tooltip.containerStyle,
+        className: [TOOLTIP_CONTAINER_CLS, tooltip.containerClassName],
+      });
+
       rootContainer.appendChild(container);
 
       this.container = container;

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -30,7 +30,12 @@ import {
   PRECISION,
   VALUE_FIELD,
 } from '../common/constant';
-import { TOOLTIP_POSITION_OFFSET } from '../common/constant/tooltip';
+import {
+  TOOLTIP_CONTAINER_CLS,
+  TOOLTIP_CONTAINER_HIDE_CLS,
+  TOOLTIP_CONTAINER_SHOW_CLS,
+  TOOLTIP_POSITION_OFFSET,
+} from '../common/constant/tooltip';
 import { i18n } from '../common/i18n';
 import type {
   AutoAdjustPositionOptions,
@@ -128,27 +133,31 @@ export const getMergedQuery = (meta: ViewMeta) => {
   return { ...meta?.colQuery, ...meta?.rowQuery };
 };
 
-/**
- * add style to container
- */
-export const setContainerStyle = (
+export const setTooltipContainerStyle = (
   container: HTMLElement,
-  options: { style?: CSS.Properties; className?: string } = {
-    className: '',
+  options: {
+    visible?: boolean;
+    style?: CSS.Properties;
+    className?: string[];
   },
 ) => {
   if (!container) {
     return;
   }
-  const { style, className } = options;
+
+  const { style, className = [], visible } = options;
+
   if (style) {
-    Object.keys(style).forEach((item) => {
-      container.style[item] = style[item];
-    });
+    Object.assign(container.style, style);
   }
-  if (className) {
-    container.className = className;
+
+  if (className.length) {
+    const classList = className.filter(Boolean);
+    container.classList.add(...classList);
   }
+
+  container.classList.toggle(TOOLTIP_CONTAINER_SHOW_CLS, visible);
+  container.classList.toggle(TOOLTIP_CONTAINER_HIDE_CLS, !visible);
 };
 
 /* formate */

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -96,12 +96,6 @@ export const s2Options: S2Options = {
   interaction: {
     enableCopy: true,
   },
-  tooltip: {
-    containerStyle: {
-      fontSize: '20px',
-    },
-    containerClassName: 'test',
-  },
   style: {
     cellCfg: {
       height: 50,

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -96,6 +96,12 @@ export const s2Options: S2Options = {
   interaction: {
     enableCopy: true,
   },
+  tooltip: {
+    containerStyle: {
+      fontSize: '20px',
+    },
+    containerClassName: 'test',
+  },
   style: {
     cellCfg: {
       height: 50,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -130,8 +130,8 @@ const partDrillDown: PartDrillDown = {
 const CustomTooltip = () => (
   <div>
     自定义 Tooltip <div>1</div>
-    <div>2</div>
-    <DatePicker.RangePicker getPopupContainer={(t) => t.parentElement} />
+    <div style={{ width: 1000, height: 2000 }}>我很宽很长</div>
+    <DatePicker.RangePicker getPopupContainer={(node) => node.parentElement} />
   </div>
 );
 

--- a/s2-site/docs/common/tooltip.zh.md
+++ b/s2-site/docs/common/tooltip.zh.md
@@ -20,6 +20,8 @@ object **必选**,_default：null_ 功能描述： tooltip 配置
 | autoAdjustBoundary | 当 tooltip 超过边界时自动调整显示位置，container: 图表区域，body: 整个浏览器窗口，设置为 `null` 可关闭此功能 | `container` \| `body`                   | `body` |      |
 | adjustPosition | 自定义 tooltip 位置，| (positionInfo: [TooltipPositionInfo](#tooltippositioninfo) ) => {x: number, y: number}                  |  |      |
 | getContainer | 自定义 tooltip 挂载容器，| `() => HTMLElement`                   | `document.body` |      |
+| containerClassName | 额外的容器类名，| `string`                   | - |      |
+| containerStyle | 额外的容器样式，| [CSSProperties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Properties_Reference)                   | - |      |
 
 ### BaseTooltipConfig
 

--- a/s2-site/docs/common/tooltip.zh.md
+++ b/s2-site/docs/common/tooltip.zh.md
@@ -20,8 +20,8 @@ object **必选**,_default：null_ 功能描述： tooltip 配置
 | autoAdjustBoundary | 当 tooltip 超过边界时自动调整显示位置，container: 图表区域，body: 整个浏览器窗口，设置为 `null` 可关闭此功能 | `container` \| `body`                   | `body` |      |
 | adjustPosition | 自定义 tooltip 位置，| (positionInfo: [TooltipPositionInfo](#tooltippositioninfo) ) => {x: number, y: number}                  |  |      |
 | getContainer | 自定义 tooltip 挂载容器，| `() => HTMLElement`                   | `document.body` |      |
-| containerClassName | 额外的容器类名，| `string`                   | - |      |
-| containerStyle | 额外的容器样式，| [CSSProperties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Properties_Reference)                   | - |      |
+| className | 额外的容器类名，| `string`                   | - |      |
+| style | 额外的容器样式，| [CSSProperties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Properties_Reference)                   | - |      |
 
 ### BaseTooltipConfig
 

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -323,10 +323,10 @@ const s2Options = {
 ```ts
 const s2Options = {
   tooltip: {
-    containerStyle: {
+    style: {
       fontSize: '20px'
     },
-    containerClassName: 'test'
+    className: 'test'
   }
 };
 ```

--- a/s2-site/docs/manual/basic/tooltip.zh.md
+++ b/s2-site/docs/manual/basic/tooltip.zh.md
@@ -316,6 +316,25 @@ const s2Options = {
 }
 ```
 
+#### 自定义 Tooltip 容器样式
+
+在 `tooltip` 容器中添加额外的 `style` 样式和 `class` 类名，可以更方便的覆盖样式
+
+```ts
+const s2Options = {
+  tooltip: {
+    containerStyle: {
+      fontSize: '20px'
+    },
+    containerClassName: 'test'
+  }
+};
+```
+
+![preview](https://gw.alipayobjects.com/zos/antfincdn/5Mk9LYotc/bb266a1d-7f8a-4876-b2b4-c633fc44efc2.png)
+
+![preview](https://gw.alipayobjects.com/zos/antfincdn/mGoP8DC5d/db963e35-dfe2-4e46-8866-aec85cbd38da.png)
+
 #### 自定义 Tooltip 类
 
 除了上面讲到的 `自定义 Tooltip 内容` 外，你还可以 `自定义 Tooltip 类` 与任意框架 (`Vue`, `Angular`, `React`) 结合


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 当tooltip内容很多超过屏幕时, 显示不全, 也无法滚动, 加上最大高度限制, 并运行滚动
2. 同时增加 containerStyle 和 containerClassName, 允许挂载自定义类名

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/174975890-09bdbe2b-e6ae-443e-9593-21173528033c.png) | ![image](https://user-images.githubusercontent.com/21015895/174975490-6e641e27-b937-4792-8115-ad0a92747016.png)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
