### PR TITLE
fix: 修复合并单元格被grid边框覆盖的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/merge-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-cell-spec.ts
@@ -38,7 +38,11 @@ describe('Merge Cells Test', () => {
   beforeEach(() => {
     mockInstance = new MockSpreadSheet();
     mockInstance.store = new Store();
-    mockInstance.interaction = {} as unknown as RootInteraction;
+    mockInstance.interaction = {
+      getPanelGroupAllDataCells() {
+        return mockAllVisibleCells;
+      },
+    } as unknown as RootInteraction;
     mockInstance.facet = {
       cfg: {
         dataCell: jest.fn(),
@@ -297,11 +301,19 @@ describe('Merge Cells Test', () => {
         height: 100,
         mergedCellsInfo: [mockMergeCellInfo],
       };
-      mockInstance.panelScrollGroup = {
+      mockInstance.interaction = {
+        getPanelGroupAllDataCells() {
+          return [];
+        },
+      } as unknown as RootInteraction;
+
+      mockInstance.mergedCellsGroup = {
         getChildren: jest.fn().mockReturnValue([]),
       } as unknown as GridGroup;
+
       updateMergedCells(mockInstance);
-      expect(mockInstance.panelScrollGroup.getChildren).toHaveBeenCalled();
+
+      expect(mockInstance.mergedCellsGroup.getChildren).not.toHaveBeenCalled();
     });
 
     test('should merge TempMergedCell when cell viewMeta id is equal. (mergeTempMergedCell)', () => {

--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -25,6 +25,7 @@ export const KEY_GROUP_BACK_GROUND = 'backGroundGroup';
 export const KEY_GROUP_FORE_GROUND = 'foreGroundGroup';
 export const KEY_GROUP_PANEL_GROUND = 'panelGroup';
 export const KEY_GROUP_PANEL_SCROLL = 'panelScrollGroup';
+export const KEY_GROUP_MERGED_CELLS = 'mergedCellsGroup';
 export const KEY_GROUP_PANEL_FROZEN_ROW = 'frozenRowGroup';
 export const KEY_GROUP_PANEL_FROZEN_COL = 'frozenColGroup';
 export const KEY_GROUP_PANEL_FROZEN_TRAILING_ROW = 'frozenTrailingRowGroup';

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -435,6 +435,7 @@ export abstract class BaseFacet {
     }
     this.foregroundGroup.set('children', []);
     this.backgroundGroup.set('children', []);
+    this.spreadsheet.mergedCellsGroup?.set('children', []);
   };
 
   scrollWithAnimation = (
@@ -1008,6 +1009,7 @@ export abstract class BaseFacet {
         findOne?.remove(true);
       });
       updateMergedCells(this.spreadsheet);
+
       DebuggerUtil.getInstance().logger(
         `Render Cell Panel: ${allCells?.length}, Add: ${add?.length}, Remove: ${remove?.length}`,
       );
@@ -1230,10 +1232,15 @@ export abstract class BaseFacet {
 
     this.realCellRender(scrollX, scrollY);
     this.drawGrid();
+    this.putMergedCellsGroupToFront();
     this.translateRelatedGroups(scrollX, scrollY, hRowScrollX);
     this.clip(scrollX, scrollY);
     this.emitScrollEvent({ scrollX, scrollY });
     this.onAfterScroll();
+  }
+
+  private putMergedCellsGroupToFront() {
+    this.spreadsheet.mergedCellsGroup?.toFront();
   }
 
   private emitScrollEvent(position: CellScrollPosition) {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -1,5 +1,10 @@
 import EE from '@antv/event-emitter';
-import { Canvas, Event as CanvasEvent, type IGroup } from '@antv/g-canvas';
+import {
+  Canvas,
+  Event as CanvasEvent,
+  Group,
+  type IGroup,
+} from '@antv/g-canvas';
 import {
   forEach,
   forIn,
@@ -15,6 +20,7 @@ import {
   FRONT_GROUND_GROUP_CONTAINER_Z_INDEX,
   KEY_GROUP_BACK_GROUND,
   KEY_GROUP_FORE_GROUND,
+  KEY_GROUP_MERGED_CELLS,
   KEY_GROUP_PANEL_GROUND,
   KEY_GROUP_PANEL_SCROLL,
   MIN_DEVICE_PIXEL_RATIO,
@@ -103,6 +109,9 @@ export abstract class SpreadSheet extends EE {
   public panelGroup: IGroup;
 
   public panelScrollGroup: PanelScrollGroup;
+
+  // 包含合并单元格的组
+  public mergedCellsGroup: IGroup;
 
   public frozenRowGroup: FrozenGroup;
 
@@ -649,6 +658,14 @@ export abstract class SpreadSheet extends EE {
       s2: this,
     });
     this.panelGroup.add(this.panelScrollGroup);
+
+    this.mergedCellsGroup = new Group({
+      name: KEY_GROUP_MERGED_CELLS,
+      zIndex: PANEL_GROUP_SCROLL_GROUP_Z_INDEX,
+      s2: this,
+    });
+
+    this.panelScrollGroup.add(this.mergedCellsGroup);
   }
 
   public getInitColumnLeafNodes(): Node[] {

--- a/packages/s2-core/src/utils/interaction/merge-cell.ts
+++ b/packages/s2-core/src/utils/interaction/merge-cell.ts
@@ -8,6 +8,7 @@ import {
   map,
 } from 'lodash';
 import { MergedCell } from '../../cell/merged-cell';
+import { DataCell } from '../../cell/data-cell';
 import { CellTypes } from '../../common/constant';
 import type {
   MergedCellInfo,
@@ -190,6 +191,7 @@ export const getTempMergedCell = (
   if (isPartiallyVisible) {
     const { cells: invisibleCells, cellsMeta: invisibleMeta } =
       getInvisibleInfo(invisibleCellInfo, sheet);
+
     viewMeta = viewMeta || invisibleMeta;
     mergedAllCells = cells.concat(invisibleCells);
   }
@@ -246,7 +248,7 @@ export const mergeCell = (
 
   const allVisibleCells = filter(
     sheet.panelScrollGroup.getChildren(),
-    (child) => !(child instanceof MergedCell),
+    (child) => child instanceof DataCell,
   ) as unknown as S2CellType[];
   const { cells, viewMeta, isPartiallyVisible } = getTempMergedCell(
     allVisibleCells,
@@ -260,7 +262,7 @@ export const mergeCell = (
       mergedCellsInfo: mergedCellInfoList,
     });
     const meta = hideData ? undefined : viewMeta;
-    sheet.panelScrollGroup.add(
+    sheet.mergedCellsGroup.add(
       new MergedCell(sheet, cells, meta, isPartiallyVisible),
     );
   }
@@ -384,7 +386,7 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
   // 可见区域的所有cells
   const allCells = filter(
     sheet.panelScrollGroup.getChildren(),
-    (child) => !(child instanceof MergedCell),
+    (child) => child instanceof DataCell,
   ) as unknown as S2CellType[];
   if (isEmpty(allCells)) return;
 
@@ -397,10 +399,8 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
     }
   });
   // 获取 oldTempMergedCells 便用后续进行 diff 操作
-  const oldMergedCells = filter(
-    sheet.panelScrollGroup.getChildren(),
-    (child) => child instanceof MergedCell,
-  ) as unknown as MergedCell[];
+  const oldMergedCells =
+    sheet.mergedCellsGroup.getChildren() as unknown as MergedCell[];
 
   const oldTempMergedCells: TempMergedCell[] =
     MergedCellConvertTempMergedCells(oldMergedCells);
@@ -424,7 +424,7 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
   });
   // add new MergedCells
   forEach(addTempMergedCells, ({ cells, viewMeta, isPartiallyVisible }) => {
-    sheet.panelScrollGroup.add(
+    sheet.mergedCellsGroup.add(
       new MergedCell(sheet, cells, viewMeta, isPartiallyVisible),
     );
   });

--- a/packages/s2-core/src/utils/interaction/merge-cell.ts
+++ b/packages/s2-core/src/utils/interaction/merge-cell.ts
@@ -8,7 +8,6 @@ import {
   map,
 } from 'lodash';
 import { MergedCell } from '../../cell/merged-cell';
-import { DataCell } from '../../cell/data-cell';
 import { CellTypes } from '../../common/constant';
 import type {
   MergedCellInfo,
@@ -246,10 +245,7 @@ export const mergeCell = (
     return;
   }
 
-  const allVisibleCells = filter(
-    sheet.panelScrollGroup.getChildren(),
-    (child) => child instanceof DataCell,
-  ) as unknown as S2CellType[];
+  const allVisibleCells = sheet.interaction.getPanelGroupAllDataCells();
   const { cells, viewMeta, isPartiallyVisible } = getTempMergedCell(
     allVisibleCells,
     sheet,
@@ -384,10 +380,8 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
   if (isEmpty(mergedCellsInfo)) return;
 
   // 可见区域的所有cells
-  const allCells = filter(
-    sheet.panelScrollGroup.getChildren(),
-    (child) => child instanceof DataCell,
-  ) as unknown as S2CellType[];
+  const allCells = sheet.interaction.getPanelGroupAllDataCells();
+
   if (isEmpty(allCells)) return;
 
   // allVisibleTempMergedCells 所有可视区域的 mergedCell


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1560 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
原因：gridGroup用于绘制边框，绘制完成后会`toFront`，导致它被放在最上面的，把合并单元格给盖住了。
现在将所有的合并单元格收敛到`mergedCellsGroup`中统一管理，并且在`drawGrid`后，将`mergedCellsGroup` toFront，保证其不会被覆盖

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![2022-07-15 18 07 58](https://user-images.githubusercontent.com/17964556/179202560-583146ee-56bf-4191-970b-faf61081a300.gif)      | ![2022-07-15 18 07 37](https://user-images.githubusercontent.com/17964556/179202552-65083c7e-c71b-4fc4-b14a-47597d4e6c13.gif)     |




### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
