### PR TITLE
fix(s2-vue): 修复表头排序交互不起作用的问题

### DIFF
--- a/packages/s2-vue/src/components/tooltip/components/operator/index.vue
+++ b/packages/s2-vue/src/components/tooltip/components/operator/index.vue
@@ -19,9 +19,13 @@ export default defineComponent({
     'onClick',
     'cell',
   ] as unknown as GetInitProps<TooltipOperatorProps>,
-  setup() {
+  setup(props, { emit }) {
+    const onMenuClick = (...args) => {
+      emit('click', ...args);
+    };
     return {
       TOOLTIP_PREFIX_CLS,
+      onMenuClick,
     };
   },
   components: {
@@ -38,7 +42,7 @@ export default defineComponent({
     <template v-if="onlyMenu">
       <Menu
         :class="`${TOOLTIP_PREFIX_CLS}-operator-menus`"
-        @click="$.emit('click')"
+        @click="onMenuClick"
       >
         <template v-for="menu in menus" :key="menu.key">
           <TooltipOperatorMenu :menu="menu" :cell="cell" />
@@ -52,7 +56,7 @@ export default defineComponent({
           <template #overlay>
             <Menu
               :class="`${TOOLTIP_PREFIX_CLS}-operator-menus`"
-              @click="$.emit('click')"
+              @click="onMenuClick"
               v-if="menu?.children?.length"
             >
               <template v-for="menu in menus" :key="menu.key">

--- a/packages/s2-vue/src/components/tooltip/components/operator/menu.vue
+++ b/packages/s2-vue/src/components/tooltip/components/operator/menu.vue
@@ -5,6 +5,7 @@ import {
   TOOLTIP_PREFIX_CLS,
 } from '@antv/s2';
 import { Menu } from 'ant-design-vue';
+import { isEmpty } from 'lodash';
 import { defineComponent } from 'vue';
 import type { GetInitProps } from '../../../../interface';
 import TooltipOperatorTitle from './title.vue';
@@ -23,6 +24,7 @@ export default defineComponent({
     };
     return {
       onMenuTitleClick,
+      isEmpty,
       TOOLTIP_PREFIX_CLS,
     };
   },
@@ -36,6 +38,7 @@ export default defineComponent({
 
 <template>
   <SubMenu
+    v-if="!isEmpty(menu.children)"
     :key="menu.key"
     :popupClassName="`${TOOLTIP_PREFIX_CLS}-operator-submenu-popup`"
     @titleClick="onMenuTitleClick"
@@ -54,6 +57,10 @@ export default defineComponent({
       </template>
     </template>
   </SubMenu>
+  <!-- v-if/else branches must use unique keys. -->
+  <MenuItem v-if="isEmpty(menu.children)" :title="menu.text" :key="menu.key">
+    <TooltipOperatorTitle :menu="menu" @click="onMenuTitleClick" />
+  </MenuItem>
 </template>
 
 <style lang="less"></style>


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1554 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

表面上是排序交互不起作用，实质上是s2-vue在生成菜单时有一种边界情况没有处理：

![image](https://user-images.githubusercontent.com/17797002/178685223-a743d4ee-1ea1-4eee-a93d-5796e8ef0828.png)

P.s：这个bug是我昨天报告的，由于项目现在需要这个功能，所以给你们提个PR，希望能尽快处理🙃

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![before](https://user-images.githubusercontent.com/17797002/178448607-2a6d4dd6-94a8-4c14-be4e-9a4651fd9098.gif) |  ![Kapture 2022-07-13 at 16 20 34](https://user-images.githubusercontent.com/17797002/178686194-53341ae7-ab66-4ca3-9b98-f8a82f566566.gif) |
| ❌      | ✅     |


### 🔗 Related issue link

https://github.com/antvis/S2/issues/1554

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
