### PR TITLE
fix: sortByFunc 排序后行列维度节点丢失

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
+++ b/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
@@ -194,8 +194,11 @@ describe('Sort By Func Tests', () => {
     expect(result).toEqual(originValues);
   });
 
-  test('should return sortFunc result', () => {
+  test('should return merged result', () => {
+    const originValues = ['四川[&]成都', '四川[&]绵阳', '浙江[&]杭州'];
+
     const result = sortByFunc({
+      originValues,
       sortParam: {
         sortFieldId: 'city',
         sortFunc: () => ['浙江[&]杭州'],
@@ -207,7 +210,30 @@ describe('Sort By Func Tests', () => {
       } as unknown as PivotDataSet,
     });
 
-    expect(result).toEqual(['浙江[&]杭州']);
+    // sortFunc 返回的值在前，未返回的值在后
+    expect(result).toEqual(['浙江[&]杭州', '四川[&]成都', '四川[&]绵阳']);
+  });
+
+  test('should return merged result when sorting by ASC', () => {
+    const originValues = ['四川[&]成都', '四川[&]绵阳', '浙江[&]杭州'];
+
+    const result = sortByFunc({
+      originValues,
+      sortParam: {
+        sortMethod: 'ASC',
+        sortFieldId: 'city',
+        sortFunc: () => ['浙江[&]杭州'],
+      },
+      dataSet: {
+        fields: {
+          rows: ['province', 'city'],
+        },
+      } as unknown as PivotDataSet,
+    });
+
+    // asc 升序时
+    // sortFunc 没返回的值在前，返回的值在后
+    expect(result).toEqual(['四川[&]成都', '四川[&]绵阳', '浙江[&]杭州']);
   });
 
   test('should return fallback result', () => {

--- a/packages/s2-core/src/utils/sort-action.ts
+++ b/packages/s2-core/src/utils/sort-action.ts
@@ -119,7 +119,7 @@ export const sortByCustom = (params: SortActionParams): string[] => {
 
 export const sortByFunc = (params: SortActionParams): string[] => {
   const { originValues, measureValues, sortParam, dataSet } = params;
-  const { sortFunc, sortFieldId } = sortParam;
+  const { sortFunc, sortFieldId, sortMethod } = sortParam;
 
   const sortResult = sortFunc({
     data: measureValues,
@@ -145,7 +145,9 @@ export const sortByFunc = (params: SortActionParams): string[] => {
       originValues,
     });
   }
-  return sortResult;
+
+  // 用户返回的 sortResult 可能是不全的，需要用原始数据补全
+  return mergeDataWhenASC(sortResult, originValues, isAscSort(sortMethod));
 };
 
 export const sortByMethod = (params: SortActionParams): string[] => {


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

> 原 issue 描述有偏差，以实际修复说明为准
- [x] Solve the issue and close #1542 

### 📝 Description

如下图所示，使用 sortByFunc 按 mesure 排序时，用户自定义的 sortFunc 会接受通过 query 查询出的数据 sortData。
当某些数据格数据缺失时（如 `湖南` 的城市），返回 sortData 也会对应缺失。

![CleanShot 2022-07-23 at 17 11 39@2x](https://user-images.githubusercontent.com/6716092/180598799-4c16b511-f2a5-4813-b5a8-be59af6f5ffc.png)

在这种情况下，用户使用缺失的数据，经过 sortFunc 返回给 s2 也是缺失的维度数据。


```
 ['四川[&]成都', '四川[&]绵阳', '浙江[&]杭州', '浙江[&]丽水']
```

而缺失的数据会直接存到 `sortedDimensionValues` 里，进而影响后续的 layout 结果。

### 🖼️ Screenshot

> 湖南下属城市消失了

| Before | After |
| ------ | ----- |
|  <img width="808" alt="CleanShot 2022-07-23 at 17 19 14@2x" src="https://user-images.githubusercontent.com/6716092/180598972-060cbbc1-0e0d-4b21-aaf8-f518ef5d0b22.png">      |  <img width="805" alt="CleanShot 2022-07-23 at 17 18 49@2x" src="https://user-images.githubusercontent.com/6716092/180598959-93977f4e-ab1b-4b94-874d-6bf1c4bfbbcb.png">    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [x] Add or update test case.
