### PR TITLE
fix(interaction): 修复链接跳转会触发单选和 Tooltip 显示的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -137,6 +137,38 @@ describe('Interaction Row & Column Cell Click Tests', () => {
     },
   );
 
+  test('should emit link field jump event when row cell clicked and not show tooltip', () => {
+    const linkFieldJump = jest.fn();
+
+    s2.on(S2Event.GLOBAL_LINK_FIELD_JUMP, linkFieldJump);
+
+    const selectHeaderCellSpy = jest
+      .spyOn(s2.interaction, 'selectHeaderCell')
+      .mockImplementationOnce(() => false);
+
+    const mockCellData = {
+      valueField: 'valueField',
+      data: { a: 1 },
+    };
+
+    s2.emit(S2Event.ROW_CELL_CLICK, {
+      stopPropagation() {},
+      target: {
+        attrs: {
+          appendInfo: {
+            cellData: mockCellData,
+            isLinkFieldText: true,
+          },
+        },
+      },
+    } as unknown as GEvent);
+
+    expect(linkFieldJump).toHaveBeenCalledTimes(1);
+    expect(s2.showTooltipWithInfo).not.toHaveBeenCalled();
+    expect(s2.showTooltip).not.toHaveBeenCalled();
+    expect(selectHeaderCellSpy).not.toHaveBeenCalled();
+  });
+
   test.each([S2Event.ROW_CELL_CLICK, S2Event.COL_CELL_CLICK])(
     'should emit cell selected event when %s clicked',
     (event) => {
@@ -172,7 +204,7 @@ describe('Interaction Row & Column Cell Click Tests', () => {
       result: true,
     },
   ])(
-    'should emit cell selected event when %s clicked111',
+    'should emit cell selected event when %s clicked with multi selection',
     ({ event, enableMultiSelection, result }) => {
       s2.options.interaction.multiSelection = enableMultiSelection;
 

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-text-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-text-click-spec.ts
@@ -56,7 +56,7 @@ describe('Interaction Row Text Click Tests', () => {
       target: {
         attrs: {
           appendInfo: {
-            isRowHeaderText: true,
+            isLinkFieldText: true,
             cellData,
           },
         },
@@ -99,7 +99,7 @@ describe('Interaction Row Text Click Tests', () => {
       target: {
         attrs: {
           appendInfo: {
-            isRowHeaderText: true,
+            isLinkFieldText: true,
             cellData,
           },
         },

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -233,7 +233,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       fill: linkFillColor,
       cursor: 'pointer',
       appendInfo: {
-        isRowHeaderText: true, // 标记为行头(明细表行头其实就是Data Cell)文本，方便做链接跳转直接识别
+        isLinkFieldText: true, // 标记为行头(明细表行头其实就是Data Cell)文本，方便做链接跳转直接识别
         cellData: this.meta,
       },
     });

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -101,7 +101,7 @@ export class RowCell extends HeaderCell {
 
   protected showTreeLeafNodeAlignDot() {
     return (
-      get(this.spreadsheet, 'options.style.showTreeLeafNodeAlignDot') &&
+      this.spreadsheet.options.style?.showTreeLeafNodeAlignDot &&
       this.spreadsheet.isHierarchyTreeType()
     );
   }

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -444,7 +444,7 @@ export interface OffsetConfig {
 }
 
 export interface CellAppendInfo<T = Node> extends Partial<ResizeInfo> {
-  isRowHeaderText?: boolean;
+  isLinkFieldText?: boolean;
   cellData?: T;
 }
 

--- a/packages/s2-core/src/interaction/base-event.ts
+++ b/packages/s2-core/src/interaction/base-event.ts
@@ -1,3 +1,5 @@
+import type { Event as CanvasEvent } from '@antv/g-canvas';
+import type { CellAppendInfo } from '../common';
 import type { SpreadSheet } from '../sheet-type';
 
 export interface BaseEventImplement {
@@ -11,6 +13,19 @@ export abstract class BaseEvent {
     this.spreadsheet = spreadsheet;
     this.bindEvents();
   }
+
+  public getCellAppendInfo<T extends Record<string, any> = CellAppendInfo>(
+    eventTarget: CanvasEvent['target'],
+  ): T {
+    return (
+      eventTarget?.attr?.('appendInfo') || eventTarget?.attrs?.appendInfo || {}
+    );
+  }
+
+  public isLinkFieldText = (eventTarget: CanvasEvent['target']) => {
+    const cellAppendInfo = this.getCellAppendInfo(eventTarget);
+    return cellAppendInfo?.isLinkFieldText;
+  };
 
   public abstract bindEvents(): void;
 }

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -73,6 +73,10 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
   private handleRowColClick = (event: CanvasEvent) => {
     event.stopPropagation();
 
+    if (this.isLinkFieldText(event.target)) {
+      return;
+    }
+
     const { interaction, options } = this.spreadsheet;
     const cell = this.spreadsheet.getCell(event.target);
 

--- a/packages/s2-core/src/interaction/base-interaction/click/row-text-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-text-click.ts
@@ -18,22 +18,19 @@ export class RowTextClick extends BaseEvent implements BaseEventImplement {
       if (this.spreadsheet.interaction.hasIntercepts([InterceptType.CLICK])) {
         return;
       }
-      const appendInfo = get(
-        event.target,
-        'attrs.appendInfo',
-        {},
-      ) as CellAppendInfo;
 
-      if (appendInfo.isRowHeaderText) {
-        const { cellData } = appendInfo;
-        const key = cellData.key;
-        const rowData = this.getRowData(cellData);
-
-        this.spreadsheet.emit(S2Event.GLOBAL_LINK_FIELD_JUMP, {
-          key,
-          record: rowData,
-        });
+      if (!this.isLinkFieldText(event.target)) {
+        return;
       }
+
+      const { cellData } = this.getCellAppendInfo(event.target);
+      const key = cellData.key;
+      const rowData = this.getRowData(cellData);
+
+      this.spreadsheet.emit(S2Event.GLOBAL_LINK_FIELD_JUMP, {
+        key,
+        record: rowData,
+      });
     });
   }
 

--- a/packages/s2-core/src/interaction/base-interaction/hover.ts
+++ b/packages/s2-core/src/interaction/base-interaction/hover.ts
@@ -66,8 +66,9 @@ export class HoverEvent extends BaseEvent implements BaseEventImplement {
   ) {
     const { interaction } = this.spreadsheet;
     const { interaction: interactionOptions } = this.spreadsheet.options;
-    interaction.clearHoverTimer();
     const { hoverFocus } = interactionOptions;
+
+    interaction.clearHoverTimer();
 
     const handleHoverFocus = () => {
       if (interaction.hasIntercepts([InterceptType.HOVER])) {

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -143,8 +143,8 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
   private bindMouseDown() {
     this.spreadsheet.on(S2Event.LAYOUT_RESIZE_MOUSE_DOWN, (event) => {
       const shape = event.target as IGroup;
-      const resizeInfo: ResizeInfo = shape?.attr('appendInfo');
       const originalEvent = event.originalEvent as MouseEvent;
+      const resizeInfo = this.getCellAppendInfo<ResizeInfo>(event.target);
       this.spreadsheet.store.set('resized', false);
 
       if (!resizeInfo?.isResizeArea) {
@@ -440,7 +440,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
   }
 
   private getResizeInfo(): ResizeInfo {
-    return this.resizeTarget?.attr('appendInfo');
+    return this.getCellAppendInfo<ResizeInfo>(this.resizeTarget);
   }
 
   private render() {

--- a/packages/s2-core/src/utils/interaction/formatter.ts
+++ b/packages/s2-core/src/utils/interaction/formatter.ts
@@ -3,14 +3,14 @@ import type { S2CellType, TargetCellInfo } from '../../common/interface';
 import type { Node } from '../../facet/layout/node';
 
 /* formate the base Event data */
-export const getBaseCellData = (ev: Event): TargetCellInfo => {
-  const currentCellData: Node = ev.target?.attrs?.appendInfo?.cellData;
-  const target = ev.target.get?.('parent') as S2CellType;
+export const getBaseCellData = (event: Event): TargetCellInfo => {
+  const currentCellData: Node = event.target?.attrs?.appendInfo?.cellData;
+  const target = event.target.get?.('parent') as S2CellType;
   const meta = (target?.getMeta?.() as Node) || currentCellData;
 
   return {
     target,
     viewMeta: meta,
-    event: ev,
+    event,
   };
 };

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -149,7 +149,6 @@ function MainLayout() {
   });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
-  const [showJumpLink, setShowJumpLink] = React.useState(false);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
     React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);
@@ -770,9 +769,8 @@ function MainLayout() {
                 <Switch
                   checkedChildren="打开链接跳转"
                   unCheckedChildren="无链接跳转"
-                  checked={showJumpLink}
+                  checked={mergedOptions.interaction.linkFields.length}
                   onChange={(checked) => {
-                    setShowJumpLink(checked);
                     updateOptions({
                       interaction: {
                         linkFields: checked ? ['province', 'city'] : [],


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 点击 rowCell 和 dataCell 的链接文字时, 会触发相应自身的交互, 如单选, 显示 tooltip 等, 应该过滤
2. `isRowHeaderText` 重命名为 `isLinkFieldText`

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/175915710-52aa33db-df87-40f9-a4ac-293aca041933.png) | ![image](https://user-images.githubusercontent.com/21015895/175915644-e5c530aa-58d1-4ae9-bf6b-ca21824047d7.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
