### PR TITLE
fix: 列头文字&icon无法正确对齐

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
@@ -312,7 +312,7 @@ describe('SpreadSheet Theme Tests', () => {
 
         expectTextAlign({
           textAlign,
-          fontWight: 520,
+          fontWight: 500,
           customNodes: isRowCell ? rowTotalNodes : colTotalNodes,
         });
       },

--- a/packages/s2-core/__tests__/unit/cell/col-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/col-cell-spec.ts
@@ -1,0 +1,108 @@
+import _ from 'lodash';
+import type { Node } from '@/facet/layout/node';
+import { PivotDataSet } from '@/data-set';
+import { SpreadSheet, PivotSheet } from '@/sheet-type';
+import { ColCell } from '@/cell';
+import type { TextAlign } from '@/common';
+
+const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
+const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
+
+describe('Col Cell Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    const container = document.createElement('div');
+
+    s2 = new MockPivotSheet(container);
+    const dataSet: PivotDataSet = new MockPivotDataSet(s2);
+    s2.dataSet = dataSet;
+  });
+
+  describe('None-leaf Nodes Tests', () => {
+    const node = {
+      isLeaf: false,
+      x: 0,
+      y: 0,
+      height: 30,
+      width: 200,
+    } as unknown as Node;
+
+    const headerConfig = {
+      width: 500, // col header width
+      scrollContainsRowHeader: true,
+      cornerWidth: 100,
+      scrollX: 30, // 模拟滚动了 30px
+    };
+
+    const actualTextWidth = 40; // 文字长度
+
+    test.each([
+      ['left', 8], // col.padding.left
+      ['center', 100], // col.width / 2
+      ['right', 192], // col.width - col.padding.right
+    ])(
+      'should calc node text position in %s align mode',
+      (textAlign: TextAlign, textX: number) => {
+        s2.setThemeCfg({
+          theme: {
+            colCell: {
+              bolderText: {
+                textAlign,
+              },
+            },
+          },
+        });
+
+        const colCell = new ColCell(node, s2, { ...headerConfig });
+        _.set(colCell, 'actualTextWidth', actualTextWidth); // 文字总长度
+
+        const getTextPosition = _.get(colCell, 'getTextPosition').bind(colCell);
+        expect(getTextPosition()).toEqual({
+          x: textX,
+          y: 15,
+        });
+      },
+    );
+
+    test.each([
+      ['left', 52], // col.padding.left + actualTextWidth + icon.margin.left
+      ['center', 115], // col.width / 2 + (actualTextWidth + icon.margin.left + icon.width + icon.margin.right) / 2  - (icon.width + icon.margin.right)
+      ['right', 178], // col.width - col.padding.right - icon.margin.right - icon.width
+    ])(
+      'should calc icon position in %s align mode',
+      (textAlign: TextAlign, iconX: number) => {
+        s2.setThemeCfg({
+          theme: {
+            colCell: {
+              bolderText: {
+                textAlign,
+              },
+            },
+          },
+        });
+        s2.setOptions({
+          headerActionIcons: [
+            {
+              iconNames: ['SortUp'],
+              belongsCell: 'colCell',
+              displayCondition: (meta) => {
+                return !meta.isLeaf;
+              },
+              action: () => true,
+            },
+          ],
+        });
+
+        const colCell = new ColCell(node, s2, { ...headerConfig });
+        _.set(colCell, 'actualTextWidth', actualTextWidth); // 文字总长度
+
+        const getIconPosition = _.get(colCell, 'getIconPosition').bind(colCell);
+        expect(getIconPosition()).toEqual({
+          x: iconX,
+          y: 10,
+        });
+      },
+    );
+  });
+});

--- a/packages/s2-core/__tests__/unit/utils/text-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/text-spec.ts
@@ -38,7 +38,8 @@ describe('Text Utils Tests', () => {
       placeholder: '--',
     });
 
-    expect(text).toEqual('12...');
+    expect(text).toEndWith('...');
+    expect(text.length).toBeLessThanOrEqual(5);
   });
 
   test('should get correct placeholder text with ""', () => {
@@ -73,10 +74,11 @@ describe('Text Utils Tests', () => {
   test('should get correct ellipsis text', () => {
     const text = getEllipsisText({
       text: '长度测试',
-      maxWidth: 20,
+      maxWidth: 24,
     });
 
-    expect(text).toEqual('长...');
+    expect(text).toEndWith('...');
+    expect(text.length).toBeLessThanOrEqual(4);
   });
 
   test('should get correct text width', () => {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -65,7 +65,7 @@ import {
   getSafetyOptions,
 } from '../utils/merge';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
-import { removeOffscreenCanvas } from '@/utils/canvas';
+import { removeOffscreenCanvas } from '../utils/canvas';
 
 export abstract class SpreadSheet extends EE {
   // theme config

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -65,6 +65,7 @@ import {
   getSafetyOptions,
 } from '../utils/merge';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
+import { removeOffscreenCanvas } from '@/utils/canvas';
 
 export abstract class SpreadSheet extends EE {
   // theme config
@@ -402,6 +403,8 @@ export abstract class SpreadSheet extends EE {
     this.destroyTooltip();
     this.clearCanvasEvent();
     this.container?.destroy();
+
+    removeOffscreenCanvas();
   }
 
   /**

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -93,7 +93,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 520,
+        fontWeight: isWindows() ? 'bold' : 500,
         fill: basicColors[14],
         linkTextFill: basicColors[6],
         opacity: 1,
@@ -183,7 +183,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 520,
+        fontWeight: isWindows() ? 'bold' : 500,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'center',
@@ -263,7 +263,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 520,
+        fontWeight: isWindows() ? 'bold' : 500,
         fill: basicColors[13],
         opacity: 1,
         textAlign: 'right',

--- a/packages/s2-core/src/utils/canvas.ts
+++ b/packages/s2-core/src/utils/canvas.ts
@@ -1,0 +1,30 @@
+const OFFSCREEN_CANVAS_DOM_ID = 's2-offscreen-canvas';
+
+/**
+ * 获取工具 canvas
+ * 需要把 canvas 插入到 body 下，继承全局的 css 样式（如 letter-spacing）
+ * 否则后续的 measureText 与实际渲染会有较大差异
+ */
+export const getOffscreenCanvas = () => {
+  let canvas = document.getElementById(
+    OFFSCREEN_CANVAS_DOM_ID,
+  ) as HTMLCanvasElement;
+  if (canvas) {
+    return canvas;
+  }
+
+  canvas = document.createElement('canvas');
+  canvas.id = OFFSCREEN_CANVAS_DOM_ID;
+  canvas.style.display = 'none';
+
+  document.body.appendChild(canvas);
+
+  return canvas;
+};
+
+/**
+ * 移除工具 canvas
+ */
+export const removeOffscreenCanvas = () => {
+  document.getElementById(OFFSCREEN_CANVAS_DOM_ID)?.remove();
+};

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -179,14 +179,14 @@ export const getTextPosition = (
 ) => getTextAndFollowingIconPosition(contentBox, textCfg).text;
 
 /**
- * 在给定视窗和单元格的情况下，计算单元格文字实际绘制位置
+ * 在给定视窗和单元格的情况下，计算单元格文字区域的坐标信息
  * 计算遵循原则：
  * 1. 若可视范围小，尽可能多展示文字
  * 2. 若可视范围大，居中展示文字
  * @param viewport 视窗坐标信息
  * @param content content 列头单元格 content 区域坐标信息
  * @param textWidth 文字实际绘制区域宽度（含icon）
- * @returns 文字绘制位置
+ * @returns 文字绘制位置（start 为文字区域的中点坐标值）
  */
 export const getTextAreaRange = (
   viewport: AreaRange,
@@ -333,7 +333,7 @@ export const getBorderPositionAndStyle = (
  *
  * 以 textAlign=left 情况为例，由大到小的矩形分别是 viewport、cellContent、cellText
  * 左图是未调整前，滚动相交判定在 viewport 最左侧，即 colCell 滚动到 viewport 左侧后，文字会贴左边绘制
- * 右图是调整后，range.start 提前了 padding.left 个元素，文字与 viewport 有一定间隙更加美观
+ * 右图是调整后，range.start 提前了 padding.left 个像素，文字与 viewport 有一定间隙更加美观
  *
  *    range.start                                   range.start
  *         |                                             |
@@ -375,29 +375,51 @@ export const adjustColHeaderScrollingViewport = (
 };
 
 /**
- * 根据文字样式调整绘制的起始点（底层g始终使用 center 样式绘制）
- * @param startX
- * @param restWidth
- * @param textAlign
- * @returns
+ * 根据文字样式计算文字实际绘制起始
+ *
+ * 以 textAlign=left 为例，g 绘制时取 text 最左侧的坐标值作为基准坐标
+ *
+ * 计算前：                                        计算后：
+ * startX = textAreaRange.start = 中心点           startX = 最左侧坐标
+ *
+ *        textAreaRange.start                     startX
+ *                |                                |
+ *                v                                v
+ *  +----------------------------+                +----------------------------+
+ *  |    +------------------+    |                |+------------------+        |
+ *  |    |   text    | icon |    |                ||   text    | icon |        |
+ *  |    +------------------+    |                |+------------------+        |
+ *  +----------------------------+                +----------------------------+
+ *       <------------------>
+ *         textAndIconSpace
+ *  <---------------------------->
+ *        textAreaRange.width
+ *
+ * @param textAreaRange 文本&icon 绘制坐标
+ * @param actualTextWidth 文本实际宽度
+ * @param actionIconSpace icon 区域实际宽度
+ * @param textAlign 对齐样式
+ * @returns 文字绘制起点坐标
  */
 export const adjustColHeaderScrollingTextPosition = (
-  startX: number,
-  restWidth: number,
+  textAreaRange: AreaRange,
+  actualTextWidth: number,
+  actionIconSpace: number,
   textAlign: TextAlign,
 ) => {
-  if (restWidth <= 0) {
-    // 没有足够的空间用于调整
-    return startX;
+  const textAndIconSpace = actualTextWidth + actionIconSpace;
+  const startX = textAreaRange.start; // 文本&icon 区域中心点坐标 x
+
+  if (textAlign === 'center') {
+    return startX - actionIconSpace / 2;
   }
 
-  switch (textAlign) {
-    case 'left':
-      return startX - restWidth / 2;
-    case 'right':
-      return startX + restWidth / 2;
-    case 'center':
-    default:
-      return startX;
-  }
+  const hasEnoughWidth = textAreaRange.width - textAndIconSpace > 0;
+  const offset = hasEnoughWidth
+    ? textAreaRange.width / 2
+    : textAndIconSpace / 2;
+
+  return textAlign === 'left'
+    ? startX - offset
+    : startX + offset - actionIconSpace;
 };

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -23,10 +23,8 @@ import type {
 } from '../common/interface';
 import type { TextTheme } from '../common/interface/theme';
 import { renderText } from '../utils/g-renders';
+import { getOffscreenCanvas } from './canvas';
 import { renderChart } from './g-mini-charts';
-
-const canvas = document.createElement('canvas');
-const ctx = canvas.getContext('2d');
 
 /**
  * 计算文本在画布中的宽度
@@ -36,6 +34,8 @@ export const measureTextWidth = memoize(
     if (!font) {
       return 0;
     }
+    const ctx = getOffscreenCanvas().getContext('2d');
+
     const { fontSize, fontFamily, fontWeight, fontStyle, fontVariant } =
       font as CSSStyleDeclaration;
     // copy G 里面的处理逻辑


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #1481 

### 📝 Description
列头文字&icon 无法正确对齐，主要原因有：
- `measureText` 中 canvas 没有渲染到 dom 数，无法继承 body 上的 css 样式，导致估计值与实际值有差距
- 最早的列头 col.ts 绘制文字时，只有 center 样式，即提供给 `g` 文字中心点位置即可。后支持了 `left`、`right` 绘制，但是 `getTextPosition` 等依旧计算的是中心点，导致有偏移效果。

### 🖼️ Screenshot
以 `textAlign=right` 为例，以下 demo 分别为不带 icon 和带 icon

| Before | After |
| ------ | ----- |
| ![CleanShot 2022-07-04 at 11 11 17](https://user-images.githubusercontent.com/6716092/177075028-5dd5f7fb-d9b2-45a4-9012-86bb6d616496.gif) | ![CleanShot 2022-07-04 at 11 08 32](https://user-images.githubusercontent.com/6716092/177074754-13fc5963-cd9b-4575-b665-baf1001be69a.gif) |
| ![CleanShot 2022-07-04 at 11 12 27](https://user-images.githubusercontent.com/6716092/177075142-3d811223-5a5d-45d5-9dd8-0185e66747ad.gif)      |   ![CleanShot 2022-07-04 at 11 07 43](https://user-images.githubusercontent.com/6716092/177074671-338071d3-8e9a-4fd6-a3eb-b5aa534ce280.gif)     |

### 🔍 Self-Check before the merge

- [x] Add or update test case.
