### PR TITLE
fix(layout): 修复 Firefox 浏览器部分 icon 渲染失败 close #1571

### DIFF
--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -69,12 +69,13 @@ export class GuiIcon extends Group {
           svg = svg.replace(/fill=[\'\"]#?\w+[\'\"]/g, ''); // 移除 fill="red|#fff"
           svg = svg.replace(/fill>/g, '>'); // fill> 替换为 >
         }
+        svg = svg.replace(
+          STYLE_PLACEHOLDER,
+          `${STYLE_PLACEHOLDER} fill="${fill}"`,
+        );
+        // 兼容 Firefox: https://github.com/antvis/S2/issues/1571 https://stackoverflow.com/questions/30733607/svg-data-image-not-working-as-a-background-image-in-a-pseudo-element/30733736#30733736
         // https://www.chromestatus.com/features/5656049583390720
-        // # 井号不能当做svg的body，这个bug在chrome72已经修复.
-        svg = svg
-          .replace(STYLE_PLACEHOLDER, `${STYLE_PLACEHOLDER} fill="${fill}"`)
-          .replace(/#/g, '%23');
-        img.src = `data:image/svg+xml;utf-8,${svg}`;
+        img.src = `data:image/svg+xml;utf-8,${encodeURIComponent(svg)}`;
       }
     });
   }

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/index.less
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/index.less
@@ -44,6 +44,7 @@
 
     .header-label {
       font-weight: 700;
+      margin-right: 20px;
     }
   }
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1571 

### 📝 Description

![image](https://user-images.githubusercontent.com/21015895/180415010-ee7deaec-ff0a-4dfe-b383-46215644d6c6.png)

1. 之前只对 SVG 中的 `#` 转义, 之前有 `.replace(/#/g, '%23');` 的处理, 未转义完整, 改为 `encodeURIComponent`
2. 为什么只有 `Plus` 和 `Minus` 这两个 icon 加载失败? 原因是有 `\t` (感谢 VSCode)

![image](https://user-images.githubusercontent.com/21015895/180415857-1fea607a-1d9b-4128-9069-ed963e5aab25.png)

![image](https://user-images.githubusercontent.com/21015895/180416507-9ca8df29-2d55-46d5-a7ba-4262acddea5e.png)


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/180415160-d52e029c-e307-469b-b064-a4f38fed391b.png)  | ![image](https://user-images.githubusercontent.com/21015895/180415056-f1b64742-8e43-4350-9868-259b97b4701c.png)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
