### PR TITLE
fix: 修复移动端滚动没有prevent问题

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1,4 +1,5 @@
 import type { IElement, IGroup } from '@antv/g-canvas';
+import type { Event as GraphEvent } from '@antv/g-base';
 import { Group } from '@antv/g-canvas';
 import { type GestureEvent, Wheel } from '@antv/g-gesture';
 import { interpolateArray } from 'd3-interpolate';
@@ -853,6 +854,8 @@ export abstract class BaseFacet {
 
   private stopScrollChaining = (event: S2WheelEvent) => {
     event?.preventDefault?.();
+    // 移动端的 prevent 存在于 originalEvent上
+    (event as unknown as GraphEvent)?.originalEvent?.preventDefault?.();
   };
 
   onWheel = (event: S2WheelEvent) => {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
在移动端中，event中prevent方法存在于`originalEvent`中：
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![2022-07-11 13 03 44](https://user-images.githubusercontent.com/17964556/178192424-3d01087b-12bc-4398-ac27-d8078ea3aa73.gif)      |  ![2022-07-11 13 03 05](https://user-images.githubusercontent.com/17964556/178192418-6af55ca7-7d10-46fe-8f0f-c26733784cd1.gif)    |


### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
