### PR TITLE
feat(tooltip): 支持设置多个class类名

### DIFF
--- a/.github/workflows/sync-site-lock-changelog-with-pr.yml
+++ b/.github/workflows/sync-site-lock-changelog-with-pr.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout branch
         run: |
           git checkout -b chore-sync
+          git fetch --all
           git merge origin/latest --squash
 
       - name: Sleep 5m

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -115,7 +115,7 @@ describe('PivotSheet Tests', () => {
       s2.tooltip.destroy();
 
       // remove container
-      expect(s2.tooltip.container.children).toHaveLength(0);
+      expect(s2.tooltip.container).toBe(null);
       // reset position
       expect(s2.tooltip.position).toEqual({
         x: 0,
@@ -935,6 +935,17 @@ describe('PivotSheet Tests', () => {
     s2.render(false);
 
     s2.store.set('test', 111);
+
+    // restore mock...
+    (s2.tooltip.show as jest.Mock).mockRestore();
+    s2.showTooltip({
+      position: {
+        x: 10,
+        y: 10,
+      },
+      content: () => 'custom callback content',
+    });
+    s2.hideTooltip();
     s2.tooltip.container.classList.add('destroy-test');
     s2.interaction.addIntercepts([InterceptType.HOVER]);
     s2.interaction.interactions.set('test-interaction', null);
@@ -955,7 +966,8 @@ describe('PivotSheet Tests', () => {
     expect(s2.interaction.eventController.s2EventHandlers).toHaveLength(0);
     expect(s2.interaction.eventController.domEventListeners).toHaveLength(0);
     // destroy tooltip
-    expect(s2.tooltip.container.children).toHaveLength(0);
+    expect(document.querySelector('.destroy-test')).toBe(null);
+    expect(s2.tooltip.container).toBe(null);
     // destroy facet
     expect(facetDestroySpy).toHaveBeenCalledTimes(1);
     // destroy hdAdapter

--- a/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
+++ b/packages/s2-core/__tests__/unit/ui/tooltip/index-spec.ts
@@ -127,6 +127,7 @@ describe('Tooltip Tests', () => {
     expect(tooltip.visible).toBeFalsy();
     // remove container
     expect(document.getElementById(containerId)).toBeFalsy();
+    expect(tooltip.container).toBe(null);
   });
 
   test('should disable pointer event', () => {
@@ -383,5 +384,22 @@ describe('Tooltip Tests', () => {
     });
 
     expect(tooltip.container.classList.contains('custom')).toBeTruthy();
+  });
+
+  test('should set custom container class name list', () => {
+    const classList = ['custom1', 'custom2'];
+    s2.options.tooltip.className = classList;
+
+    tooltip = new BaseTooltip(s2);
+
+    tooltip.show({
+      position: {
+        x: 10,
+        y: 10,
+      },
+    });
+
+    expect(tooltip.container.classList.contains(classList[0])).toBeTruthy();
+    expect(tooltip.container.classList.contains(classList[1])).toBeTruthy();
   });
 });

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -163,7 +163,7 @@ export interface BaseTooltipConfig<T = TooltipContentType> {
   // Custom tooltip mount container
   getContainer?: () => HTMLElement;
   // Extra tooltip container class name
-  className?: string;
+  className?: string | string[];
   // Extra tooltip container style
   style?: CSS.Properties;
 }

--- a/packages/s2-core/src/ui/tooltip/index.ts
+++ b/packages/s2-core/src/ui/tooltip/index.ts
@@ -93,6 +93,7 @@ export class BaseTooltip {
 
     this.resetPosition();
     this.container.remove?.();
+    this.container = null;
   }
 
   public renderContent<T = TooltipContentType>(content: T) {
@@ -155,7 +156,7 @@ export class BaseTooltip {
 
       setTooltipContainerStyle(container, {
         style: tooltip.style,
-        className: [TOOLTIP_CONTAINER_CLS, tooltip.className],
+        className: [TOOLTIP_CONTAINER_CLS].concat(tooltip.className),
       });
 
       rootContainer.appendChild(container);

--- a/packages/s2-react/__tests__/util/helpers.ts
+++ b/packages/s2-react/__tests__/util/helpers.ts
@@ -101,6 +101,16 @@ export const createMockCellInfo = (
     rowIndex,
     type: undefined,
     update: jest.fn(),
+    spreadsheet: {
+      dataCfg: {
+        meta: null,
+        data: [],
+        fields: {},
+      },
+      dataSet: {
+        getFieldDescription: jest.fn(),
+      },
+    } as unknown as SpreadSheet,
   };
   const mockCellMeta = omit(mockCellViewMeta, 'update');
   const mockCell = {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description
- feat: options.tooltip.className 支持数组形式以设置多个类名
- fix: BaseTooltip destroy 后 this.container 变量未重置