### PR TITLE
docs: 修改透视表文档

### DIFF
--- a/s2-site/docs/manual/basic/sheet-type/pivot-mode.zh.md
+++ b/s2-site/docs/manual/basic/sheet-type/pivot-mode.zh.md
@@ -57,7 +57,7 @@ const data = [
 // 2. 配置数据
 const dataCfg = {
   fields: {
-    rows: ["province", "city"]
+    rows: ["province", "city"],
     columns: ["type", "sub_type"],
     values: ["price"]
   },


### PR DESCRIPTION
🐛 基础教程中的表形态透视表的 React组件方式中，dataCfg  对象内少了一个 `,` 会导致报错


