### PR TITLE
fix(drill-down): values 配置为空时未显示下钻 icon

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -1077,6 +1077,33 @@ describe('PivotSheet Tests', () => {
       );
       // modify valueInCols config
       expect(sheet.dataCfg.fields.valueInCols).toBeFalsy();
+
+      sheet.destroy();
+    });
+
+    // https://github.com/antvis/S2/issues/1514
+    it('should not show default action icons if values is empty', () => {
+      const layoutDataCfg: S2DataConfig = customMerge(originalDataCfg, {
+        fields: {
+          values: [],
+          valueInCols: true,
+        },
+      } as S2DataConfig);
+
+      const sheet = new PivotSheet(getContainer(), layoutDataCfg, {
+        width: 400,
+        height: 200,
+        showDefaultHeaderActionIcon: true,
+        hierarchyType: 'tree',
+      });
+      sheet.render();
+
+      sheet.getRowLeafNodes().forEach((node) => {
+        const rowCell = node.belongsCell;
+        expect(get(rowCell, 'actionIcons')).toHaveLength(0);
+      });
+
+      sheet.destroy();
     });
   });
 });

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -1,5 +1,14 @@
 import type { Event as CanvasEvent, IShape } from '@antv/g-canvas';
-import { find, first, forEach, get, includes, isEqual, map } from 'lodash';
+import {
+  find,
+  first,
+  forEach,
+  get,
+  includes,
+  isEmpty,
+  isEqual,
+  map,
+} from 'lodash';
 import { BaseCell } from '../cell/base-cell';
 import {
   CellTypes,
@@ -89,7 +98,10 @@ export abstract class HeaderCell extends BaseCell<Node> {
   }
 
   protected showSortIcon() {
-    if (this.spreadsheet.options.showDefaultHeaderActionIcon) {
+    const { options, dataCfg } = this.spreadsheet;
+    const isEmptyValues = isEmpty(dataCfg.fields.values);
+
+    if (options.showDefaultHeaderActionIcon && !isEmptyValues) {
       const { sortParam } = this.headerConfig;
       const query = this.meta.query;
       // sortParam的query，和type本身可能会 undefined
@@ -100,6 +112,7 @@ export abstract class HeaderCell extends BaseCell<Node> {
         sortParam?.type !== 'none'
       );
     }
+
     return false;
   }
 

--- a/packages/s2-react/__tests__/data/mock-dataset.json
+++ b/packages/s2-react/__tests__/data/mock-dataset.json
@@ -3,7 +3,6 @@
   "fields": {
     "rows": ["province", "city"],
     "columns": ["type", "sub_type"],
-    "values": ["number"],
     "valueInCols": true
   },
   "meta": [

--- a/packages/s2-react/__tests__/data/mock-dataset.json
+++ b/packages/s2-react/__tests__/data/mock-dataset.json
@@ -3,6 +3,7 @@
   "fields": {
     "rows": ["province", "city"],
     "columns": ["type", "sub_type"],
+    "values": ["number"],
     "valueInCols": true
   },
   "meta": [

--- a/packages/s2-react/__tests__/spreadsheet/drill-down-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/drill-down-spec.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import type { GuiIcon, Node, RowCell, S2Options, SpreadSheet } from '@antv/s2';
-import * as mockDataConfig from 'tests/data/simple-data.json';
+import {
+  customMerge,
+  GuiIcon,
+  Node,
+  RowCell,
+  S2Options,
+  SpreadSheet,
+} from '@antv/s2';
 import { get, noop } from 'lodash';
+import * as mockDataConfig from '../data/simple-data.json';
 import { type SheetComponentsProps, SheetComponent } from '../../src';
 import { getContainer } from '../util/helpers';
 
 const s2Options: S2Options = {
   width: 600,
-  height: 600,
+  height: 300,
   hierarchyType: 'tree',
 };
 
@@ -53,6 +60,7 @@ describe('Spread Sheet Drill Down Tests', () => {
   });
 
   afterEach(() => {
+    ReactDOM.unmountComponentAtNode(container);
     container?.remove();
   });
 
@@ -111,5 +119,63 @@ describe('Spread Sheet Drill Down Tests', () => {
     expect(s2Instance.store.get('drillItemsNum')).toEqual(
       EXPECT_DRILL_ITEMS_NUM,
     );
+  });
+
+  // https://github.com/antvis/S2/issues/1514
+  test('should render drill down icon and not show sort icon if value is empty', () => {
+    let s2: SpreadSheet;
+
+    act(() => {
+      ReactDOM.render(
+        <SheetComponent
+          options={s2Options}
+          dataCfg={customMerge(mockDataConfig, {
+            fields: {
+              values: [],
+            },
+          })}
+          getSpreadSheet={(instance) => {
+            s2 = instance;
+          }}
+          partDrillDown={partDrillDownParams}
+        />,
+        container,
+      );
+    });
+
+    const rowNodes = s2.getRowNodes().filter((node) => node.rowIndex >= 1);
+
+    rowNodes.forEach((node) => {
+      expect(get(node.belongsCell, 'actionIcons.0.cfg.name')).toEqual(
+        'DrillDownIcon',
+      );
+    });
+  });
+
+  test('should not render drill down icon is displayCondition return false', () => {
+    let s2: SpreadSheet;
+
+    act(() => {
+      ReactDOM.render(
+        <SheetComponent
+          options={s2Options}
+          dataCfg={mockDataConfig}
+          getSpreadSheet={(instance) => {
+            s2 = instance;
+          }}
+          partDrillDown={{
+            ...partDrillDownParams,
+            displayCondition: () => false,
+          }}
+        />,
+        container,
+      );
+    });
+
+    const rowNodes = s2.getRowNodes();
+
+    rowNodes.forEach((node) => {
+      expect(get(node.belongsCell, 'actionIcons')).toHaveLength(0);
+    });
   });
 });

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -164,13 +164,14 @@ function MainLayout() {
 
   //  ================== Callback ========================
   const updateOptions = (newOptions: Partial<S2Options<React.ReactNode>>) => {
-    setOptions(customMerge({}, options, newOptions));
+    setOptions(customMerge(options, newOptions));
   };
+
   const updateDataCfg = (newDataCfg: Partial<S2DataConfig>) => {
     const currentDataCfg =
       sheetType === 'pivot' ? pivotSheetDataCfg : tableSheetDataCfg;
 
-    setDataCfg(customMerge({}, currentDataCfg, newDataCfg));
+    setDataCfg(customMerge(currentDataCfg, newDataCfg));
   };
 
   const onAutoAdjustBoundaryChange = (value: TooltipAutoAdjustBoundary) => {

--- a/packages/s2-shared/src/utils/drill-down.ts
+++ b/packages/s2-shared/src/utils/drill-down.ts
@@ -100,7 +100,7 @@ export const handleActionIconClick = (params: ActionIconParams) => {
 const defaultPartDrillDownDisplayCondition = (meta: Node) => {
   const s2 = meta.spreadsheet;
   const { fields } = s2.dataCfg;
-  const iconLevel = fields.rows.length - 1;
+  const iconLevel = fields.rows?.length - 1;
 
   // 当 values 为空时, 会将 dataCfg.fields.valueInCols 强制置为 false, 导致下钻 icon 不显示
   // 兼容初始 values 为空, 默认需要显示下钻 icon, 通过下钻动态改变 values 的场景  https://github.com/antvis/S2/issues/1514


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

1. values 配置为空时未显示下钻 icon

当 fields.values 为空时, 由于布局限制, 会将 valueInCols 为空

https://github.com/antvis/S2/blob/a92a4b717f48dd12040ce1d3fac02bdc8aea157a/packages/s2-core/src/utils/merge.ts#L50

而下钻需要置为列头, 导致影响了显示下钻icon的判断

![image](https://user-images.githubusercontent.com/21015895/177696848-e6bb830f-980b-42da-9438-b9220888a97e.png)

2. 默认的 sort icon 加上 values 不为空的限制


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/177697173-555fa084-cc26-4391-aafe-ab74d625647b.png) |  ![image](https://user-images.githubusercontent.com/21015895/177697011-aec300be-292e-40a7-b835-3c86f671c811.png) |

### 🔗 Related issue link

close #1514 

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
- [ ] 