### PR TITLE
fix(strategysheet): 修复趋势分析表无法自定义 Tooltip

### DIFF
--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { type SpreadSheet, type S2DataConfig } from '@antv/s2';
+import { SheetComponent, SheetComponentsProps } from '../../../../src';
+import { getContainer } from '../../../util/helpers';
+
+describe('<SheetComponent/> Tests', () => {
+  describe('<StrategySheet/> Tests', () => {
+    let s2: SpreadSheet;
+    let container: HTMLDivElement;
+
+    const renderStrategySheet = (
+      options: SheetComponentsProps['options'],
+      dataCfg: S2DataConfig = null,
+    ) => {
+      act(() => {
+        ReactDOM.render(
+          <SheetComponent
+            sheetType="strategy"
+            options={options}
+            dataCfg={dataCfg}
+            getSpreadSheet={(instance) => {
+              s2 = instance;
+            }}
+          />,
+          container,
+        );
+      });
+    };
+
+    beforeEach(() => {
+      container = getContainer();
+    });
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(container);
+      container.remove();
+    });
+
+    test('should overwrite strategy sheet tooltip data cell content', () => {
+      const content = 'custom';
+
+      const s2Options: SheetComponentsProps['options'] = {
+        tooltip: {
+          data: {
+            content,
+          },
+        },
+      };
+
+      renderStrategySheet(s2Options);
+
+      expect(s2.options.tooltip.data.content).toEqual(content);
+    });
+
+    test('should replace hierarchyType with "customTree" when rows is empty and contains custom tree items', () => {
+      const s2Options: SheetComponentsProps['options'] = {
+        hierarchyType: 'grid',
+      };
+
+      const s2DataConfig: S2DataConfig = {
+        fields: {
+          rows: [],
+          customTreeItems: [
+            {
+              key: '1',
+              title: '1',
+            },
+          ],
+        },
+      };
+
+      renderStrategySheet(s2Options, s2DataConfig);
+
+      expect(s2.options.hierarchyType).toEqual('customTree');
+    });
+
+    test('should hideMeasureColumn if only one value field', () => {
+      const s2Options: SheetComponentsProps['options'] = {
+        hierarchyType: 'grid',
+      };
+
+      const s2DataConfig: S2DataConfig = {
+        fields: {
+          values: ['a'],
+        },
+      };
+
+      renderStrategySheet(s2Options, s2DataConfig);
+
+      expect(s2.options.style.colCfg.hideMeasureColumn).toBeTruthy();
+    });
+
+    test('should enable hidden columns operation', () => {
+      renderStrategySheet(null);
+
+      expect(s2.options.tooltip.operation.hiddenColumns).toBeTruthy();
+    });
+
+    test.each([
+      'brushSelection',
+      'selectedCellMove',
+      'multiSelection',
+      'rangeSelection',
+    ])('should disable %s interaction', (interactionName) => {
+      renderStrategySheet(null);
+
+      expect(s2.options.interaction[interactionName]).toBeFalsy();
+    });
+  });
+});

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -1,5 +1,6 @@
+import React from 'react';
 import { isUpDataValue } from '@antv/s2';
-import type { S2DataConfig, S2Options, S2Theme } from '@antv/s2';
+import type { S2DataConfig, S2Options } from '@antv/s2';
 import { getBaseSheetComponentOptions } from '@antv/s2-shared';
 import type { SliderSingleProps } from 'antd';
 import { isNil } from 'lodash';

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -84,13 +84,14 @@ export const strategyOptions: S2Options = {
             field: 'number',
             mapping: (value, cellInfo) => {
               const { meta } = cellInfo;
-              const isNormalValue = isNil(value);
+              const isNormalValue = isNil(value) || value === '';
 
               if (meta.fieldValue.values[0][0] === value || isNormalValue) {
                 return {
                   fill: '#000',
                 };
               }
+
               return {
                 fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
               };

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -7,7 +7,6 @@ import {
   type HeaderActionIconProps,
   Node,
   type S2DataConfig,
-  S2Event,
   type S2Options,
   SpreadSheet,
   type TargetCellInfo,
@@ -279,7 +278,7 @@ function MainLayout() {
 
   //  ================== Config ========================
 
-  const mergedOptions: Partial<S2Options<React.ReactNode>> = customMerge(
+  const mergedOptions: S2Options<React.ReactNode> = customMerge(
     {},
     {
       pagination: showPagination && {
@@ -879,8 +878,8 @@ function MainLayout() {
           </Collapse>
           {render && (
             <SheetComponent
-              dataCfg={dataCfg as S2DataConfig}
-              options={mergedOptions as S2Options}
+              dataCfg={dataCfg}
+              options={mergedOptions}
               sheetType={sheetType}
               adaptive={adaptive}
               ref={s2Ref}

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
@@ -54,7 +54,7 @@ export const DataTooltip: React.FC<CustomTooltipProps> = ({ cell }) => {
           <div className={tooltipCls('divider')} />
           <ul className={tooltipCls('derived-values')}>
             {derivedValues.map((derivedValue, i) => {
-              const isNormal = isNil(derivedValue);
+              const isNormal = isNil(derivedValue) || derivedValue === '';
               const isUp = isUpDataValue(derivedValue as string);
               const isDown = !isNormal && !isUp;
 

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -126,7 +126,7 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
       return customMerge(dataCfg, defaultFields);
     }, [dataCfg]);
 
-    const s2Options = React.useMemo<SheetComponentsProps['options']>(() => {
+    const s2Options = React.useMemo<S2Options>(() => {
       return customMerge(options, strategySheetOptions);
     }, [options, strategySheetOptions]);
 

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -97,17 +97,17 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
               const meta = cell.getMeta() as ViewMeta;
               const fieldValue = meta.fieldValue as MultiData;
 
-              // 如果是数组, 说明是普通数值+同环比数据 或者 KPI数据, 显示普通数值 Tooltip
-              if (isArray(fieldValue?.values)) {
-                return <DataTooltip cell={cell} />;
-              }
-
               const tooltipContent = options.tooltip?.data
                 ?.content as TooltipShowOptions<React.ReactNode>['content'];
 
               const content = isFunction(tooltipContent)
                 ? tooltipContent?.(cell, defaultTooltipShowOptions)
                 : tooltipContent;
+
+              // 如果是数组, 说明是普通数值+同环比数据 或者 KPI数据, 显示普通数值 Tooltip
+              if (isArray(fieldValue?.values)) {
+                return content ?? <DataTooltip cell={cell} />;
+              }
 
               return content ?? <></>;
             },


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

趋势分析表本身就是对 s2-core 的 tooltip 自定义, 但是业务侧还需要对趋势分析表的 Tooltip 再次进行自定义, 所以需要暴露一个口子

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
