### PR TITLE
fix: 修复趋势分析表导出问题

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,12 +60,7 @@ module.exports = {
         allowAfterThis: true,
       },
     ],
-    'no-plusplus': [
-      1,
-      {
-        allowForLoopAfterthoughts: true,
-      },
-    ],
+    'no-plusplus': 0,
     'class-methods-use-this': 0,
     'no-param-reassign': 0,
     '@typescript-eslint/no-empty-function': 0,

--- a/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
@@ -1,4 +1,5 @@
 import type { SimpleBBox } from '@antv/g-canvas';
+import { getNodeDepth } from './../../../../src/utils/cell/cell';
 import { CellBorderPosition, type CellTheme } from '@/common/interface';
 import type { AreaRange } from '@/common/interface/scroll';
 import {
@@ -8,6 +9,7 @@ import {
   getTextAreaRange,
   getBorderPositionAndStyle,
 } from '@/utils/cell/cell';
+import { Node } from '@/facet/layout/node';
 
 describe('Cell Content Test', () => {
   test('should return content area', () => {
@@ -557,5 +559,20 @@ describe('Horizontal Scrolling Text Position Test', () => {
       x2: 200,
       y2: 49,
     });
+  });
+});
+
+describe('Node Depth Test', () => {
+  const root = Node.rootNode();
+  test('should return 1 when node only has root parent', () => {
+    const node = new Node({ id: 'node', parent: root } as any);
+    expect(getNodeDepth(node)).toEqual(1);
+  });
+
+  test('should return 2 when node has two ancestors', () => {
+    const node1 = new Node({ id: 'node1', parent: root } as any);
+    const node2 = new Node({ id: 'node2', parent: node1 } as any);
+    expect(getNodeDepth(node1)).toEqual(1);
+    expect(getNodeDepth(node2)).toEqual(2);
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/cell/cell-spec.ts
@@ -1,5 +1,4 @@
 import type { SimpleBBox } from '@antv/g-canvas';
-import { getNodeDepth } from './../../../../src/utils/cell/cell';
 import { CellBorderPosition, type CellTheme } from '@/common/interface';
 import type { AreaRange } from '@/common/interface/scroll';
 import {
@@ -9,7 +8,6 @@ import {
   getTextAreaRange,
   getBorderPositionAndStyle,
 } from '@/utils/cell/cell';
-import { Node } from '@/facet/layout/node';
 
 describe('Cell Content Test', () => {
   test('should return content area', () => {
@@ -559,20 +557,5 @@ describe('Horizontal Scrolling Text Position Test', () => {
       x2: 200,
       y2: 49,
     });
-  });
-});
-
-describe('Node Depth Test', () => {
-  const root = Node.rootNode();
-  test('should return 1 when node only has root parent', () => {
-    const node = new Node({ id: 'node', parent: root } as any);
-    expect(getNodeDepth(node)).toEqual(1);
-  });
-
-  test('should return 2 when node has two ancestors', () => {
-    const node1 = new Node({ id: 'node1', parent: root } as any);
-    const node2 = new Node({ id: 'node2', parent: node1 } as any);
-    expect(getNodeDepth(node1)).toEqual(1);
-    expect(getNodeDepth(node2)).toEqual(2);
   });
 });

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -1,5 +1,6 @@
 import type { SimpleBBox } from '@antv/g-canvas';
 import { merge } from 'lodash';
+import { ROOT_ID } from '../../common/constant/basic';
 import type {
   AreaRange,
   CellTheme,
@@ -10,6 +11,8 @@ import type {
   TextBaseline,
 } from '../../common/interface';
 import { CellBorderPosition } from '../../common/interface';
+import type { Node } from '../../facet/layout/node';
+
 /**
  * -----------------------------
  * |           padding         |
@@ -422,4 +425,16 @@ export const adjustColHeaderScrollingTextPosition = (
   return textAlign === 'left'
     ? startX - offset
     : startX + offset - actionIconSpace;
+};
+
+export const getNodeDepth = (node: Node) => {
+  let depth = 0;
+  while (node) {
+    if (node.id === ROOT_ID) {
+      break;
+    }
+    depth++;
+    node = node.parent;
+  }
+  return depth;
 };

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -426,15 +426,3 @@ export const adjustColHeaderScrollingTextPosition = (
     ? startX - offset
     : startX + offset - actionIconSpace;
 };
-
-export const getNodeDepth = (node: Node) => {
-  let depth = 0;
-  while (node) {
-    if (node.id === ROOT_ID) {
-      break;
-    }
-    depth++;
-    node = node.parent;
-  }
-  return depth;
-};

--- a/packages/s2-core/src/utils/cell/cell.ts
+++ b/packages/s2-core/src/utils/cell/cell.ts
@@ -1,6 +1,5 @@
 import type { SimpleBBox } from '@antv/g-canvas';
 import { merge } from 'lodash';
-import { ROOT_ID } from '../../common/constant/basic';
 import type {
   AreaRange,
   CellTheme,
@@ -11,7 +10,6 @@ import type {
   TextBaseline,
 } from '../../common/interface';
 import { CellBorderPosition } from '../../common/interface';
-import type { Node } from '../../facet/layout/node';
 
 /**
  * -----------------------------

--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -10,7 +10,6 @@ import {
   size,
   trim,
 } from 'lodash';
-import { getNodeDepth } from '../cell/cell';
 import {
   ID_SEPARATOR,
   ROOT_BEGINNING_REGEX,
@@ -272,8 +271,9 @@ export const copyData = (
   );
 
   // get max query property length
-  const rowLength = rowLeafNodes.reduce((maxDepth, node) => {
-    const depth = getNodeDepth(node);
+  const maxRowDepth = rowLeafNodes.reduce((maxDepth, node) => {
+    // 第一层的level为0
+    const depth = (node.level ?? 0) + 1;
     return depth > maxDepth ? depth : maxDepth;
   }, 0);
   // Generate the table body.
@@ -403,28 +403,26 @@ export const copyData = (
             colNodes.find(({ field }) => field === columns[index])?.label || '',
             ...item,
           ];
-          // eslint-disable-next-line no-else-return
-        } else {
-          // 行头展开多少层，则复制多少层的内容。不进行全量复制。 eg: 树结构下，行头为 省份/城市, 折叠所有城市，则只复制省份
-
-          const copiedRows = rows.slice(0, rowLength);
-          // 在趋势分析表中，行头只有一个 extra的维度，但是有有个层级
-          if (copiedRows.length < rowLength) {
-            copiedRows.unshift(
-              ...Array(rowLength - copiedRows.length).fill(''),
-            );
-          }
-          return [
-            ...copiedRows.map(
-              (row) => sheetInstance.dataSet.getFieldName(row) || '',
-            ),
-            ...item,
-          ];
         }
+        // 行头展开多少层，则复制多少层的内容。不进行全量复制。 eg: 树结构下，行头为 省份/城市, 折叠所有城市，则只复制省份
+
+        const copiedRows = rows.slice(0, maxRowDepth);
+        // 在趋势分析表中，行头只有一个 extra的维度，但是有有个层级
+        if (copiedRows.length < maxRowDepth) {
+          copiedRows.unshift(
+            ...Array(maxRowDepth - copiedRows.length).fill(''),
+          );
+        }
+        return [
+          ...copiedRows.map(
+            (row) => sheetInstance.dataSet.getFieldName(row) || '',
+          ),
+          ...item,
+        ];
       }
 
       return index < colHeader.length
-        ? Array(rowLength)
+        ? Array(maxRowDepth)
             .fill('')
             .concat(...item)
         : rowsHeader.concat(...item);

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -1,4 +1,10 @@
-import { EXTRA_COLUMN_FIELD, type S2DataConfig } from '@antv/s2';
+import {
+  EXTRA_COLUMN_FIELD,
+  isUpDataValue,
+  type S2DataConfig,
+  type S2Options,
+} from '@antv/s2';
+import { isNil } from 'lodash';
 
 const getKPIMockData = () => {
   return {
@@ -346,5 +352,49 @@ export const StrategySheetDataConfig: S2DataConfig = {
         ],
       },
     ],
+  },
+};
+
+export const StrategyOptions: S2Options = {
+  width: 800,
+  height: 800,
+  cornerText: '指标',
+  placeholder: (v) => {
+    const placeholder = v?.fieldValue ? '-' : '';
+    return placeholder;
+  },
+  headerActionIcons: [
+    {
+      iconNames: ['Trend'],
+      belongsCell: 'rowCell',
+      defaultHide: true,
+      action: () => {},
+    },
+  ],
+  conditions: {
+    text: [
+      {
+        mapping: (value, cellInfo) => {
+          const { meta } = cellInfo;
+          const isNilValue = isNil(value) || value === '';
+          if (meta?.fieldValue?.values[0][0] === value || isNilValue) {
+            return {
+              fill: '#000',
+            };
+          }
+          return {
+            fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
+          };
+        },
+      },
+    ],
+  },
+  style: {
+    cellCfg: {
+      height: 76,
+      valuesCfg: {
+        originalValueField: 'originalValues',
+      },
+    },
   },
 };

--- a/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { copyData, type PivotSheet } from '@antv/s2';
+import {
+  StrategySheetDataConfig,
+  StrategyOptions,
+} from '../data/strategy-data';
+import { SheetComponent } from '../../src';
+import { getContainer } from '../util/helpers';
+
+describe('Spread Sheet Tests', () => {
+  describe('Mount Sheet tests', () => {
+    let container: HTMLDivElement;
+    beforeEach(() => {
+      container = getContainer();
+    });
+
+    afterEach(() => {
+      container?.remove();
+    });
+
+    test('should export correct data of strategy sheet', () => {
+      let s2Instance: PivotSheet;
+      act(() => {
+        ReactDOM.render(
+          <SheetComponent
+            getSpreadSheet={(s2) => {
+              s2Instance = s2;
+            }}
+            sheetType="strategy"
+            options={StrategyOptions}
+            dataCfg={StrategySheetDataConfig}
+          />,
+          container,
+        );
+      });
+
+      // 角头部分展示如下：
+      // ["", "","时间"]
+      // ["", "","数值"]
+      const result = copyData(s2Instance, '\t');
+
+      const rows = result.split('\n');
+      const corner1 = rows[0].split('\t').slice(0, 3);
+      const corner2 = rows[1].split('\t').slice(0, 3);
+      expect(corner1).toEqual(['', '', `"时间"`]);
+      expect(corner2).toEqual(['', '', `"数值"`]);
+    });
+  });
+});

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -59,50 +59,6 @@ export const sliderOptions: SliderSingleProps = {
   },
 };
 
-export const strategyOptions: S2Options = {
-  width: 800,
-  height: 800,
-  cornerText: '指标',
-  placeholder: (v) => {
-    const placeholder = v?.fieldValue ? '-' : '';
-    return placeholder;
-  },
-  headerActionIcons: [
-    {
-      iconNames: ['Trend'],
-      belongsCell: 'rowCell',
-      defaultHide: true,
-      action: () => {},
-    },
-  ],
-  conditions: {
-    text: [
-      {
-        mapping: (value, cellInfo) => {
-          const { meta } = cellInfo;
-          const isNilValue = isNil(value) || value === '';
-          if (meta?.fieldValue?.values[0][0] === value || isNilValue) {
-            return {
-              fill: '#000',
-            };
-          }
-          return {
-            fill: isUpDataValue(value) ? '#FF4D4F' : '#29A294',
-          };
-        },
-      },
-    ],
-  },
-  style: {
-    cellCfg: {
-      height: 76,
-      valuesCfg: {
-        originalValueField: 'originalValues',
-      },
-    },
-  },
-};
-
 export const mockGridAnalysisOptions: S2Options = {
   width: 1600,
   height: 600,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -45,13 +45,15 @@ import { SheetComponent } from '../src';
 import { customTreeFields } from '../__tests__/data/custom-tree-fields';
 import { dataCustomTrees } from '../__tests__/data/data-custom-trees';
 import { mockGridAnalysisDataCfg } from '../__tests__/data/grid-analysis-data';
-import { StrategySheetDataConfig } from '../__tests__/data/strategy-data';
+import {
+  StrategySheetDataConfig,
+  StrategyOptions,
+} from '../__tests__/data/strategy-data';
 import {
   defaultOptions,
   mockGridAnalysisOptions,
   pivotSheetDataCfg,
   sliderOptions,
-  strategyOptions,
   tableSheetDataCfg,
 } from './config';
 import './index.less';
@@ -958,7 +960,7 @@ function MainLayout() {
           <SheetComponent
             sheetType="strategy"
             dataCfg={strategyDataCfg}
-            options={strategyOptions}
+            options={StrategyOptions}
             onRowCellClick={logHandler('onRowCellClick')}
             header={{
               title: '趋势分析表',

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-data-set.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-data-set.ts
@@ -4,13 +4,15 @@ import {
   type S2DataConfig,
   EXTRA_FIELD,
   VALUE_FIELD,
+  type Meta,
+  i18n,
 } from '@antv/s2';
 
 export class StrategyDataSet extends CustomTreePivotDataSet {
   processDataCfg(dataCfg: S2DataConfig): S2DataConfig {
     dataCfg.fields.rows = [EXTRA_FIELD];
     dataCfg.fields.valueInCols = false;
-    const { data, ...restCfg } = dataCfg;
+    const { data, meta, ...restCfg } = dataCfg;
     const transformedData = [];
     forEach(data, (dataItem) => {
       let isPushed = false;
@@ -28,8 +30,19 @@ export class StrategyDataSet extends CustomTreePivotDataSet {
         transformedData.push(dataItem);
       }
     });
+
+    const extraFieldName =
+      this.spreadsheet?.options?.cornerExtraFieldText || i18n('数值');
+
+    const extraFieldMeta: Meta = {
+      field: EXTRA_FIELD,
+      name: extraFieldName,
+    };
+    const newMeta: Meta[] = [...meta, extraFieldMeta];
+
     return {
       data: uniq(transformedData),
+      meta: newMeta,
       ...restCfg,
     };
   }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
趋势分析表即使有多个层级的行头，`rows`配置也只有`extra`，此时，角头部分需要增加占位来对齐行头的单元格，以下图为例：
![image](https://user-images.githubusercontent.com/17964556/178293332-4e897b8a-aed3-4524-ba15-d271f88efae0.png)

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/178293768-abb11d96-5a53-4d73-8d51-1f166fa957f7.png) | ![image](https://user-images.githubusercontent.com/17964556/178293454-a0f678d4-dd4e-4cb3-b89e-67fe61a58816.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
