### PR TITLE
fix: 趋势表自定义列头数值误用数据单元格样式

### DIFF
--- a/packages/s2-react/package.json
+++ b/packages/s2-react/package.json
@@ -44,6 +44,7 @@
     "build:umd": "cross-env FORMAT=umd vite build",
     "build:analysis": "cross-env FORMAT=es ANALYSIS=true vite build",
     "build:dts": "run-s dts:*",
+    "watch": "rimraf esm && yarn build:esm -w",
     "dts:build": "tsc -p tsconfig.declaration.json",
     "dts:extract": "cross-env LIB=s2-react node ../../scripts/dts.js",
     "bundle:size": "bundlesize",


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

趋势表使用 `drawObjectText` 绘制数值列头时：
- 之前：通过 `const dataCellStyle = cell.getStyle(CellTypes.DATA_CELL)` 使用的数据单元格文字样式
- 现在：改为使用列头主题样式。

改动：
- 新增 `getDrawStyle` 函数，判断是否列头数值字段，选用不同的 cell 主题样式和 textStyle
- `getTextStyle` 更名 `getCurrentTextStyle`，复用 `getDrawStyle`  返回的 textStyle

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|    <img width="479" alt="CleanShot 2022-06-22 at 20 32 19@2x" src="https://user-images.githubusercontent.com/6716092/175029705-63d63d2a-8e09-4951-b07e-71614cfc1a9d.png">    |   <img width="494" alt="CleanShot 2022-06-22 at 20 29 57@2x" src="https://user-images.githubusercontent.com/6716092/175029273-c61003ab-8456-4cdc-941d-88681a8decb2.png">     |
