### PR TITLE
feat: 明细表的 getCellData 可获取单行数据

### DIFF
--- a/packages/s2-core/__tests__/unit/data-set/table-data-set-spec.ts
+++ b/packages/s2-core/__tests__/unit/data-set/table-data-set-spec.ts
@@ -105,6 +105,18 @@ describe('Table Mode Dataset Test', () => {
     test('getCellData function', () => {
       expect(
         dataSet.getCellData({
+          query: { rowIndex: 0 },
+        }),
+      ).toEqual({
+        city: '杭州市',
+        number: 7789,
+        province: '浙江省',
+        sub_type: '桌子',
+        type: '家具',
+      });
+
+      expect(
+        dataSet.getCellData({
           query: {
             rowIndex: 0,
             col: 'city',

--- a/packages/s2-core/src/data-set/table-data-set.ts
+++ b/packages/s2-core/src/data-set/table-data-set.ts
@@ -149,7 +149,13 @@ export class TableDataSet extends BaseDataSet {
     if (this.displayData.length === 0 && query.rowIndex === 0) {
       return;
     }
-    return this.displayData[query.rowIndex][query.col];
+
+    const rowData = this.displayData[query.rowIndex];
+
+    if (!('col' in query)) {
+      return rowData;
+    }
+    return rowData[query.col];
   }
 
   public getMultiData(query: DataType, isTotals?: boolean): DataType[] {

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -152,7 +152,7 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
       const { valueField: key, data: record } = cellData;
       this.spreadsheet.emit(S2Event.GLOBAL_LINK_FIELD_JUMP, {
         key,
-        record,
+        record: Object.assign({ rowIndex: cellData.rowIndex }, record),
       });
     }
   }

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -269,6 +269,7 @@ function MainLayout() {
     );
     s2Ref.current?.on(S2Event.GLOBAL_LINK_FIELD_JUMP, (data) => {
       logHandler('🔗链接跳转 data:')(data);
+
       window.open(
         'https://s2.antv.vision/en/docs/manual/advanced/interaction/link-jump#%E6%A0%87%E8%AE%B0%E9%93%BE%E6%8E%A5%E5%AD%97%E6%AE%B5',
       );
@@ -780,14 +781,14 @@ function MainLayout() {
                   onChange={setShowCustomTooltip}
                 />
                 <Switch
-                  checkedChildren="无链接跳转"
-                  unCheckedChildren="打开链接跳转"
+                  checkedChildren="打开链接跳转"
+                  unCheckedChildren="无链接跳转"
                   checked={showJumpLink}
                   onChange={(checked) => {
                     setShowJumpLink(checked);
                     updateOptions({
                       interaction: {
-                        linkFields: checked ? ['province', 'city'] : null,
+                        linkFields: checked ? ['province', 'city'] : [],
                       },
                     });
                   }}

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -150,6 +150,7 @@ function MainLayout() {
   });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
+  const [showJumpLink, setShowJumpLink] = React.useState(false);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
     React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);
@@ -266,6 +267,12 @@ function MainLayout() {
       S2Event.DATA_CELL_TREND_ICON_CLICK,
       logHandler('趋势图点击'),
     );
+    s2Ref.current?.on(S2Event.GLOBAL_LINK_FIELD_JUMP, (data) => {
+      logHandler('🔗链接跳转 data:')(data);
+      window.open(
+        'https://s2.antv.vision/en/docs/manual/advanced/interaction/link-jump#%E6%A0%87%E8%AE%B0%E9%93%BE%E6%8E%A5%E5%AD%97%E6%AE%B5',
+      );
+    });
   }, [sheetType]);
 
   useUpdateEffect(() => {
@@ -771,6 +778,19 @@ function MainLayout() {
                   unCheckedChildren="默认Tooltip"
                   checked={showCustomTooltip}
                   onChange={setShowCustomTooltip}
+                />
+                <Switch
+                  checkedChildren="无链接跳转"
+                  unCheckedChildren="打开链接跳转"
+                  checked={showJumpLink}
+                  onChange={(checked) => {
+                    setShowJumpLink(checked);
+                    updateOptions({
+                      interaction: {
+                        linkFields: checked ? ['province', 'city'] : null,
+                      },
+                    });
+                  }}
                 />
               </Space>
             </Collapse.Panel>


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot
feat: 明细表的 getCellData 可获取单行数据
fix: 明细模式下返回值 对齐 聚合模式，添加 rowIndex

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
