### PR TITLE
fix: s2-vue 保持和react组件一致的tooltip summary渲染逻辑

### DIFF
--- a/packages/s2-vue/src/components/tooltip/components/summary.vue
+++ b/packages/s2-vue/src/components/tooltip/components/summary.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { size, reduce } from 'lodash';
-import { i18n, type SummaryProps, TOOLTIP_PREFIX_CLS } from '@antv/s2';
+import { i18n, type SummaryProps, type TooltipSummaryOptions, TOOLTIP_PREFIX_CLS } from '@antv/s2';
 import { computed, defineComponent } from 'vue';
 import type { GetInitProps } from '../../../interface';
 
@@ -8,12 +8,25 @@ export default defineComponent({
   name: 'TooltipSummary',
   props: ['summaries'] as unknown as GetInitProps<SummaryProps>,
   setup(props) {
-    const count = computed(() =>
-      reduce(props.summaries, (pre, next) => pre + size(next?.selectedData), 0),
+    const summaryInfo = computed(() =>
+      reduce(
+        props.summaries,
+        (pre, next) => {
+          pre.count += size(next?.selectedData);
+          if (next.value || next.name) {
+            pre.summaries.push(next);
+          }
+          return pre;
+        },
+        { count: 0, summaries: [] } as {
+          count: number;
+          summaries: Array<TooltipSummaryOptions>;
+        },
+      ),
     );
 
     return {
-      count: count.value,
+      summaryInfo,
       i18n,
       TOOLTIP_PREFIX_CLS,
     };
@@ -26,12 +39,12 @@ export default defineComponent({
   <div :class="`${TOOLTIP_PREFIX_CLS}-summary`">
     <div :class="`${TOOLTIP_PREFIX_CLS}-summary-item`">
       <span :class="`${TOOLTIP_PREFIX_CLS}-selected`">
-        {{ count }} {{ i18n('项') }}
+        {{ summaryInfo.count }} {{ i18n('项') }}
       </span>
       {{ i18n('已选择') }}
     </div>
     <div
-      v-for="summary in summaries"
+      v-for="summary in summaryInfo.summaries"
       :key="`${summary.name}-${summary.value}`"
       :class="`${TOOLTIP_PREFIX_CLS}-summary-item`"
     >


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1575

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
s2-vue 明细表圈选多个 dataCell 不应该显示总和

### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/8591261/179470755-2dc977df-c53d-4f0b-ae8d-13285ba7b609.png)
![image](https://user-images.githubusercontent.com/8591261/179470877-191100ae-d09f-465d-b95d-711bec55b347.png)


| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
