### PR TITLE
fix: 优化 mini 图坐标计算逻辑

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/g-mini-charts-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/g-mini-charts-spec.ts
@@ -7,14 +7,44 @@ import {
 import { MiniChartTypes, type S2CellType } from '@/common';
 
 describe('MiniCharts Utils Tests', () => {
-  test('should get right scale of line', () => {
+  const padding = {
+    left: 8,
+    right: 8,
+    top: 4,
+    bottom: 4,
+  };
+
+  const cell = {
+    getMeta: () => {
+      return {
+        x: 0,
+        y: 0,
+        height: 108,
+        width: 208,
+      };
+    },
+    getStyle: () => {
+      return {
+        cell: {
+          padding,
+        },
+        miniChart: {
+          bar: {
+            intervalPadding: 4,
+          },
+        },
+      };
+    },
+  };
+
+  test('should get right points of line', () => {
     const chartData = {
       type: MiniChartTypes.Line,
       data: [
         { year: '2018', value: 10 },
-        { year: '2019', value: 20 },
-        { year: '2020', value: 30 },
-        { year: '2021', value: 40 },
+        { year: '2019', value: 0 },
+        { year: '2020', value: -10 },
+        { year: '2021', value: 0 },
       ],
       encode: {
         x: 'year',
@@ -22,48 +52,92 @@ describe('MiniCharts Utils Tests', () => {
       },
     };
 
-    const cell = {
-      getMeta: () => {
-        return {
-          x: 0,
-          y: 0,
-          height: 108,
-          width: 208,
-        };
-      },
-      getStyle: () => {
-        return {
-          cell: {
-            padding: {
-              left: 8,
-              right: 8,
-              top: 8,
-              bottom: 8,
-            },
-          },
-          miniChart: {
-            bar: {
-              intervalPadding: 4,
-            },
-          },
-        };
+    expect(scale(chartData, cell as S2CellType)).toEqual({
+      points: [
+        [8, 4],
+        [72, 54],
+        [136, 104],
+        [200, 54],
+      ],
+      box: [],
+    });
+  });
+
+  test('should get right points of line when all values are more then 0', () => {
+    const chartData = {
+      type: MiniChartTypes.Line,
+      data: [
+        { year: '2018', value: 10 },
+        { year: '2019', value: 5 },
+        { year: '2020', value: 5 },
+        { year: '2021', value: 5 },
+      ],
+      encode: {
+        x: 'year',
+        y: 'value',
       },
     };
 
     expect(scale(chartData, cell as S2CellType)).toEqual({
-      range: {
-        xStart: 8,
-        xEnd: 200,
-        yStart: 8,
-        yEnd: 100,
-      },
       points: [
-        [8, 77],
-        [72, 54],
-        [136, 31],
-        [200, 8],
+        [8, 4],
+        [72, 104],
+        [136, 104],
+        [200, 104],
       ],
-      intervalX: 64,
+      box: [],
+    });
+  });
+
+  test('should get right points of line when all values are less then 0', () => {
+    const chartData = {
+      type: MiniChartTypes.Line,
+      data: [
+        { year: '2018', value: -5 },
+        { year: '2019', value: -10 },
+        { year: '2020', value: -5 },
+        { year: '2021', value: -10 },
+      ],
+      encode: {
+        x: 'year',
+        y: 'value',
+      },
+    };
+
+    expect(scale(chartData, cell as S2CellType)).toEqual({
+      points: [
+        [8, 4],
+        [72, 104],
+        [136, 4],
+        [200, 104],
+      ],
+      box: [],
+    });
+  });
+
+  test('should get right points of line when all values are equal to each other', () => {
+    const chartData = {
+      type: MiniChartTypes.Line,
+      data: [
+        { year: '2018', value: 0 },
+        { year: '2019', value: 0 },
+        { year: '2020', value: 0 },
+        { year: '2021', value: 0 },
+      ],
+      encode: {
+        x: 'year',
+        y: 'value',
+      },
+    };
+
+    expect(scale(chartData, cell as S2CellType)).toEqual({
+      points: [
+        [8, 104],
+        [72, 104],
+        [136, 104],
+        [200, 104],
+      ],
+      box: [],
     });
   });
 
@@ -72,9 +146,9 @@ describe('MiniCharts Utils Tests', () => {
       type: MiniChartTypes.Bar,
       data: [
         { year: '2018', value: 10 },
-        { year: '2019', value: 20 },
-        { year: '2020', value: 30 },
-        { year: '2021', value: 40 },
+        { year: '2019', value: 0 },
+        { year: '2020', value: -10 },
+        { year: '2021', value: 0 },
       ],
       encode: {
         x: 'year',
@@ -82,48 +156,82 @@ describe('MiniCharts Utils Tests', () => {
       },
     };
 
-    const cell = {
-      getMeta: () => {
-        return {
-          x: 0,
-          y: 0,
-          height: 108,
-          width: 208,
-        };
-      },
-      getStyle: () => {
-        return {
-          cell: {
-            padding: {
-              left: 8,
-              right: 8,
-              top: 8,
-              bottom: 8,
-            },
-          },
-          miniChart: {
-            bar: {
-              intervalPadding: 4,
-            },
-          },
-        };
+    expect(scale(chartData, cell as S2CellType)).toEqual({
+      box: [
+        [45, 50],
+        [45, 0],
+        [45, 50],
+        [45, 0],
+      ],
+      points: [
+        [8, 4],
+        [57, 54],
+        [106, 54],
+        [155, 54],
+      ],
+    });
+  });
+
+  test('should get right scale of bar when all values are less then 0', () => {
+    const chartData = {
+      type: MiniChartTypes.Bar,
+      data: [
+        { year: '2018', value: -5 },
+        { year: '2019', value: -10 },
+        { year: '2020', value: -5 },
+        { year: '2021', value: -10 },
+      ],
+      encode: {
+        x: 'year',
+        y: 'value',
       },
     };
 
     expect(scale(chartData, cell as S2CellType)).toEqual({
-      range: {
-        xStart: 8,
-        xEnd: 200,
-        yStart: 8,
-        yEnd: 100,
-      },
-      points: [
-        [8, 77],
-        [57, 54],
-        [106, 31],
-        [155, 8],
+      box: [
+        [45, 50],
+        [45, 100],
+        [45, 50],
+        [45, 100],
       ],
-      intervalX: 49,
+
+      points: [
+        [8, 4],
+        [57, 4],
+        [106, 4],
+        [155, 4],
+      ],
+    });
+  });
+
+  test('should get right points of bar when all values are equal to each other', () => {
+    const chartData = {
+      type: MiniChartTypes.Bar,
+      data: [
+        { year: '2018', value: 10 },
+        { year: '2019', value: 10 },
+        { year: '2020', value: 10 },
+        { year: '2021', value: 10 },
+      ],
+      encode: {
+        x: 'year',
+        y: 'value',
+      },
+    };
+
+    expect(scale(chartData, cell as S2CellType)).toEqual({
+      box: [
+        [45, 100],
+        [45, 100],
+        [45, 100],
+        [45, 100],
+      ],
+      points: [
+        [8, 104],
+        [57, 104],
+        [106, 104],
+        [155, 104],
+      ],
     });
   });
 

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -69,15 +69,31 @@ const getKPIMockData = () => {
 
 const getMiniChartMockData = () => {
   return {
+    'custom-node-1': {
+      values: {
+        type: 'line',
+        data: [
+          { year: '2018', value: -1 },
+          { year: '2019', value: 1 },
+          { year: '2020', value: 2 },
+          { year: '2021', value: -100 },
+          { year: '2022', value: 2 },
+        ],
+        encode: {
+          x: 'year',
+          y: 'value',
+        },
+      },
+    },
     'measure-a': {
       values: {
         type: 'line',
         data: [
-          { year: '2018', value: 15468 },
-          { year: '2019', value: 16100 },
-          { year: '2020', value: 15900 },
-          { year: '2021', value: 17409 },
-          { year: '2022', value: 17000 },
+          { year: '2018', value: 100 },
+          { year: '2019', value: 100 },
+          { year: '2020', value: 100 },
+          { year: '2021', value: 100 },
+          { year: '2022', value: 100 },
         ],
         encode: {
           x: 'year',
@@ -89,12 +105,12 @@ const getMiniChartMockData = () => {
       values: {
         type: 'bar',
         data: [
-          { year: '2017', value: 368 },
-          { year: '2018', value: 168 },
-          { year: '2019', value: 160 },
-          { year: '2020', value: 290 },
-          { year: '2021', value: 149 },
-          { year: '2022', value: 300 },
+          { year: '2017', value: -368 },
+          { year: '2018', value: 368 },
+          { year: '2019', value: 368 },
+          { year: '2020', value: 368 },
+          { year: '2021', value: 368 },
+          { year: '2022', value: 368 },
         ],
         encode: {
           x: 'year',
@@ -106,14 +122,37 @@ const getMiniChartMockData = () => {
       values: {
         type: 'line',
         data: [
-          { year: '2018', value: 154 },
-          { year: '2019', value: 161 },
-          { year: '2020', value: 159 },
-          { year: '2021', value: 174 },
-          { year: '2022', value: 170 },
+          {
+            date: '2022-06-30',
+            value: 0,
+          },
+          {
+            date: '2022-07-01',
+            value: 0,
+          },
+          {
+            date: '2022-07-02',
+            value: 8,
+          },
+          {
+            date: '2022-07-03',
+            value: 8,
+          },
+          {
+            date: '2022-07-04',
+            value: 8,
+          },
+          {
+            date: '2022-07-05',
+            value: 8,
+          },
+          {
+            date: '2022-07-06',
+            value: 0,
+          },
         ],
         encode: {
-          x: 'year',
+          x: 'date',
           y: 'value',
         },
       },
@@ -122,11 +161,11 @@ const getMiniChartMockData = () => {
       values: {
         type: 'line',
         data: [
-          { year: '2018', value: 68 },
-          { year: '2019', value: 100 },
-          { year: '2020', value: 900 },
-          { year: '2021', value: 409 },
-          { year: '2022', value: 300 },
+          { year: '2018', value: 0 },
+          { year: '2019', value: 0 },
+          { year: '2020', value: 0 },
+          { year: '2021', value: 0 },
+          { year: '2022', value: 0 },
         ],
         encode: {
           x: 'year',
@@ -138,12 +177,10 @@ const getMiniChartMockData = () => {
       values: {
         type: 'bar',
         data: [
-          { year: '2017', value: 568 },
-          { year: '2018', value: 368 },
-          { year: '2019', value: 550 },
-          { year: '2020', value: 900 },
-          { year: '2021', value: 409 },
-          { year: '2022', value: 230 },
+          { year: '2018', value: -5 },
+          { year: '2019', value: -10 },
+          { year: '2020', value: -5 },
+          { year: '2021', value: -10 },
         ],
         encode: {
           x: 'year',
@@ -228,6 +265,7 @@ export const StrategySheetDataConfig: S2DataConfig = {
   fields: {
     columns: ['date', EXTRA_COLUMN_FIELD],
     values: [
+      'custom-node-1',
       'measure-a',
       'measure-b',
       'measure-c',


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

* 修复趋势相同、为负等多种情况下折线图柱状图绘制不正确问题

### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/10885578/177599767-5c2d1da5-9ab3-4e90-80e1-a336703046c9.png)


