### PR TITLE
feat(strategysheet): 趋势分析表允许对行头和列头的 tooltip 做自定义

### DIFF
--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import { type SpreadSheet, type S2DataConfig, customMerge } from '@antv/s2';
+import {
+  type SpreadSheet,
+  type S2DataConfig,
+  customMerge,
+  CellTypes,
+} from '@antv/s2';
 import { SheetType } from '@antv/s2-shared';
+import type { Event as GEvent } from '@antv/g-canvas';
 import { SheetComponent, SheetComponentsProps } from '../../../../src';
 import { getContainer } from '../../../util/helpers';
 
@@ -121,5 +127,32 @@ describe('<SheetComponent/> Tests', () => {
 
       expect(s2.options.tooltip.operation.hiddenColumns).toBeTruthy();
     });
+
+    test.each([CellTypes.ROW_CELL, CellTypes.COL_CELL, CellTypes.DATA_CELL])(
+      'should overwrite strategy sheet default custom tooltip and render custom %s tooltip',
+      (cellType) => {
+        const content = `${cellType} test content`;
+        const cell = {
+          [CellTypes.ROW_CELL]: 'row',
+          [CellTypes.COL_CELL]: 'col',
+          [CellTypes.DATA_CELL]: 'data',
+        }[cellType];
+
+        renderStrategySheet({
+          tooltip: {
+            showTooltip: true,
+            [cell]: {
+              content: () => <div>{content}</div>,
+            },
+          },
+        });
+
+        jest.spyOn(s2, 'getCellType').mockReturnValueOnce(cellType);
+
+        s2.showTooltipWithInfo({} as GEvent, []);
+
+        expect(s2.tooltip.container.innerText).toEqual(content);
+      },
+    );
   });
 });

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/__snapshots__/index-spec.tsx.snap
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/__snapshots__/index-spec.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StrategySheet Tooltip Tests should render tooltip with {
+  label: 'test col label',
+  component: [Function: StrategySheetColTooltip] {
+    [length]: 1,
+    [name]: 'StrategySheetColTooltip'
+  }
+} 1`] = `
+<span
+  class="s2-strategy-sheet-tooltip-name"
+>
+  test col label
+</span>
+`;
+
+exports[`StrategySheet Tooltip Tests should render tooltip with {
+  label: 'test data label',
+  component: [Function: StrategySheetDataTooltip] {
+    [length]: 1,
+    [name]: 'StrategySheetDataTooltip'
+  }
+} 1`] = `
+<span
+  class="header-label"
+>
+  test data label
+</span>
+`;
+
+exports[`StrategySheet Tooltip Tests should render tooltip with {
+  label: 'test row label',
+  component: [Function: StrategySheetRowTooltip] {
+    [length]: 1,
+    [name]: 'StrategySheetRowTooltip'
+  }
+} 1`] = `
+<div
+  class="s2-strategy-sheet-tooltip-value"
+>
+  test row label
+</div>
+`;

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/index-spec.tsx
@@ -9,24 +9,6 @@ import {
 
 describe('StrategySheet Tooltip Tests', () => {
   const mockCellInfo = createMockCellInfo('test');
-  const mockCell = {
-    ...mockCellInfo.mockCell,
-    getMeta: () => {
-      return {
-        spreadsheet: {
-          options: {
-            style: {},
-          },
-          getRowNodes: jest.fn(),
-          getColumnNodes: jest.fn(),
-          dataSet: {
-            getFieldDescription: jest.fn(),
-            getFieldName: jest.fn(),
-          },
-        },
-      };
-    },
-  };
 
   test.each([
     {
@@ -42,7 +24,8 @@ describe('StrategySheet Tooltip Tests', () => {
       component: StrategySheetRowTooltip,
     },
   ])('should render tooltip with %o', ({ label, component: Comp }) => {
-    render(<Comp cell={mockCell} label={label} />);
+    render(<Comp cell={mockCellInfo.mockCell} label={label} />);
     expect(screen.getByText(label)).toBeDefined();
+    expect(screen.getByText(label)).toMatchSnapshot();
   });
 });

--- a/packages/s2-react/__tests__/util/helpers.ts
+++ b/packages/s2-react/__tests__/util/helpers.ts
@@ -102,6 +102,11 @@ export const createMockCellInfo = (
     type: undefined,
     update: jest.fn(),
     spreadsheet: {
+      options: {
+        style: {},
+      },
+      getRowNodes: jest.fn(),
+      getColumnNodes: jest.fn(),
       dataCfg: {
         meta: null,
         data: [],
@@ -109,6 +114,7 @@ export const createMockCellInfo = (
       },
       dataSet: {
         getFieldDescription: jest.fn(),
+        getFieldName: jest.fn(),
       },
     } as unknown as SpreadSheet,
   };

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
@@ -22,7 +22,7 @@ export const StrategySheetDataTooltip: React.FC<CustomTooltipProps> = ({
   const meta = cell.getMeta() as ViewMeta;
   const metaFieldValue = meta?.fieldValue as MultiData<SimpleDataItem[][]>;
 
-  const rowDiscription = getRowDescription(meta);
+  const rowDescription = getRowDescription(meta);
   const defaultRowName = getRowName(meta);
   const customLabel = isFunction(label) ? label(cell, defaultRowName) : label;
   const rowName = customLabel ?? defaultRowName;
@@ -89,9 +89,9 @@ export const StrategySheetDataTooltip: React.FC<CustomTooltipProps> = ({
           </ul>
         </>
       )}
-      {rowDiscription && (
-        <div>
-          {i18n('说明')}: {rowDiscription}
+      {rowDescription && (
+        <div className={tooltipCls('description')}>
+          {i18n('说明')}: {rowDescription}
         </div>
       )}
     </div>

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-row-tooltip.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-row-tooltip.tsx
@@ -21,7 +21,7 @@ export const StrategySheetRowTooltip: React.FC<CustomTooltipProps> = ({
     <div className={cls(tooltipCls(), tooltipCls('row'))}>
       <div className={tooltipCls('value')}>{rowName}</div>
       {description && (
-        <div>
+        <div className={tooltipCls('description')}>
           {i18n('说明')}: {description}
         </div>
       )}

--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -1,3 +1,4 @@
+import type { S2CellType } from '@antv/s2';
 import {
   type ColHeaderConfig,
   customMerge,
@@ -21,6 +22,7 @@ import {
   StrategySheetDataTooltip,
   StrategySheetRowTooltip,
 } from './custom-tooltip';
+
 /* *
  * 趋势分析表特性：
  * 1. 维度为空时默认为自定义目录树结构
@@ -59,6 +61,23 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
         hideMeasureColumn = true;
       }
 
+      const getContent =
+        (cellType: 'row' | 'col' | 'data') =>
+        (
+          cell: S2CellType,
+          tooltipOptions: TooltipShowOptions<React.ReactNode>,
+        ): React.ReactNode => {
+          // 优先级: 单元格 > 表格级
+          const tooltipContent: TooltipShowOptions<React.ReactNode>['content'] =
+            options.tooltip?.[cellType]?.content ?? options.tooltip?.content;
+
+          const content = isFunction(tooltipContent)
+            ? tooltipContent?.(cell, tooltipOptions)
+            : tooltipContent;
+
+          return content;
+        };
+
       return {
         dataCell: (viewMeta: ViewMeta) =>
           new CustomDataCell(viewMeta, viewMeta.spreadsheet),
@@ -88,28 +107,36 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
             hiddenColumns: true,
           },
           row: {
-            content: (cell) => <StrategySheetRowTooltip cell={cell} />,
+            content: (cell, tooltipOptions) =>
+              getContent('row')(cell, tooltipOptions) ?? (
+                <StrategySheetRowTooltip cell={cell} />
+              ),
           },
           col: {
-            content: (cell) => <StrategySheetColTooltip cell={cell} />,
+            content: (cell, tooltipOptions) =>
+              getContent('row')(cell, tooltipOptions) ?? (
+                <StrategySheetColTooltip cell={cell} />
+              ),
           },
           data: {
-            content: (cell, defaultTooltipShowOptions) => {
+            content: (cell, tooltipOptions) => {
               const meta = cell.getMeta() as ViewMeta;
               const fieldValue = meta.fieldValue as MultiData;
-
-              const tooltipContent = options.tooltip?.data
-                ?.content as TooltipShowOptions<React.ReactNode>['content'];
-
-              const content = isFunction(tooltipContent)
-                ? tooltipContent?.(cell, defaultTooltipShowOptions)
-                : tooltipContent;
+              const content = getContent('data')(cell, tooltipOptions);
 
               // 如果是数组, 说明是普通数值+同环比数据 或者 KPI数据, 显示普通数值 Tooltip
               if (isArray(fieldValue?.values)) {
-                return content ?? <StrategySheetDataTooltip cell={cell} />;
+                return (
+                  content ?? (
+                    <StrategySheetDataTooltip
+                      cell={cell}
+                      label={(cell, defaultLabel) =>
+                        `${defaultLabel}（自定义标题）`
+                      }
+                    />
+                  )
+                );
               }
-
               return content ?? <></>;
             },
           },

--- a/packages/s2-react/src/components/sheets/strategy-sheet/utils/index.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/utils/index.ts
@@ -17,19 +17,12 @@ export const getRowName = (meta: ViewMeta) => {
   );
 };
 
-export const getRowDescription = (meta: ViewMeta) => {
+export const getRowDescription = (meta: ViewMeta): string => {
   const currentRow = find(meta.spreadsheet.getRowNodes(), {
     rowIndex: meta.rowIndex,
   });
   return (
     meta.spreadsheet.dataSet.getFieldDescription(currentRow?.field) ||
-    currentRow?.extra.description
+    currentRow?.extra?.description
   );
-};
-
-export const getColName = (meta: ViewMeta) => {
-  const leafColNode = getLeafColNode(meta);
-
-  // 兼容多列头, 优先取父级节点标题
-  return leafColNode?.parent?.label || leafColNode?.label || '';
 };

--- a/s2-site/docs/manual/basic/analysis/strategy.zh.md
+++ b/s2-site/docs/manual/basic/analysis/strategy.zh.md
@@ -17,41 +17,41 @@ order: 9
 <summary>点击查看趋势分析表 options 配置</summary>
 
 ```js
- const s2Options = {
-      width: 600,
-      height: 480,
-      cornerText: '指标层级', // 角头对应行头的 label 名
-      hierarchyType: 'customTree', // 必须指定类型
-      style: {  // 染色逻辑，区分指标和副指标
-        cellCfg: {
-          valuesCfg: {
-            originalValueField: 'originalValues',
-            conditions: {
-              text: {
-                field: 'number',
-                mapping: (value, cellInfo) => {
-                  const { meta } = cellInfo;
+const s2Options = {
+  width: 600,
+  height: 480,
+  cornerText: '指标层级', // 角头对应行头的 label 名
+  hierarchyType: 'customTree', // 必须指定类型
+  style: {  // 染色逻辑，区分指标和副指标
+    cellCfg: {
+      valuesCfg: {
+        originalValueField: 'originalValues',
+        conditions: {
+          text: {
+            field: 'number',
+            mapping: (value, cellInfo) => {
+              const { meta } = cellInfo;
 
-                  if (meta.fieldValue.values[0][0] === value || !value) {
-                    return {
-                      fill: '#000',
-                    };
-                  }
-                  return {
-                    fill: value > 0 ? '#FF4D4F' : '#29A294',
-                  };
-                },
-              },
+              if (meta.fieldValue.values[0][0] === value || !value) {
+                return {
+                  fill: '#000',
+                };
+              }
+              return {
+                fill: value > 0 ? '#FF4D4F' : '#29A294',
+              };
             },
           },
         },
       },
-    };
+    },
+  },
+};
 ```
 
 </details>
 
-```js
+```ts
 import React from "react";
 import ReactDOM from "react-dom";
 import { SheetComponent } from "@antv/s2-react";
@@ -100,3 +100,33 @@ object **必选**,_default：null_
 
 * 必须指定 `hierarchyType: 'customTree'`
 * 染色逻辑配置可以在  `options.conditions` 中配置，不需要指定 `field` 参数，用法参考 [字段标记](/zh/docs/manual/basic/conditions) 目前暂时只支持文本颜色通道
+
+## Tooltip
+
+趋势分析表的 `Tooltip`, 使用 `S2` 提供的 [自定义能力](/zh/docs/manual/basic/tooltip#%E8%87%AA%E5%AE%9A%E4%B9%89-tooltip-%E5%86%85%E5%AE%B9) 分别对 `行头 (row)`, `列头 (col)`, `数值 (data)` 进行了 [定制](https://github.com/antvis/S2/blob/f35ff01400384cd2f3d84705e9daf75fc11b0149/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx#L105), 同时可以在 `@antv/s2-react` 包中进行单独引入
+
+```ts
+import { StrategySheetRowTooltip, StrategySheetColTooltip, StrategySheetDataTooltip } from '@antv/s2-react'
+
+const s2Options = {
+  tooltip: {
+    content: (cell) => <StrategySheetDataTooltip cell={cell} label={label}/>
+  }
+}
+```
+
+<img src="https://gw.alipayobjects.com/zos/antfincdn/MCgZSZyEm/df084a59-407c-4a69-bc93-1f12eb01b019.png" width="600"  alt="preview" />
+
+### 自定义标题
+
+默认使用行头节点名字作为 Tooltip 标题，可通过 `label` 自定义内容的方式
+
+```ts
+// 字符串
+<StrategySheetDataTooltip cell={cell} label={"自定义标题"}/>
+
+// 自定义组件
+<StrategySheetDataTooltip cell={cell} label={(cell, defaultLabel) => `${defaultLabel}（自定义标题`} />
+```
+
+<img src="https://gw.alipayobjects.com/zos/antfincdn/dosQkhLBp/fbe5a635-60ad-4e55-9a23-858842b977ac.png" width="600"  alt="preview" />


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

```ts
const s2Options = {
  tooltip: {
    content: (cell) => <StrategySheetRowTooltip cell={cell} label={(cell, defaultLabel) => `${defaultLabel}（自定义标题`} />
  }
}
```

满足业务侧, 需要对 行头和列头再次自定义 Tooltip 的场景

### 🖼️ Screenshot

![image](https://user-images.githubusercontent.com/21015895/178249413-d5196cbe-5014-461a-a2c3-0ef31b415d7c.png)

### 🔗 Related issue link

ref https://github.com/antvis/S2/pull/1523

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
