### PR TITLE
fix(strategysheet): 修复单元格宽度拖拽变小后子弹图宽度计算错误

### DIFF
--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -211,12 +211,14 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     bulletStyle;
 
   const { measure, target } = value;
+
   const displayMeasure = Math.max(Number(measure), 0);
   const displayTarget = Math.max(Number(target), 0);
 
   // 原本是 "0%", 需要精确到浮点数后两位, 保证数值很小时能正常显示, 显示的百分比格式为 "0.22%"
   // 所以子弹图需要为数值预留宽度
-  const measurePercent = transformRatioToPercent(displayMeasure, 2);
+  // 对于负数, 进度条计算按照 0 处理, 但是展示还是要显示原来的百分比
+  const measurePercent = transformRatioToPercent(measure, 2);
   const measurePercentWidth = Math.ceil(
     measureTextWidth(measurePercent, dataCellStyle),
   );
@@ -247,10 +249,15 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     'spreadsheet.options.bullet.getRangeColor',
   );
 
+  const displayBulletWidth = Math.max(
+    Math.min(bulletWidth * displayMeasure, bulletWidth),
+    0,
+  );
+
   renderRect(cell, {
     x: positionX,
     y: positionY + (progressBar.height - progressBar.innerHeight) / 2,
-    width: Math.min(bulletWidth * displayMeasure, bulletWidth),
+    width: displayBulletWidth,
     height: progressBar.innerHeight,
     fill:
       getRangeColor?.(displayMeasure, displayTarget) ??

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -30,12 +30,12 @@ const getKPIMockData = () => {
     },
     'measure-c': {
       originalValues: {
-        measure: 1,
-        target: 0.3,
+        measure: 10.73922,
+        target: 0.54396,
       },
       values: {
-        measure: '1',
-        target: '0.3',
+        measure: 10.73922,
+        target: 0.54396,
       },
     },
     'measure-d': {

--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -185,8 +185,8 @@ describe('<SheetComponent/> Tests', () => {
 
       expect(bulletMeasureTextList).toStrictEqual([
         '0.25%',
-        '0.00%',
-        '100.00%',
+        '-82.61%',
+        '1073.92%',
         '50.00%',
         '68.00%',
       ]);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

1. 修复当百分比过大, 且列宽过小时, 子弹图宽度计算为负数, 同时 G 又支持 负数绘制, 出现了如下图的效果...

同时需要配合 https://github.com/antvis/S2/pull/1583 对子弹图列做限制, 不允许拖拽缩小宽度

2. 修复百分比为负数时，数值错误的显示为 `0%`，应该是进度为0，但是数值还是为 `-xx%`

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/179733452-cb9f4252-77da-49dc-9a40-df52e21dbf41.png) | ![image](https://user-images.githubusercontent.com/21015895/179733198-366fcced-f4c3-4dd1-a765-405eb679e590.png)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
