### PR TITLE
fix(strategysheet): 修复子弹图进度小于 1% 时显示错误的问题

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,6 @@ jobs:
         node-version: [16]
 
     steps:
-      # 每次 push 代码时取消上一次的 CI, 避免排队
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@main
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,6 @@ jobs:
         node-version: [16]
 
     steps:
-      # 每次 push 代码时取消上一次的 CI, 避免排队
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@main
-        with:
-          access_token: ${{ github.token }}
-
       - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -369,7 +369,7 @@ export const getTheme = (
         // ------------- bullet graph -----------------
         bullet: {
           progressBar: {
-            widthPercent: 0.7,
+            widthPercent: 0.75,
             height: 10,
             innerHeight: 6,
           },

--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -204,33 +204,32 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     return;
   }
 
-  const FRACTION_DIGITS = 2;
   const dataCellStyle = cell.getStyle(CellTypes.DATA_CELL);
   const bulletStyle = dataCellStyle.miniChart.bullet;
   const { x, y, height, width } = cell.getMeta();
   const { progressBar, comparativeMeasure, rangeColors, backgroundColor } =
     bulletStyle;
 
+  const { measure, target } = value;
+  const displayMeasure = Math.max(Number(measure), 0);
+  const displayTarget = Math.max(Number(target), 0);
+
   // 原本是 "0%", 需要精确到浮点数后两位, 保证数值很小时能正常显示, 显示的百分比格式为 "0.22%"
-  // 所以子弹图需要为小数点后两位的额外数值预留宽度, 即 `.22`
-  const simplePercentText = `.${'0'.repeat(FRACTION_DIGITS)}`;
+  // 所以子弹图需要为数值预留宽度
+  const measurePercent = transformRatioToPercent(displayMeasure, 2);
   const measurePercentWidth = Math.ceil(
-    measureTextWidth(simplePercentText, dataCellStyle),
+    measureTextWidth(measurePercent, dataCellStyle),
   );
 
   const bulletWidth = progressBar.widthPercent * width - measurePercentWidth;
   const measureWidth = width - bulletWidth;
 
   const padding = dataCellStyle.cell.padding;
-  const { measure, target } = value;
-
-  const displayMeasure = Math.max(Number(measure), 0);
-  const displayTarget = Math.max(Number(target), 0);
 
   // TODO 先支持默认右对齐
   // 绘制子弹图
   // 1. 背景
-  const positionX = x + width - padding.right - bulletWidth;
+  const positionX = x + width - padding.right - padding.left - bulletWidth;
   const positionY = y + height / 2 - progressBar.height / 2;
 
   renderRect(cell, {
@@ -279,10 +278,6 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
   );
 
   // 4.绘制指标
-  const measurePercent = transformRatioToPercent(
-    displayMeasure,
-    FRACTION_DIGITS,
-  );
   renderText(
     cell,
     [],

--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -19,7 +19,7 @@ import {
   renderText,
 } from '../utils/g-renders';
 import { CellTypes, MiniChartTypes } from '../common/constant';
-import { getEllipsisText } from './text';
+import { getEllipsisText, measureTextWidth } from './text';
 
 /**
  *  坐标转换
@@ -180,6 +180,7 @@ export const getBulletRangeColor = (
   if (delta > 0.1 && delta <= 0.2) {
     return rangeColors.satisfactory;
   }
+
   return rangeColors.bad;
 };
 
@@ -202,22 +203,36 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
   if (isEmpty(value)) {
     return;
   }
+
+  const FRACTION_DIGITS = 2;
   const dataCellStyle = cell.getStyle(CellTypes.DATA_CELL);
   const bulletStyle = dataCellStyle.miniChart.bullet;
   const { x, y, height, width } = cell.getMeta();
   const { progressBar, comparativeMeasure, rangeColors, backgroundColor } =
     bulletStyle;
-  const bulletWidth = progressBar.widthPercent * width;
+
+  // 原本是 "0%", 需要精确到浮点数后两位, 保证数值很小时能正常显示, 显示的百分比格式为 "0.22%"
+  // 所以子弹图需要为小数点后两位的额外数值预留宽度, 即 `.22`
+  const simplePercentText = `.${'0'.repeat(FRACTION_DIGITS)}`;
+  const measurePercentWidth = Math.ceil(
+    measureTextWidth(simplePercentText, dataCellStyle),
+  );
+
+  const bulletWidth = progressBar.widthPercent * width - measurePercentWidth;
   const measureWidth = width - bulletWidth;
 
   const padding = dataCellStyle.cell.padding;
   const { measure, target } = value;
+
+  const displayMeasure = Math.max(Number(measure), 0);
+  const displayTarget = Math.max(Number(target), 0);
 
   // TODO 先支持默认右对齐
   // 绘制子弹图
   // 1. 背景
   const positionX = x + width - padding.right - bulletWidth;
   const positionY = y + height / 2 - progressBar.height / 2;
+
   renderRect(cell, {
     x: positionX,
     y: positionY,
@@ -232,18 +247,19 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     cell.getMeta(),
     'spreadsheet.options.bullet.getRangeColor',
   );
+
   renderRect(cell, {
     x: positionX,
     y: positionY + (progressBar.height - progressBar.innerHeight) / 2,
-    width: Math.min(bulletWidth * Number(measure), bulletWidth),
+    width: Math.min(bulletWidth * displayMeasure, bulletWidth),
     height: progressBar.innerHeight,
     fill:
-      getRangeColor?.(measure, target) ??
-      getBulletRangeColor(measure, target, rangeColors),
+      getRangeColor?.(displayMeasure, displayTarget) ??
+      getBulletRangeColor(displayMeasure, displayTarget, rangeColors),
   });
 
   // 3.测量标记线
-  const lineX = positionX + bulletWidth * Number(target);
+  const lineX = positionX + bulletWidth * displayTarget;
   renderLine(
     cell,
     {
@@ -262,9 +278,11 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     },
   );
 
-  const measurePercent = transformRatioToPercent(measure);
-
-  // 绘制指标
+  // 4.绘制指标
+  const measurePercent = transformRatioToPercent(
+    displayMeasure,
+    FRACTION_DIGITS,
+  );
   renderText(
     cell,
     [],
@@ -279,7 +297,7 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
   );
 };
 
-export const renderChart = (data: MiniChartData, cell: S2CellType) => {
+export const renderMiniChart = (data: MiniChartData, cell: S2CellType) => {
   switch (data?.type) {
     case MiniChartTypes.Line:
       drawLine(data, cell);

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -24,7 +24,7 @@ import type {
 import type { Padding, TextTheme } from '../common/interface/theme';
 import { renderText } from '../utils/g-renders';
 import { getOffscreenCanvas } from './canvas';
-import { renderChart } from './g-mini-charts';
+import { renderMiniChart } from './g-mini-charts';
 
 /**
  * 计算文本在画布中的宽度
@@ -395,8 +395,9 @@ export const drawObjectText = (
   const { valuesCfg } = options.style.cellCfg;
   // 趋势分析表默认只作用一个条件（因为指标挂行头，每列都不一样，直接在回调里判断是否需要染色即可）
   const textCondition = options?.conditions?.text?.[0];
+
   if (!isArray(textValues)) {
-    renderChart(textValues, cell);
+    renderMiniChart(textValues, cell);
     return;
   }
 

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -20,12 +20,12 @@ const getKPIMockData = () => {
     },
     'measure-b': {
       originalValues: {
-        measure: 0.25,
-        target: 0.8,
+        measure: -0.82607,
+        target: 0.53022,
       },
       values: {
-        measure: '0.25',
-        target: '0.8',
+        measure: -0.82607,
+        target: 0.53022,
       },
     },
     'measure-c': {

--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -11,6 +11,7 @@ import { SheetType } from '@antv/s2-shared';
 import type { Event as GEvent } from '@antv/g-canvas';
 import { SheetComponent, SheetComponentsProps } from '../../../../src';
 import { getContainer } from '../../../util/helpers';
+import { StrategySheetDataConfig } from '../../../data/strategy-data';
 
 describe('<SheetComponent/> Tests', () => {
   let s2: SpreadSheet;
@@ -54,10 +55,13 @@ describe('<SheetComponent/> Tests', () => {
         ReactDOM.render(
           <SheetComponent
             sheetType="strategy"
-            options={customMerge(options, {
-              width: 200,
-              height: 200,
-            })}
+            options={customMerge(
+              {
+                width: 200,
+                height: 200,
+              },
+              options,
+            )}
             dataCfg={dataCfg}
             getSpreadSheet={(instance) => {
               s2 = instance;
@@ -154,5 +158,38 @@ describe('<SheetComponent/> Tests', () => {
         expect(s2.tooltip.container.innerText).toEqual(content);
       },
     );
+
+    test('should render correctly KPI bullet column measure text', () => {
+      renderStrategySheet(
+        {
+          width: 600,
+          height: 600,
+        },
+        StrategySheetDataConfig,
+      );
+
+      // 当前测试数据, 第二列是子弹图
+      const dataCell = s2.interaction
+        .getPanelGroupAllDataCells()
+        .filter((cell) => {
+          const meta = cell.getMeta();
+          return meta.colIndex === 1 && meta.fieldValue;
+        });
+
+      const bulletMeasureTextList = dataCell.map((cell) => {
+        const textShape = cell
+          .getChildren()
+          .find((child) => child.cfg.type === 'text');
+        return textShape?.attr('text');
+      });
+
+      expect(bulletMeasureTextList).toStrictEqual([
+        '0.25%',
+        '0.00%',
+        '100.00%',
+        '50.00%',
+        '68.00%',
+      ]);
+    });
   });
 });

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -33,6 +33,8 @@ export const s2Options: S2Options = {
   showSeriesNumber: false,
   interaction: {
     enableCopy: true,
+    // 防止 mac 触摸板横向滚动触发浏览器返回
+    overscrollBehavior: 'contain',
   },
   tooltip: {
     operation: {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 绘制字段图指标时, 由于浮点数精度为 0, 导致低于 1% 的数值显示错误, 修改为 toFixed(2)

![image](https://user-images.githubusercontent.com/21015895/178919343-4a40045a-acf6-41bd-bc74-a926303883cb.png)

2. 子弹图绘制预留额外的宽度, 以便于完整的显示 `0%` => `0.22%`, 解决文本部分越界的问题
3. 兼容目标为负数的场景, 按照进度为 `0` 处理  (KPI 目标 和普通的双向柱状图, 负数左, 正数右不同)


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/178920235-c3d8fb1b-4e0d-4566-a770-0feb50614718.png) | ![image](https://user-images.githubusercontent.com/21015895/178920297-8ef22def-fc1d-4e97-930c-563bb378b5d0.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
