### PR TITLE
fix: 修复 line 包围盒问题

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1539-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1539-spec.ts
@@ -24,8 +24,8 @@ describe('Table Left Border Tests', () => {
     const gridGroup = (panelScrollGroup as any).gridGroup as IGroup;
     const leftBorder = gridGroup.getChildren()[0].getBBox();
 
-    expect(leftBorder.x).toEqual(-0.5);
-    expect(leftBorder.y).toEqual(-0.5);
+    expect(leftBorder.x).toBeLessThanOrEqual(1);
+    expect(leftBorder.y).toBeLessThanOrEqual(1);
   });
 
   test('should draw left border with series number', () => {
@@ -38,8 +38,7 @@ describe('Table Left Border Tests', () => {
     const panelScrollGroup = s2.facet.panelGroup.getChildren()[0];
     const gridGroup = (panelScrollGroup as any).gridGroup as IGroup;
     const leftBorder = gridGroup.getChildren()[0].getBBox();
-
-    expect(leftBorder.x).toEqual(-0.5);
-    expect(leftBorder.y).toEqual(-0.5);
+    expect(leftBorder.x).toBeLessThanOrEqual(1);
+    expect(leftBorder.y).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/s2-core/__tests__/bugs/issue-1561-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1561-spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @description spec for issue #1561
+ * https://github.com/antvis/S2/issues/1561
+ * 内容未填充整个画布且存在滚动条（横向或者纵向）情况下，拖动滚动条会导致边框绘制到内容区之外
+ *
+ */
+import { getContainer } from 'tests/util/helpers';
+import type { IGroup } from '@antv/g-canvas';
+import dataCfg from '../data/simple-table-data.json';
+import { TableSheet } from '@/sheet-type';
+import type { S2Options } from '@/common/interface';
+
+const s2Options: S2Options = {
+  width: 200,
+  height: 1000,
+};
+
+describe('Grid Border Tests', () => {
+  test('should draw left border without series number', () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, s2Options);
+    s2.render();
+
+    const panelScrollGroup = s2.facet.panelGroup.getChildren()[0];
+    const gridGroup = (panelScrollGroup as any).gridGroup as IGroup;
+    const originalLeftBorderBbox = gridGroup.getChildren()[0].getBBox();
+
+    s2.facet.updateScrollOffset({ offsetX: { value: 100, animate: false } });
+    s2.facet.updateScrollOffset({ offsetX: { value: 200, animate: false } });
+    s2.facet.updateScrollOffset({ offsetX: { value: 300, animate: false } });
+    s2.facet.updateScrollOffset({ offsetX: { value: 0, animate: false } });
+    const newLeftBorderBbox = gridGroup.getChildren()[0].getBBox();
+
+    const widthRatio =
+      newLeftBorderBbox.maxX -
+      newLeftBorderBbox.minX -
+      (originalLeftBorderBbox.maxX - originalLeftBorderBbox.minX);
+    const heightRatio =
+      newLeftBorderBbox.maxY -
+      newLeftBorderBbox.minY -
+      (originalLeftBorderBbox.maxY - originalLeftBorderBbox.minY);
+    // g绘制时，会将坐标1变成0.5，来达到真正绘制1px的效果，因此宽高不一定完全相同，会有1px的差值
+    expect(widthRatio).not.toBeGreaterThan(1);
+    expect(heightRatio).not.toBeGreaterThan(1);
+  });
+});

--- a/packages/s2-core/__tests__/bugs/issue-1561-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1561-spec.ts
@@ -39,7 +39,7 @@ describe('Grid Border Tests', () => {
       newLeftBorderBbox.minY -
       (originalLeftBorderBbox.maxY - originalLeftBorderBbox.minY);
     // g绘制时，会将坐标1变成0.5，来达到真正绘制1px的效果，因此宽高不一定完全相同，会有1px的差值
-    expect(widthRatio).not.toBeGreaterThan(1);
-    expect(heightRatio).not.toBeGreaterThan(1);
+    expect(widthRatio).toBeLessThanOrEqual(1);
+    expect(heightRatio).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -85,3 +85,6 @@ export enum MiniChartTypes {
   Bar = 'bar',
   Bullet = 'bullet',
 }
+
+// 线条 linecap 样式
+export const SQUARE_LINE_CAP = 'square';

--- a/packages/s2-core/src/group/grid-group.ts
+++ b/packages/s2-core/src/group/grid-group.ts
@@ -3,6 +3,7 @@ import { Group } from '@antv/g-canvas';
 import {
   KEY_GROUP_GRID_GROUP,
   KEY_GROUP_PANEL_FROZEN_COL,
+  SQUARE_LINE_CAP,
 } from '../common/constant';
 import type { GridInfo } from '../common/interface';
 import type { SpreadSheet } from '../sheet-type/spread-sheet';
@@ -68,7 +69,7 @@ export class GridGroup extends Group {
           stroke: style.verticalBorderColor,
           strokeOpacity: style.verticalBorderColorOpacity,
           lineWidth: verticalBorderWidth,
-          lineCap: 'square',
+          lineCap: SQUARE_LINE_CAP,
         },
       );
     });
@@ -88,7 +89,7 @@ export class GridGroup extends Group {
           stroke: style.horizontalBorderColor,
           strokeOpacity: style.horizontalBorderColorOpacity,
           lineWidth: horizontalBorderWidth,
-          lineCap: 'square',
+          lineCap: SQUARE_LINE_CAP,
         },
       );
     });

--- a/packages/s2-core/src/group/grid-group.ts
+++ b/packages/s2-core/src/group/grid-group.ts
@@ -48,41 +48,51 @@ export class GridGroup extends Group {
       this.gridInfo.cols.unshift(0);
     }
 
-    this.gridInfo.cols.forEach((item) => {
-      const x = Math.max(item - style.verticalBorderWidth / 2, 0);
+    // line 在绘制时，包围盒计算有点问题，会代入lineWidth
+    // 比如传入的 x1=0, x2=10, lineWidth=20
+    // 最后line得出来的包围盒 minX=-10, maxX=20，会将lineWidth/2纳入计算中
+    // 最后就会导致更新过程中，GridGroup的包围盒不断被放大
+    // 因此在传入时，将这部分坐标减去，并结合lineCap将这部分绘制出来，达到内容区域绘制不变，包围盒计算正确的目的
+    const verticalBorderWidth = style.verticalBorderWidth;
+    const halfVerticalBorderWidthBorderWidth = style.verticalBorderWidth / 2;
+    this.gridInfo.cols.forEach((x) => {
       renderLine(
         this.gridGroup as Group,
         {
           x1: x,
           x2: x,
-          y1: Math.ceil(bbox.minY),
-          y2: Math.floor(bbox.maxY),
+          y1: Math.ceil(bbox.minY + halfVerticalBorderWidthBorderWidth),
+          y2: Math.floor(bbox.maxY - halfVerticalBorderWidthBorderWidth),
         },
         {
           stroke: style.verticalBorderColor,
           strokeOpacity: style.verticalBorderColorOpacity,
-          lineWidth: style.verticalBorderWidth,
+          lineWidth: verticalBorderWidth,
+          lineCap: 'square',
         },
       );
     });
 
-    this.gridInfo.rows.forEach((item) => {
-      const y = item - style.horizontalBorderWidth / 2;
+    const horizontalBorderWidth = style.horizontalBorderWidth;
+    const halfHorizontalBorderWidth = style.horizontalBorderWidth / 2;
+    this.gridInfo.rows.forEach((y) => {
       renderLine(
         this.gridGroup as Group,
         {
-          x1: Math.ceil(bbox.minX),
-          x2: Math.floor(bbox.maxX),
+          x1: Math.ceil(bbox.minX + halfHorizontalBorderWidth),
+          x2: Math.floor(bbox.maxX - halfHorizontalBorderWidth),
           y1: y,
           y2: y,
         },
         {
           stroke: style.horizontalBorderColor,
           strokeOpacity: style.horizontalBorderColorOpacity,
-          lineWidth: style.horizontalBorderWidth,
+          lineWidth: horizontalBorderWidth,
+          lineCap: 'square',
         },
       );
     });
+
     this.gridGroup.toFront();
   };
 }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1561 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
 grid line 在绘制时，包围盒计算有点问题，会代入lineWidth
比如传入的 x1=0, x2=10, lineWidth=20
最后line得出来的包围盒 minX=-10, maxX=20，会将lineWidth/2纳入计算中
最后就会导致更新过程中，GridGroup的包围盒不断被放大，并且只会出现在 lineWidth >=2时（猜测是 lineWith=1 时，lineWidth/2会向下取整为0了，当好负负得正）
因此在传入时，将这部分坐标减去，并结合lineCap将这部分绘制出来，达到内容区域绘制不变，包围盒计算正确的目的
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![2022-07-15 14 30 21](https://user-images.githubusercontent.com/17964556/179164982-455ab170-3586-45e4-b140-0df0d4e2bd96.gif)![2022-07-15 14 30 33](https://user-images.githubusercontent.com/17964556/179164986-6c419cac-499e-4217-bd92-8c2694ac24aa.gif)      | ![2022-07-15 14 30 48](https://user-images.githubusercontent.com/17964556/179164993-75bc556a-568d-429d-a622-72d3c8627283.gif) ![2022-07-15 14 31 04](https://user-images.githubusercontent.com/17964556/179165002-1798256a-de21-44bb-b438-9d5d100e494d.gif)     |



### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
