### PR TITLE
fix(interaction): 修复按下快捷选中按钮之后通过触摸板切换页面，快捷键状态没有reset的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
@@ -227,4 +227,13 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
 
     expect(s2.store.get('lastClickedCell')).toEqual(mockCell00.mockCell);
   });
+
+  test('should get correct state when reset', () => {
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.META,
+    } as KeyboardEvent);
+    expect((dataCellMultiSelection as any).isMultiSelection).toBe(true);
+    dataCellMultiSelection.reset();
+    expect((dataCellMultiSelection as any).isMultiSelection).toBe(false);
+  });
 });

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -226,4 +226,13 @@ describe('Interaction Range Selection Tests', () => {
     ).toBeTruthy();
     expect(s2.showTooltipWithInfo).toHaveBeenCalled();
   });
+
+  test('should get correct state when reset', () => {
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.SHIFT,
+    } as KeyboardEvent);
+    expect((rangeSelection as any).isMultiSelection).toBe(true);
+    rangeSelection.reset();
+    expect((rangeSelection as any).isMultiSelection).toBe(false);
+  });
 });

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -231,8 +231,8 @@ describe('Interaction Range Selection Tests', () => {
     s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
       key: InteractionKeyboardKey.SHIFT,
     } as KeyboardEvent);
-    expect((rangeSelection as any).isMultiSelection).toBe(true);
+    expect((rangeSelection as any).isRangeSelection).toBe(true);
     rangeSelection.reset();
-    expect((rangeSelection as any).isMultiSelection).toBe(false);
+    expect((rangeSelection as any).isRangeSelection).toBe(false);
   });
 });

--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -613,4 +613,16 @@ describe('RootInteraction Tests', () => {
       });
     },
   );
+
+  test('should reset interaction when visibilitychange', () => {
+    rootInteraction = new RootInteraction(mockSpreadSheetInstance);
+    rootInteraction.interactions.forEach((interaction) => {
+      interaction.reset = jest.fn();
+    });
+    window.dispatchEvent(new Event('visibilitychange'));
+
+    rootInteraction.interactions.forEach((interaction) => {
+      expect(interaction.reset).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/s2-core/src/interaction/base-event.ts
+++ b/packages/s2-core/src/interaction/base-event.ts
@@ -12,5 +12,7 @@ export abstract class BaseEvent {
     this.bindEvents();
   }
 
+  reset() {}
+
   public abstract bindEvents(): void;
 }

--- a/packages/s2-core/src/interaction/data-cell-multi-selection.ts
+++ b/packages/s2-core/src/interaction/data-cell-multi-selection.ts
@@ -26,6 +26,11 @@ export class DataCellMultiSelection
     this.bindKeyboardUp();
   }
 
+  public reset() {
+    this.isMultiSelection = false;
+    this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
+  }
+
   private bindKeyboardDown() {
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
@@ -41,8 +46,7 @@ export class DataCellMultiSelection
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
       if (isMultiSelectionKey(event)) {
-        this.isMultiSelection = false;
-        this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
+        this.reset();
       }
     });
   }

--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -24,6 +24,11 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
     this.bindKeyboardUp();
   }
 
+  public reset() {
+    this.isRangeSelection = false;
+    this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
+  }
+
   private bindKeyboardDown() {
     this.spreadsheet.on(
       S2Event.GLOBAL_KEYBOARD_DOWN,
@@ -39,8 +44,7 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
       if (event.key === InteractionKeyboardKey.SHIFT) {
-        this.isRangeSelection = false;
-        this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
+        this.reset();
       }
     });
   }

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -65,6 +65,7 @@ export class RootInteraction {
     this.spreadsheet = spreadsheet;
     this.registerEventController();
     this.registerInteractions();
+    window.addEventListener('visibilitychange', this.handleVisibilityChange);
   }
 
   public destroy() {
@@ -73,6 +74,7 @@ export class RootInteraction {
     this.eventController.clear();
     this.clearHoverTimer();
     this.resetState();
+    window.removeEventListener('visibilitychange', this.handleVisibilityChange);
   }
 
   public reset() {
@@ -81,6 +83,11 @@ export class RootInteraction {
     this.intercepts.clear();
     this.spreadsheet.hideTooltip();
   }
+
+  private handleVisibilityChange = () => {
+    this.interactions.get(InteractionName.RANGE_SELECTION)?.reset();
+    this.interactions.get(InteractionName.DATA_CELL_MULTI_SELECTION)?.reset();
+  };
 
   public setState(interactionStateInfo: InteractionStateInfo) {
     setState(this.spreadsheet, interactionStateInfo);

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -65,7 +65,10 @@ export class RootInteraction {
     this.spreadsheet = spreadsheet;
     this.registerEventController();
     this.registerInteractions();
-    window.addEventListener('visibilitychange', this.handleVisibilityChange);
+    window.addEventListener(
+      'visibilitychange',
+      this.onTriggerInteractionsResetEffect,
+    );
   }
 
   public destroy() {
@@ -74,7 +77,10 @@ export class RootInteraction {
     this.eventController.clear();
     this.clearHoverTimer();
     this.resetState();
-    window.removeEventListener('visibilitychange', this.handleVisibilityChange);
+    window.removeEventListener(
+      'visibilitychange',
+      this.onTriggerInteractionsResetEffect,
+    );
   }
 
   public reset() {
@@ -84,9 +90,10 @@ export class RootInteraction {
     this.spreadsheet.hideTooltip();
   }
 
-  private handleVisibilityChange = () => {
-    this.interactions.get(InteractionName.RANGE_SELECTION)?.reset();
-    this.interactions.get(InteractionName.DATA_CELL_MULTI_SELECTION)?.reset();
+  private onTriggerInteractionsResetEffect = () => {
+    this.interactions.forEach((interaction) => {
+      interaction.reset();
+    });
   };
 
   public setState(interactionStateInfo: InteractionStateInfo) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

复现场景
在使用meta键或者shift键进行单元格多选的时候，如果通过触控板切换桌面，会导致快捷键的状态没有取消，之后再切换回当前页面的时候还是处于多选状态中

场景预期
切换会桌面的时候，多选状态会被清除，重新点击变成单选。

解决方案
监听window的visibilitychange事件，change之后将DataCellMultiSelection和 RangeSelection的状态reset（只有这两个交互设计到键盘事件和鼠标事件叠加状态）

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
