### PR TITLE
fix: 修复大量数据下，行列总计单元格计算时耗时和内存问题

### DIFF
--- a/packages/s2-core/src/utils/data-set-operate.ts
+++ b/packages/s2-core/src/utils/data-set-operate.ts
@@ -44,21 +44,22 @@ export const flattenDeep = (data: Record<any, any>[] | Record<any, any>) =>
   }, []);
 
 export const flatten = (data: Record<any, any>[] | Record<any, any>) => {
-  let result = [];
+  const result = [];
+
   if (Array.isArray(data)) {
-    keys(data)?.forEach((item) => {
-      const current = get(data, item);
-      const currentKeys = keys(current);
-      if (currentKeys.includes('undefined')) {
-        currentKeys.forEach((ki) => {
+    data.forEach((current) => {
+      if (current && 'undefined' in current) {
+        keys(current).forEach((ki) => {
           result.push(current[ki]);
         });
+      } else if (Array.isArray(current)) {
+        result.push(...current);
       } else {
-        result = result.concat(current);
+        result.push(current);
       }
     });
   } else {
-    result = result.concat(data);
+    result.push(data);
   }
   return result;
 };

--- a/packages/s2-core/src/utils/data-set-operate.ts
+++ b/packages/s2-core/src/utils/data-set-operate.ts
@@ -47,7 +47,7 @@ export const flatten = (data: Record<any, any>[] | Record<any, any>) => {
   const result = [];
 
   if (Array.isArray(data)) {
-    // 总计小计在数组里面，以 undefine作为key, 所以需要 keys 拿到所有字段，直接forEach的话会漏掉总计小计
+    // 总计小计在数组里面，以 undefine作为key, 直接forEach的话会漏掉总计小计
     const containsTotal = 'undefined' in data;
     const itemLength = data.length + (containsTotal ? 1 : 0);
 

--- a/packages/s2-core/src/utils/data-set-operate.ts
+++ b/packages/s2-core/src/utils/data-set-operate.ts
@@ -47,7 +47,16 @@ export const flatten = (data: Record<any, any>[] | Record<any, any>) => {
   const result = [];
 
   if (Array.isArray(data)) {
-    data.forEach((current) => {
+    // 总计小计在数组里面，以 undefine作为key, 所以需要 keys 拿到所有字段，直接forEach的话会漏掉总计小计
+    const containsTotal = 'undefined' in data;
+    const itemLength = data.length + (containsTotal ? 1 : 0);
+
+    let i = 0;
+    while (i < itemLength) {
+      // eslint-disable-next-line dot-notation
+      const current = i === data.length ? data['undefined'] : data[i];
+      i++;
+
       if (current && 'undefined' in current) {
         keys(current).forEach((ki) => {
           result.push(current[ki]);
@@ -57,7 +66,7 @@ export const flatten = (data: Record<any, any>[] | Record<any, any>) => {
       } else {
         result.push(current);
       }
-    });
+    }
   } else {
     result.push(data);
   }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1516 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
之前的`flatten`计算对于内存和性能消耗都很大，如果表格数据量特别大时，并且遇到单元格刚好是行总计和列总计的交叉单元格，s2会将所有的数据拿到然后再进行`flatten`，会直接卡死
### 🖼️ Screenshot
在64w条数据的情况下，`flatten`性能消耗：
| Before | After |
| ------ | ----- |
| ❌   卡死   |  ![image](https://user-images.githubusercontent.com/17964556/177682577-aae0072c-2502-441b-98ee-cac04e05d011.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
