### PR TITLE
fix: 下钻个数为-1时应展示全部下钻数据

### DIFF
--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -64,7 +64,7 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
 
   // limit displayed drill down data by drillItemsNum
   const drillItemsNum = spreadsheet.store.get('drillItemsNum');
-  if (drillItemsNum && isDrillDownItem) {
+  if (isDrillDownItem && drillItemsNum > 0) {
     fieldValues = fieldValues.slice(0, drillItemsNum);
   }
 

--- a/packages/s2-react/__tests__/unit/utils/drill-down-spec.ts
+++ b/packages/s2-react/__tests__/unit/utils/drill-down-spec.ts
@@ -12,6 +12,7 @@ import {
 } from '@antv/s2';
 import {
   buildDrillDownOptions,
+  DrillDownParams,
   getDrillDownCache,
   handleActionIconClick,
   handleDrillDown,
@@ -105,9 +106,31 @@ describe('Drill Down Test', () => {
     cityNode.spreadsheet = mockInstance;
   });
 
+  test('should set correct drilldownNum', () => {
+    const getDrillDownParams = (drillItemsNum?: number) =>
+      ({
+        rows: mockDataCfg.fields.rows,
+        drillFields: ['district'],
+        fetchData,
+        spreadsheet: mockInstance,
+        drillItemsNum,
+      } as DrillDownParams);
+
+    // drillDownNum = undefined
+    handleDrillDown(getDrillDownParams());
+    expect(mockInstance.store.get('drillItemsNum')).toEqual(-1);
+
+    // reset
+    mockInstance.store.get('drillItemsNum', undefined);
+
+    // drillDownNum = integer
+    handleDrillDown(getDrillDownParams(19));
+    expect(mockInstance.store.get('drillItemsNum')).toEqual(19);
+  });
+
   test('for handleDrillDown function', async () => {
     mockInstance.store.set('drillDownNode', cityNode);
-    const drillDownCfg = {
+    const drillDownCfg: DrillDownParams = {
       rows: mockDataCfg.fields.rows,
       drillFields: ['district'],
       fetchData,

--- a/packages/s2-shared/src/utils/drill-down.ts
+++ b/packages/s2-shared/src/utils/drill-down.ts
@@ -161,10 +161,10 @@ export const buildDrillDownOptions = (
 };
 
 export const handleDrillDown = (params: DrillDownParams) => {
-  const { fetchData, spreadsheet, drillFields, drillItemsNum } = params;
-  if (drillItemsNum) {
-    spreadsheet.store.set('drillItemsNum', drillItemsNum);
-  }
+  const { fetchData, spreadsheet, drillFields, drillItemsNum = -1 } = params;
+
+  spreadsheet.store.set('drillItemsNum', drillItemsNum);
+
   const meta = spreadsheet.store.get('drillDownNode');
   const { drillDownDataCache, drillDownCurrentCache } = getDrillDownCache(
     spreadsheet,


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
s2 通过 drillItemsNum 来约束下钻维度展示的个数，但是没有特殊判断 -1、0 等。
实际只有 drillItemsNum > 0 时，限制才会有意义。

> 附：清空下钻数据时，s2 也会把下钻个数重置为 -1 `clearDrillDownData@pivot-data-set.ts`，导致问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
