### PR TITLE
fix: 修复明细表最左侧边框绘制问题

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1539-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1539-spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @description spec for issue #1539
+ * https://github.com/antvis/S2/issues/1539
+ * 明细表，开启序号时，左侧边框丢失
+ *
+ */
+import { getContainer } from 'tests/util/helpers';
+import type { IGroup } from '@antv/g-canvas';
+import dataCfg from '../data/simple-table-data.json';
+import { TableSheet } from '@/sheet-type';
+import type { S2Options } from '@/common/interface';
+
+const s2Options: S2Options = {
+  width: 600,
+  height: 400,
+};
+
+describe('Table Left Border Tests', () => {
+  test('should draw left border without series number', () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, s2Options);
+    s2.render();
+
+    const panelScrollGroup = s2.facet.panelGroup.getChildren()[0];
+    const gridGroup = (panelScrollGroup as any).gridGroup as IGroup;
+    const leftBorder = gridGroup.getChildren()[0].getBBox();
+
+    expect(leftBorder.x).toEqual(-0.5);
+    expect(leftBorder.y).toEqual(-0.5);
+  });
+
+  test('should draw left border with series number', () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, {
+      ...s2Options,
+      showSeriesNumber: true,
+    });
+    s2.render();
+
+    const panelScrollGroup = s2.facet.panelGroup.getChildren()[0];
+    const gridGroup = (panelScrollGroup as any).gridGroup as IGroup;
+    const leftBorder = gridGroup.getChildren()[0].getBBox();
+
+    expect(leftBorder.x).toEqual(-0.5);
+    expect(leftBorder.y).toEqual(-0.5);
+  });
+});

--- a/packages/s2-core/src/facet/layout/build-table-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-table-hierarchy.ts
@@ -31,7 +31,7 @@ export const buildTableHierarchy = (params: TableHeaderParams) => {
   }
 
   generateHeaderNodes({
-    currentField: displayedColumns[0],
+    currentField: fields[0],
     fields,
     fieldValues,
     facetCfg,

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -298,7 +298,7 @@ export class TableFacet extends BaseFacet {
       allNodes.length,
     );
 
-    const adaptiveColWitdth = this.getAdaptiveColWidth(colLeafNodes);
+    const adaptiveColWidth = this.getAdaptiveColWidth(colLeafNodes);
 
     const nodes = [];
 
@@ -309,7 +309,7 @@ export class TableFacet extends BaseFacet {
       currentNode.x = preLeafNode.x + preLeafNode.width;
       currentNode.width = this.calculateColLeafNodesWidth(
         currentNode,
-        adaptiveColWitdth,
+        adaptiveColWidth,
       );
       preLeafNode = currentNode;
       currentNode.y = 0;
@@ -348,7 +348,7 @@ export class TableFacet extends BaseFacet {
 
   private calculateColLeafNodesWidth(
     col: Node,
-    adaptiveColWitdth: number,
+    adaptiveColWidth: number,
   ): number {
     const { colCfg, dataSet, spreadsheet } = this.cfg;
     const layoutWidthType = this.spreadsheet.getLayoutWidthType();
@@ -402,7 +402,7 @@ export class TableFacet extends BaseFacet {
             EXTRA_PIXEL;
         }
       } else {
-        colWidth = adaptiveColWitdth;
+        colWidth = adaptiveColWidth;
       }
 
       if (col.field === SERIES_NUMBER_FIELD) {

--- a/packages/s2-core/src/group/grid-group.ts
+++ b/packages/s2-core/src/group/grid-group.ts
@@ -1,6 +1,9 @@
 import type { IGroup } from '@antv/g-canvas';
 import { Group } from '@antv/g-canvas';
-import { KEY_GROUP_GRID_GROUP } from '../common/constant';
+import {
+  KEY_GROUP_GRID_GROUP,
+  KEY_GROUP_PANEL_FROZEN_COL,
+} from '../common/constant';
 import type { GridInfo } from '../common/interface';
 import type { SpreadSheet } from '../sheet-type/spread-sheet';
 import { renderLine } from '../utils/g-renders';
@@ -22,9 +25,15 @@ export class GridGroup extends Group {
 
   public updateGrid = (gridInfo: GridInfo, id = KEY_GROUP_GRID_GROUP) => {
     const bbox = this.getBBox();
-    const { theme, isTableMode, options } = this.s2;
+    const { theme, isTableMode } = this.s2;
+
     const style = theme.dataCell.cell;
-    const shoudDrawLeftBorder = isTableMode() && !options.showSeriesNumber;
+    // 在明细表中需要补全左侧的边框，分为两种情况：
+    // 1. 存在行头冻结，需要为冻结的行头组添加边框
+    // 2. 不存在行头冻结，需要为默认的 Grid 组添加边框
+    const shouldDrawLeftBorder =
+      isTableMode() &&
+      (id === KEY_GROUP_GRID_GROUP || id === KEY_GROUP_PANEL_FROZEN_COL);
 
     if (!this.gridGroup || !this.findById(id)) {
       this.gridGroup = this.addGroup({
@@ -35,8 +44,7 @@ export class GridGroup extends Group {
     this.gridGroup.clear();
 
     this.gridInfo = gridInfo;
-
-    if (shoudDrawLeftBorder) {
+    if (shouldDrawLeftBorder) {
       this.gridInfo.cols.unshift(0);
     }
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1539 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
明细表使用 grid 进行边框绘制时，对左侧边框是否绘制判断逻辑有问题，同时会导致行列冻结时，clip区域有错误，明细表绘制左边边框的场景有两种：
1. 存在行头冻结，需要为冻结的行头组添加边框
2. 不存在行头冻结，需要为默认的 Grid 组添加边框
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![2022-07-14 12 01 12](https://user-images.githubusercontent.com/17964556/178895851-6e03fe12-5a1d-4d0c-aa69-aa6bb60b2513.gif) ![2022-07-14 12 01 49](https://user-images.githubusercontent.com/17964556/178895882-fc3e84e0-b182-4afa-ac33-ac54ff968eb4.gif)     |    ![2022-07-14 12 00 36](https://user-images.githubusercontent.com/17964556/178895763-5ae12675-7c89-4f73-a6ea-ad58d4a2e148.gif)  ![2022-07-14 12 00 13](https://user-images.githubusercontent.com/17964556/178895746-4980c46a-1831-4d31-af51-b7ced6889af0.gif) |


### 🔗 Related issue link



<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
