### PR TITLE
fix: 有冻结行且有垂直 scrollWidth 时冻结行无法 resize

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -39,7 +39,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       ).toEqual(mockTableDataConfig.fields.columns);
     });
 
-    test('should hidden column correctly', () => {
+    test('should hide column correctly', () => {
       const hiddenColumns = ['cost'];
 
       tableSheet.interaction.hideColumns(hiddenColumns);
@@ -62,7 +62,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       expect(costDetail.hideColumnNodes[0].field).toEqual('cost');
     });
 
-    test('should hidden multiple columns correctly', () => {
+    test('should hide multiple columns correctly', () => {
       const hiddenColumns = ['price', 'city'];
 
       tableSheet.interaction.hideColumns(hiddenColumns);
@@ -98,7 +98,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       expect(cityDetail.hideColumnNodes[0].field).toEqual('city');
     });
 
-    test('should hidden closer group columns correctly', () => {
+    test('should hide closer group columns correctly', () => {
       const hiddenColumns = ['cost', 'province'];
 
       tableSheet.interaction.hideColumns(hiddenColumns);
@@ -125,7 +125,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       expect(groupDetail.hideColumnNodes[1].field).toEqual('province');
     });
 
-    test('should default hidden columns by interaction hiddenColumnFields config', () => {
+    test('should hide columns by interaction hiddenColumnFields config by default', () => {
       const hiddenColumns = ['cost'];
       const sheet = new TableSheet(getContainer(), mockTableDataConfig, {
         ...s2Options,
@@ -184,7 +184,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       ).toEqual([typePriceColumnId, cityPriceColumnId]);
     });
 
-    test('should hidden column correctly', () => {
+    test('should hide column correctly', () => {
       const hiddenColumns = [typePriceColumnId];
 
       pivotSheet.interaction.hideColumns(hiddenColumns);
@@ -207,7 +207,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       expect(priceDetail.hideColumnNodes[0].id).toEqual(typePriceColumnId);
     });
 
-    test('should hidden multiple columns correctly', () => {
+    test('should hide multiple columns correctly', () => {
       const hiddenColumns = [typePriceColumnId, cityPriceColumnId];
 
       pivotSheet.interaction.hideColumns(hiddenColumns);

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -4,6 +4,7 @@ import {
   type S2Options,
   type S2DataConfig,
   ResizeType,
+  ColCell,
 } from '@/index';
 
 const data = getMockData(
@@ -123,5 +124,33 @@ describe('TableSheet normal spec', () => {
       hRowScrollX: 0,
     });
     expect(onScrollFinish).toBeCalled();
+
+    s2.destroy();
   });
+
+  test('should be able to resize frozen col when there is a vertical scroll width', async () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, options);
+    s2.render();
+
+    const onScrollFinish = jest.fn();
+    s2.facet.scrollWithAnimation(
+      {
+        offsetX: {
+          value: 100,
+          animate: true,
+        },
+      },
+      10,
+      onScrollFinish,
+    );
+    await sleep(30);
+
+
+    const firstColCell = s2.getColumnNodes()[1].belongsCell as any
+
+    expect(firstColCell.shouldAddVerticalResizeArea()).toBe(true)
+    expect(firstColCell.getVerticalResizeAreaOffset()).toEqual({ x: 80, y: 0 })
+
+  });
+
 });

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -49,10 +49,10 @@ export class TableColCell extends ColCell {
       this.spreadsheet.dataSet.getFieldName(this.meta.label),
     );
   }
-  
+
   protected shouldAddVerticalResizeArea() {
     if (this.isFrozenCell()) return true
-    else return super.shouldAddVerticalResizeArea()
+    return super.shouldAddVerticalResizeArea()
   }
 
   protected getVerticalResizeAreaOffset() {
@@ -74,10 +74,7 @@ export class TableColCell extends ColCell {
 
   protected getColResizeArea() {
     const isFrozenCell = this.isFrozenCell();
-
-    if (!isFrozenCell) {
-      return super.getColResizeArea();
-    }
+    if (!isFrozenCell) return super.getColResizeArea();
     return getOrCreateResizeAreaGroupById(
       this.spreadsheet,
       KEY_GROUP_FROZEN_COL_RESIZE_AREA,

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -49,6 +49,28 @@ export class TableColCell extends ColCell {
       this.spreadsheet.dataSet.getFieldName(this.meta.label),
     );
   }
+  
+  protected shouldAddVerticalResizeArea() {
+    if (this.isFrozenCell()) return true
+    else return super.shouldAddVerticalResizeArea()
+  }
+
+  protected getVerticalResizeAreaOffset() {
+    const { x, y } = this.meta;
+    const { scrollX, position } = this.headerConfig;
+
+    if (this.isFrozenCell()) {
+      return {
+        x,
+        y,
+      };
+    }
+    return {
+      x: position.x + x - scrollX,
+      y: position.y + y,
+    };
+  }
+
 
   protected getColResizeArea() {
     const isFrozenCell = this.isFrozenCell();


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1593


### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌  
<img width="482" alt="image" src="https://user-images.githubusercontent.com/9219215/180349023-7be7abb1-0ce4-4a63-a198-a619c7cb8bd4.png">
    | ✅   
<img width="871" alt="image" src="https://user-images.githubusercontent.com/9219215/180348937-90fc11ed-07cc-4d02-ad6c-e80ab8e786a8.png">
  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
