### PR TITLE
fix: 修复初始化时, border不见的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -5,6 +5,7 @@ import { Canvas, Group } from '@antv/g-canvas';
 import { assembleDataCfg, assembleOptions } from 'tests/util';
 import { size, get, find } from 'lodash';
 import { getMockPivotMeta } from './util';
+import type { PanelScrollGroup } from '@/group/panel-scroll-group';
 import { SpreadSheet } from '@/sheet-type';
 import { PivotDataSet } from '@/data-set/pivot-data-set';
 import { PivotFacet } from '@/facet/pivot-facet';
@@ -15,7 +16,6 @@ import { DEFAULT_OPTIONS, DEFAULT_STYLE } from '@/common/constant/options';
 import { ColHeader, CornerHeader, Frame, RowHeader } from '@/facet/header';
 import type { ViewMeta } from '@/common/interface/basic';
 import { RootInteraction } from '@/interaction/root';
-import type { GridGroup } from '@/group/grid-group';
 
 jest.mock('@/interaction/root');
 
@@ -35,8 +35,8 @@ jest.mock('@/sheet-type', () => {
     height: 100,
     container: document.body,
   });
-  const panelScrollGroup = new Group({}) as GridGroup;
-  panelScrollGroup.updateGrid = () => {};
+  const panelScrollGroup = new Group({}) as PanelScrollGroup;
+  panelScrollGroup.update = () => {};
   container.add(panelScrollGroup);
   return {
     SpreadSheet: jest.fn().mockImplementation(() => {

--- a/packages/s2-core/__tests__/unit/utils/merge-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-cell-spec.ts
@@ -1,3 +1,4 @@
+import type { IGroup } from '@antv/g-canvas';
 import { SpreadSheet } from '@/sheet-type';
 import { Store } from '@/common/store';
 import {
@@ -23,7 +24,6 @@ import type {
 } from '@/common/interface';
 import type { BaseFacet } from '@/facet';
 import type { MergedCell } from '@/cell';
-import type { GridGroup } from '@/group/grid-group';
 
 jest.mock('@/sheet-type');
 
@@ -282,17 +282,19 @@ describe('Merge Cells Test', () => {
         mergedCellsInfo: undefined,
       };
 
-      mockInstance.panelScrollGroup = {
+      const mergedCellsGroup = {
         getChildren: jest.fn().mockReturnValue([]),
-      } as unknown as GridGroup;
-      updateMergedCells(mockInstance);
-      expect(mockInstance.panelScrollGroup.getChildren).not.toHaveBeenCalled();
+      } as unknown as IGroup;
+
+      updateMergedCells(mockInstance, mergedCellsGroup);
+
+      expect(mergedCellsGroup.getChildren).not.toHaveBeenCalled();
       mockInstance.options = {
         ...mockInstance.options,
         mergedCellsInfo: [],
       };
-      updateMergedCells(mockInstance);
-      expect(mockInstance.panelScrollGroup.getChildren).not.toHaveBeenCalled();
+      updateMergedCells(mockInstance, mergedCellsGroup);
+      expect(mergedCellsGroup.getChildren).not.toHaveBeenCalled();
     });
 
     test('should not update mergedCells when visible area do not contain MergedCell', () => {
@@ -307,13 +309,13 @@ describe('Merge Cells Test', () => {
         },
       } as unknown as RootInteraction;
 
-      mockInstance.mergedCellsGroup = {
+      const mergedCellsGroup = {
         getChildren: jest.fn().mockReturnValue([]),
-      } as unknown as GridGroup;
+      } as unknown as IGroup;
 
-      updateMergedCells(mockInstance);
+      updateMergedCells(mockInstance, mergedCellsGroup);
 
-      expect(mockInstance.mergedCellsGroup.getChildren).not.toHaveBeenCalled();
+      expect(mergedCellsGroup.getChildren).not.toHaveBeenCalled();
     });
 
     test('should merge TempMergedCell when cell viewMeta id is equal. (mergeTempMergedCell)', () => {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -435,7 +435,9 @@ export abstract class BaseFacet {
     }
     this.foregroundGroup.set('children', []);
     this.backgroundGroup.set('children', []);
+    // 在 panelScroll 和 mergedCellsGroups 都清空后，需要重新将mergedCellsGroups设置为panelScroll的子节点，保证它们的初始化层级关系
     this.spreadsheet.mergedCellsGroup?.set('children', []);
+    this.spreadsheet.panelScrollGroup.add(this.spreadsheet.mergedCellsGroup);
   };
 
   scrollWithAnimation = (

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -4,17 +4,7 @@ import { Group } from '@antv/g-canvas';
 import { type GestureEvent, Wheel } from '@antv/g-gesture';
 import { interpolateArray } from 'd3-interpolate';
 import { timer, type Timer } from 'd3-timer';
-import {
-  clamp,
-  debounce,
-  each,
-  find,
-  findKey,
-  get,
-  isUndefined,
-  last,
-  reduce,
-} from 'lodash';
+import { clamp, debounce, each, find, isUndefined, last, reduce } from 'lodash';
 import { DataCell } from '../cell';
 import {
   InterceptType,
@@ -435,9 +425,6 @@ export abstract class BaseFacet {
     }
     this.foregroundGroup.set('children', []);
     this.backgroundGroup.set('children', []);
-    // 在 panelScroll 和 mergedCellsGroups 都清空后，需要重新将mergedCellsGroups设置为panelScroll的子节点，保证它们的初始化层级关系
-    this.spreadsheet.mergedCellsGroup?.set('children', []);
-    this.spreadsheet.panelScrollGroup.add(this.spreadsheet.mergedCellsGroup);
   };
 
   scrollWithAnimation = (
@@ -1010,7 +997,6 @@ export abstract class BaseFacet {
         );
         findOne?.remove(true);
       });
-      updateMergedCells(this.spreadsheet);
 
       DebuggerUtil.getInstance().logger(
         `Render Cell Panel: ${allCells?.length}, Add: ${add?.length}, Remove: ${remove?.length}`,
@@ -1209,9 +1195,9 @@ export abstract class BaseFacet {
     };
   };
 
-  public drawGrid() {
+  public updatePanelScrollGroup() {
     this.gridInfo = this.getGridInfo();
-    this.spreadsheet.panelScrollGroup.updateGrid(this.gridInfo);
+    this.spreadsheet.panelScrollGroup.update(this.gridInfo);
   }
 
   /**
@@ -1233,16 +1219,11 @@ export abstract class BaseFacet {
     );
 
     this.realCellRender(scrollX, scrollY);
-    this.drawGrid();
-    this.putMergedCellsGroupToFront();
+    this.updatePanelScrollGroup();
     this.translateRelatedGroups(scrollX, scrollY, hRowScrollX);
     this.clip(scrollX, scrollY);
     this.emitScrollEvent({ scrollX, scrollY });
     this.onAfterScroll();
-  }
-
-  private putMergedCellsGroupToFront() {
-    this.spreadsheet.mergedCellsGroup?.toFront();
   }
 
   private emitScrollEvent(position: CellScrollPosition) {

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -1151,8 +1151,8 @@ export class TableFacet extends BaseFacet {
     }
   }
 
-  public drawGrid() {
-    super.drawGrid();
+  public updatePanelScrollGroup() {
+    super.updatePanelScrollGroup();
     [
       FrozenGroup.FROZEN_COL,
       FrozenGroup.FROZEN_ROW,

--- a/packages/s2-core/src/group/grid-group.ts
+++ b/packages/s2-core/src/group/grid-group.ts
@@ -10,16 +10,16 @@ import type { SpreadSheet } from '../sheet-type/spread-sheet';
 import { renderLine } from '../utils/g-renders';
 
 export class GridGroup extends Group {
-  private s2: SpreadSheet;
+  protected s2: SpreadSheet;
 
   constructor(cfg) {
     super(cfg);
     this.s2 = cfg.s2;
   }
 
-  private gridGroup: IGroup;
+  protected gridGroup: IGroup;
 
-  private gridInfo: GridInfo = {
+  protected gridInfo: GridInfo = {
     cols: [],
     rows: [],
   };

--- a/packages/s2-core/src/group/panel-scroll-group.ts
+++ b/packages/s2-core/src/group/panel-scroll-group.ts
@@ -1,3 +1,40 @@
+import type { IGroup } from '@antv/g-canvas';
+import { updateMergedCells } from '../utils/interaction/merge-cell';
+import type { GridInfo } from '../common/interface';
+import type { MergedCell } from './../cell/merged-cell';
+import { KEY_GROUP_MERGED_CELLS } from './../common/constant/basic';
 import { GridGroup } from './grid-group';
 
-export class PanelScrollGroup extends GridGroup {}
+export class PanelScrollGroup extends GridGroup {
+  protected mergedCellsGroup: IGroup;
+
+  constructor(cfg) {
+    super(cfg);
+    this.initMergedCellsGroup();
+  }
+
+  protected initMergedCellsGroup() {
+    if (this.mergedCellsGroup && this.findById(KEY_GROUP_MERGED_CELLS)) {
+      return;
+    }
+
+    this.mergedCellsGroup = this.addGroup({
+      id: KEY_GROUP_MERGED_CELLS,
+    });
+  }
+
+  updateMergedCells() {
+    this.initMergedCellsGroup();
+    updateMergedCells(this.s2, this.mergedCellsGroup);
+    this.mergedCellsGroup.toFront();
+  }
+
+  addMergeCell(mergeCell: MergedCell) {
+    this.mergedCellsGroup?.add(mergeCell);
+  }
+
+  update(gridInfo: GridInfo) {
+    this.updateGrid(gridInfo);
+    this.updateMergedCells();
+  }
+}

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -20,7 +20,6 @@ import {
   FRONT_GROUND_GROUP_CONTAINER_Z_INDEX,
   KEY_GROUP_BACK_GROUND,
   KEY_GROUP_FORE_GROUND,
-  KEY_GROUP_MERGED_CELLS,
   KEY_GROUP_PANEL_GROUND,
   KEY_GROUP_PANEL_SCROLL,
   MIN_DEVICE_PIXEL_RATIO,
@@ -109,9 +108,6 @@ export abstract class SpreadSheet extends EE {
   public panelGroup: IGroup;
 
   public panelScrollGroup: PanelScrollGroup;
-
-  // 包含合并单元格的组
-  public mergedCellsGroup: IGroup;
 
   public frozenRowGroup: FrozenGroup;
 
@@ -658,14 +654,6 @@ export abstract class SpreadSheet extends EE {
       s2: this,
     });
     this.panelGroup.add(this.panelScrollGroup);
-
-    this.mergedCellsGroup = new Group({
-      name: KEY_GROUP_MERGED_CELLS,
-      zIndex: PANEL_GROUP_SCROLL_GROUP_Z_INDEX,
-      s2: this,
-    });
-
-    this.panelScrollGroup.add(this.mergedCellsGroup);
   }
 
   public getInitColumnLeafNodes(): Node[] {

--- a/packages/s2-core/src/utils/interaction/merge-cell.ts
+++ b/packages/s2-core/src/utils/interaction/merge-cell.ts
@@ -1,3 +1,4 @@
+import type { IGroup } from '@antv/g-canvas';
 import {
   differenceWith,
   filter,
@@ -257,7 +258,7 @@ export const mergeCell = (
       mergedCellsInfo: mergedCellInfoList,
     });
     const meta = hideData ? undefined : viewMeta;
-    sheet.mergedCellsGroup.add(new MergedCell(sheet, cells, meta));
+    sheet.panelScrollGroup.addMergeCell(new MergedCell(sheet, cells, meta));
   }
 };
 
@@ -367,7 +368,10 @@ export const differenceTempMergedCells = (
  * update the mergedCell
  * @param sheet the base sheet instance
  */
-export const updateMergedCells = (sheet: SpreadSheet) => {
+export const updateMergedCells = (
+  sheet: SpreadSheet,
+  mergedCellsGroup: IGroup,
+) => {
   const mergedCellsInfo = sheet.options?.mergedCellsInfo;
   if (isEmpty(mergedCellsInfo)) return;
 
@@ -386,7 +390,7 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
   });
   // 获取 oldTempMergedCells 便用后续进行 diff 操作
   const oldMergedCells =
-    sheet.mergedCellsGroup.getChildren() as unknown as MergedCell[];
+    mergedCellsGroup.getChildren() as unknown as MergedCell[];
 
   const oldTempMergedCells: TempMergedCell[] =
     MergedCellConvertTempMergedCells(oldMergedCells);
@@ -410,6 +414,6 @@ export const updateMergedCells = (sheet: SpreadSheet) => {
   });
   // add new MergedCells
   forEach(addTempMergedCells, ({ cells, viewMeta }) => {
-    sheet.mergedCellsGroup.add(new MergedCell(sheet, cells, viewMeta));
+    mergedCellsGroup.add(new MergedCell(sheet, cells, viewMeta));
   });
 };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
`mergedCellsGroup`作为`panelScrollGroup`的子节点，在每次`panelScrollGroup`清空时，需要重建父子关系，否则就会出现多次初始后不成功。

原本的`mergedCellsGroup`是作为`sheet`的属性存在，又被挂在了`panelScrollGroup`上，逻辑不够收敛。所以本次改动直接将所有`mergedCellsGroup`收敛到`PanelScrollGroup`中，降低代码耦合性，对于gridGroup和mergedGroup的层级控制也更直接
### 🖼️ Screenshot

| 表格初始化Before | 表格初始化After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/179668563-8bab122b-bddf-47d1-91ec-17c9ab44e7d5.png)      | ![image](https://user-images.githubusercontent.com/17964556/179668469-651f5789-976f-40f8-b41b-1c781763ea5a.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
