### PR TITLE
fix(theme): 修复调整序号列后色板丢失 close #1538

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
@@ -3,7 +3,11 @@ import { createPivotSheet } from 'tests/util/helpers';
 import type { IGroup } from '@antv/g-canvas';
 import { get } from 'lodash';
 import type { ShapeAttrs } from '@antv/g-canvas';
-import type { TextBaseline, TextTheme } from '@/common/interface/theme';
+import type {
+  TextBaseline,
+  TextTheme,
+  ThemeCfg,
+} from '@/common/interface/theme';
 import type { PivotSheet } from '@/sheet-type';
 import {
   CellTypes,
@@ -61,6 +65,46 @@ describe('SpreadSheet Theme Tests', () => {
         expect(cellTheme.text.fill).toEqual(cellTheme.icon.fill);
       },
     );
+
+    test('should set theme correctly', () => {
+      s2.setTheme({
+        rowCell: {
+          seriesNumberWidth: 200,
+        },
+      });
+
+      expect(s2.theme.rowCell.seriesNumberWidth).toStrictEqual(200);
+    });
+
+    // https://github.com/antvis/S2/issues/1538
+    test('should not reset theme palette after updated theme', () => {
+      const palette: ThemeCfg['palette'] = {
+        basicColors: Array.from({ length: 10 }).fill('red') as string[],
+        semanticColors: {
+          red: 'red',
+          green: 'green',
+        },
+      };
+
+      s2.setThemeCfg({
+        palette,
+        theme: {
+          rowCell: {
+            text: {
+              textAlign: 'left',
+            },
+          },
+        },
+      });
+
+      s2.setTheme({
+        rowCell: {
+          seriesNumberWidth: 200,
+        },
+      });
+
+      expect(s2.theme.background.color).toStrictEqual('red');
+    });
   });
 
   describe('Custom SVG Icon Tests', () => {

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -14,6 +14,7 @@ import {
   S2Event,
   type S2Options,
   SpreadSheet,
+  type ThemeCfg,
 } from '@/index';
 import type { BaseFacet } from '@/facet/base-facet';
 
@@ -434,6 +435,25 @@ describe('Interaction Row Column Resize Tests', () => {
     );
 
     expect(s2.theme.rowCell.seriesNumberWidth).toEqual(resizeInfo.width);
+  });
+
+  // https://github.com/antvis/S2/issues/1538
+  test('should not reset theme palette after resize series', () => {
+    const palette: ThemeCfg['palette'] = {
+      basicColors: Array.from({ length: 10 }).fill('red') as string[],
+      semanticColors: {
+        red: 'red',
+        green: 'green',
+      },
+    };
+
+    s2.setThemeCfg({
+      palette,
+    });
+
+    emitResize(ResizeDirectionType.Horizontal, ResizeAreaEffect.Series);
+
+    expect(s2.theme.background.color).toEqual('red');
   });
 
   test('should get vertical cell resize style', () => {

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -24,7 +24,6 @@ import type {
   ResizeInfo,
   ResizePosition,
 } from '../common/interface/resize';
-import { customMerge } from '../utils';
 import { BaseEvent, type BaseEventImplement } from './base-interaction';
 
 export class RowColumnResize extends BaseEvent implements BaseEventImplement {

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -24,6 +24,7 @@ import type {
   ResizeInfo,
   ResizePosition,
 } from '../common/interface/resize';
+import { customMerge } from '../utils';
 import { BaseEvent, type BaseEventImplement } from './base-interaction';
 
 export class RowColumnResize extends BaseEvent implements BaseEventImplement {
@@ -426,11 +427,9 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     }
 
     if (seriesNumberWidth) {
-      this.spreadsheet.setThemeCfg({
-        theme: {
-          rowCell: {
-            seriesNumberWidth,
-          },
+      this.spreadsheet.setTheme({
+        rowCell: {
+          seriesNumberWidth,
         },
       });
     }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -407,18 +407,14 @@ export abstract class SpreadSheet extends EE {
     removeOffscreenCanvas();
   }
 
-  /**
-   * Update theme config, if the {@param type} is exists, re-use it,
-   * otherwise create new one {@see theme}
-   * @param type string
-   * @param theme
-   */
   public setThemeCfg(themeCfg: ThemeCfg = {}) {
     const theme = themeCfg?.theme || {};
-    this.theme = customMerge(
-      getTheme({ ...themeCfg, spreadsheet: this }),
-      theme,
-    );
+    const newTheme = getTheme(themeCfg, this);
+    this.theme = customMerge(newTheme, theme);
+  }
+
+  public setTheme(theme: S2Theme) {
+    this.theme = customMerge(this.theme, theme);
   }
 
   /**

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -409,7 +409,8 @@ export abstract class SpreadSheet extends EE {
 
   public setThemeCfg(themeCfg: ThemeCfg = {}) {
     const theme = themeCfg?.theme || {};
-    const newTheme = getTheme(themeCfg, this);
+    const newTheme = getTheme({ ...themeCfg, spreadsheet: this });
+
     this.theme = customMerge(newTheme, theme);
   }
 

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -6,10 +6,11 @@ import { getPalette } from '../utils/theme';
 
 /**
  * @describe generate the theme according to the type
- * @param  name
+ * @param themeCfg
  */
 export const getTheme = (
-  themeCfg: Omit<ThemeCfg, 'theme'> & { spreadsheet?: SpreadSheet },
+  themeCfg: Omit<ThemeCfg, 'theme'>,
+  spreadsheet?: SpreadSheet,
 ): S2Theme => {
   const {
     basicColors,
@@ -17,7 +18,7 @@ export const getTheme = (
     others: otherColors,
   } = themeCfg?.palette || getPalette(themeCfg?.name);
 
-  const isTable = themeCfg?.spreadsheet?.isTableMode();
+  const isTable = spreadsheet?.isTableMode();
 
   return {
     // ------------- Headers -------------------

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -9,8 +9,7 @@ import { getPalette } from '../utils/theme';
  * @param themeCfg
  */
 export const getTheme = (
-  themeCfg: Omit<ThemeCfg, 'theme'>,
-  spreadsheet?: SpreadSheet,
+  themeCfg: Omit<ThemeCfg, 'theme'> & { spreadsheet?: SpreadSheet },
 ): S2Theme => {
   const {
     basicColors,
@@ -18,7 +17,7 @@ export const getTheme = (
     others: otherColors,
   } = themeCfg?.palette || getPalette(themeCfg?.name);
 
-  const isTable = spreadsheet?.isTableMode();
+  const isTable = themeCfg?.spreadsheet?.isTableMode();
 
   return {
     // ------------- Headers -------------------

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -30,7 +30,7 @@ export const s2Options: S2Options = {
   debug: true,
   width: 600,
   height: 400,
-  showSeriesNumber: true,
+  showSeriesNumber: false,
   interaction: {
     enableCopy: true,
   },

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -30,6 +30,7 @@ export const s2Options: S2Options = {
   debug: true,
   width: 600,
   height: 400,
+  showSeriesNumber: true,
   interaction: {
     enableCopy: true,
   },

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -137,32 +137,6 @@ const CustomColTooltip = () => <div>custom colTooltip</div>;
 
 const ActionIconTooltip = ({ name }) => <div>{name} Tooltip</div>;
 
-const s2Palette = {
-  basicColors: [
-    '#FFFFFF',
-    '#F8F5FE',
-    '#EDE1FD',
-    '#873BF4',
-    '#7232CF',
-    '#7232CF',
-    '#7232CF',
-    '#AB76F7',
-    '#FFFFFF',
-    '#DDC7FC',
-    '#9858F5',
-    '#B98EF8',
-    '#873BF4',
-    '#282B33',
-    '#121826',
-  ],
-
-  // ---------- semantic colors ----------
-  semanticColors: {
-    red: '#FF4D4F',
-    green: '#29A294',
-  },
-};
-
 function MainLayout() {
   //  ================== State ========================
   const [render, setRender] = React.useState(true);
@@ -171,7 +145,6 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({
     name: 'default',
-    palette: s2Palette,
   });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -137,6 +137,32 @@ const CustomColTooltip = () => <div>custom colTooltip</div>;
 
 const ActionIconTooltip = ({ name }) => <div>{name} Tooltip</div>;
 
+const s2Palette = {
+  basicColors: [
+    '#FFFFFF',
+    '#F8F5FE',
+    '#EDE1FD',
+    '#873BF4',
+    '#7232CF',
+    '#7232CF',
+    '#7232CF',
+    '#AB76F7',
+    '#FFFFFF',
+    '#DDC7FC',
+    '#9858F5',
+    '#B98EF8',
+    '#873BF4',
+    '#282B33',
+    '#121826',
+  ],
+
+  // ---------- semantic colors ----------
+  semanticColors: {
+    red: '#FF4D4F',
+    green: '#29A294',
+  },
+};
+
 function MainLayout() {
   //  ================== State ========================
   const [render, setRender] = React.useState(true);
@@ -145,6 +171,7 @@ function MainLayout() {
   const [showTotals, setShowTotals] = React.useState(false);
   const [themeCfg, setThemeCfg] = React.useState<ThemeCfg>({
     name: 'default',
+    palette: s2Palette,
   });
   const [themeColor, setThemeColor] = React.useState<string>('#FFF');
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -12,6 +12,7 @@ import { getSheetComponentOptions } from '../../../utils';
 import { Header } from '../../header';
 import { S2Pagination } from '../../pagination';
 import type { SheetComponentsProps } from '../../sheets/interface';
+
 import './index.less';
 
 export const BaseSheet = React.forwardRef(

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -53,7 +53,8 @@ s2.xx()
 | setOptions | 更新表格配置 | (options: [S2Options](/zh/docs/api/general/S2Options)) => void |
 | render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据，`reBuildDataSet` = true, 重新构建数据集，`reBuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean, { reBuildDataSet?: boolean; reBuildHiddenColumnsDetail?: boolean }) => void` |
 | destroy | 销毁表格 | `() => void` |
-| setThemeCfg | 更新主题配置 | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme)) => void |
+| setThemeCfg | 更新主题配置 （含主题 schema, 色板，主题名） | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme/#themecfg)) => void |
+| setTheme | 更新主题 （只包含主题 scheme) | (theme: [S2Theme](/zh/docs/api/general/S2Theme/#s2theme)) => void |
 | updatePagination | 更新分页 | (pagination: [Pagination](/zh/docs/api/general/S2Options#pagination)) => void |
 | getContentHeight | 获取当前表格实际内容高度 | `() => number` |
 | changeSheetSize （别名：changeSize) | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |

--- a/s2-site/docs/manual/basic/theme.zh.md
+++ b/s2-site/docs/manual/basic/theme.zh.md
@@ -5,7 +5,7 @@ order: 6
 
 ## 简介
 
-S2 中内置了 3 套开箱即用的主题配置，也提供了强大的主题自定义功能。
+S2 中内置了 **3** 套开箱即用的主题配置，也提供了强大的主题自定义功能。
 
 ### 色彩
 
@@ -28,7 +28,7 @@ S2 中内置了 3 套开箱即用的主题配置，也提供了强大的主题�
 - basicColors：基础颜色，共 15 个色彩位，本质上确定了表格的配色方案，生成主题 schema 时会从 basicColors 固定索引上取色，如行头背景颜色固定会取 `basicColors[1]` 的颜色
 - basicColorRelations：basicColors 与标准色板的对应关系，如内置的 colorful 主题中，行头背景色 `basicColors[1]` 是取用标准色板中的索引 0 的颜色
 
-由此 s2 保证了，所有绘制时使用的颜色均来自于主题色或主题色的派生颜色。这样使表格界面颜色统一，也便于用户根据自己需要的主题色，生成个性化主题。
+由此 S2 保证了，所有绘制时使用的颜色均来自于主题色或主题色的派生颜色。这样使表格界面颜色统一，也便于用户根据自己需要的主题色，生成个性化主题。
 
 ### 主题 schema
 
@@ -37,6 +37,17 @@ S2 中内置了 3 套开箱即用的主题配置，也提供了强大的主题�
 - basicColors：基础颜色，如角/列/行头背景，字体/icon 颜色
 - semanticColors：语义颜色，如红色、绿色指代的色值
 - others：补充颜色，一些固定特殊色，如搜索结果
+
+```ts
+const s2 = new PivotSheet(container, s2DataConfig, s2Options);
+
+s2.setTheme({
+  background: {
+    color: '#353c59',
+  },
+});
+s2.render(false);
+```
 
 ## 自定义主题
 
@@ -55,7 +66,7 @@ const s2 = new PivotSheet(container, s2DataConfig, s2Options);
 
 // name 可为 default, colorful, gray
 s2.setThemeCfg({ name: 'colorful' });
-s2.render();
+s2.render(false);
 ```
 
 S2 内置 3 套主题效果：
@@ -110,8 +121,8 @@ const customTheme = {
   },
 };
 
-s2.setThemeCfg({ theme: customTheme });
-s2.render();
+s2.setThemeCfg({ theme: customTheme }); // 也可以使用：s2.setTheme(customTheme)
+s2.render(false);
 ```
 
 <playground path="theme/custom/demo/custom-schema.ts" rid='custom-schema'></playground>
@@ -124,7 +135,7 @@ s2.render();
 
 你可以参考 [内置色板](https://github.com/antvis/S2/blob/master/packages/s2-core/src/theme/palette/colorful.ts) 个人化设置 `basicColors` 与 `semanticColors`，所选颜色会被用于表格不同部分的绘制，颜色使用关系请参考下方的 [色板对照表](#色板对照表)。
 
-另外为方便大家调配专属色板，S2 官方提供了[自助色板调色工具](/zh/examples/theme/custom/#custom-manual-palette)，所见即所得帮助你快速调配色板，一键复制粘贴进项目使用。
+另外为方便大家调配专属色板，S2 官方提供了 [自助色板调色工具](/zh/examples/theme/custom/#custom-manual-palette)，所见即所得帮助你快速调配色板，一键复制粘贴进项目使用。
 
 ```js
 const s2 = new PivotSheet(container, s2DataConfig, s2Options);
@@ -136,8 +147,6 @@ const s2Palette = {
     '#F8F5FE',
     '#EDE1FD',
     '#873BF4',
-    '#7232CF',
-    '#7232CF',
     '#7232CF',
     '#AB76F7',
     '#FFFFFF',
@@ -155,7 +164,7 @@ const s2Palette = {
   },
 };
 s2.setThemeCfg({ palette: s2Palette });
-s2.render();
+s2.render(false);
 ```
 
 <playground path="theme/custom/demo/custom-manual-palette.tsx" height="500" rid='custom-manual-palette'></playground>
@@ -183,7 +192,7 @@ s2.setThemeCfg({
 });
 
 s2.setThemeCfg({ palette: s2Palette });
-s2.render();
+s2.render(false);
 ```
 
 <playground path="theme/custom/demo/custom-generate-palette.tsx" rid='custom-generate-palette'></playground>

--- a/s2-site/docs/manual/faq.zh.md
+++ b/s2-site/docs/manual/faq.zh.md
@@ -51,21 +51,21 @@ s2.render(false)
 const pivotSheet = new PivotSheet(document.getElementById('container'), dataCfg, options);
 ```
 
-更新 options: [可选项](https://s2.antv.vision/zh/docs/api/general/S2Options)
+更新 options: [可选项](/zh/docs/api/general/S2Options)
 
 ```ts
 pivotSheet.setOptions({ ... })
 pivotSheet.render(false) // 重新渲染，不更新数据
 ```
 
-更新 dataCfg: [可选项](https://s2.antv.vision/zh/docs/api/general/S2DataConfig)
+更新 dataCfg: [可选项](/zh/docs/api/general/S2DataConfig)
 
 ```ts
 pivotSheet.setDataCfg({ ... })
 pivotSheet.render(true) // 重新渲染，且更新数据
 ```
 
-更新 theme: [可选项](https://s2.antv.vision/zh/docs/api/general/S2Theme)
+更新 theme: [可选项](/zh/docs/api/general/S2Theme)
 
 ```ts
 pivotSheet.setThemeCfg({ ... })
@@ -150,7 +150,7 @@ s2.render(false)
 
 ### 怎样贡献代码？
 
-请查看 [贡献指南](https://s2.antv.vision/zh/docs/manual/contribution)
+请查看 [贡献指南](/zh/docs/manual/contribution)
 
 ### 为什么在小程序上面表格无法显示？
 
@@ -182,7 +182,7 @@ s2.render(false)
 
 - 尽量抹去一些带有你自己业务语义的一些名词和描述
 
-在提出问题前，请确保你已经阅读过 [官方文档](https://s2.antv.vision/zh/docs/manual/introduction) 和 [常见问题](https://s2.antv.vision/zh/docs/manual/faq), 并且已经搜索查阅过相关 [Issues 列表](https://github.com/antvis/S2/issues?q=is%3Aissue+is%3Aclosed)
+在提出问题前，请确保你已经阅读过 [官方文档](/zh/docs/manual/introduction) 和 [常见问题](/zh/docs/manual/faq), 并且已经搜索查阅过相关 [Issues 列表](https://github.com/antvis/S2/issues?q=is%3Aissue+is%3Aclosed)
 
 强烈建议阅读：
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1538 

### 📝 Description

序号列的宽度属于 `rowCell.seriesNumberWidth` 主题配置, 在序号列拖拽后会通过改变它进行宽度更新

![image](https://user-images.githubusercontent.com/21015895/177957811-6498ce2a-de87-4d3a-b57f-6e8b33fee199.png)

此时 `palette` 为空, 导致 `palette` 被覆盖, 解法是新增 `setTheme` 方法只负责更新主题, 和 `setThemeCfg` 方法分开

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-07-08 at 17 08 58](https://user-images.githubusercontent.com/21015895/177958718-71b839fa-5b66-4169-9874-517089686ec7.gif) | ![Kapture 2022-07-08 at 17 07 24](https://user-images.githubusercontent.com/21015895/177958442-d63c149e-b25a-4a17-a68e-6204bdaf2c9a.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
