### PR TITLE
fix(interaction): 向左移动到不完全可见cell的时候，没有滚动过去

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/selected-cell-move-spec.ts
@@ -30,6 +30,12 @@ describe('Interaction Keyboard Move Tests', () => {
         },
       },
     } as S2Options;
+    s2.theme = {
+      splitLine: {
+        verticalBorderWidth: 1,
+        horizontalBorderWidth: 1,
+      },
+    };
     s2.isTableMode = jest.fn(() => true);
     s2.dataSet = {
       fields: { columns: ['0', '1'] },
@@ -43,8 +49,16 @@ describe('Interaction Keyboard Move Tests', () => {
         ],
       },
       getTotalHeightForRange: (start, end) => 0,
-      scrollWithAnimation: (data) => {},
-      getScrollOffset: () => ({ scrollX: 0, scrollY: 0 }),
+      scrollWithAnimation: (data) => {
+        s2.store.set('scrollX', data?.offsetX?.value);
+        s2.store.set('scrollY', data?.offsetY?.value);
+      },
+      getScrollOffset: () => {
+        return {
+          scrollX: s2.store.get('scrollX', 0),
+          scrollY: s2.store.get('scrollY', 0),
+        };
+      },
       panelBBox: {
         viewportHeight: 200,
         viewportWidth: 200,
@@ -308,5 +322,35 @@ describe('Interaction Keyboard Move Tests', () => {
     expect(s2.interaction.changeState).not.toBeCalled();
 
     s2.interaction.eventController.isCanvasEffect = true;
+  });
+
+  test('should scroll to active cell', () => {
+    s2.interaction.changeState = jest.fn((state) => {});
+    s2.interaction.getCells = () => [mockCell01.mockCell as any];
+    // select cell
+    keyboardMove.startCell = mockCell01.mockCell;
+    keyboardMove.endCell = mockCell01.mockCell;
+    s2.facet.scrollWithAnimation({
+      offsetX: {
+        value: 1,
+      },
+      offsetY: {
+        value: 1,
+      },
+    });
+
+    expect(s2.facet.getScrollOffset()).toEqual({
+      scrollX: 1,
+      scrollY: 1,
+    });
+
+    s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+      key: InteractionKeyboardKey.ARROW_LEFT,
+    } as KeyboardEvent);
+
+    expect(s2.facet.getScrollOffset()).toEqual({
+      scrollX: 0,
+      scrollY: 1,
+    });
   });
 });

--- a/packages/s2-core/src/interaction/selected-cell-move.ts
+++ b/packages/s2-core/src/interaction/selected-cell-move.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@antv/g-canvas';
+import { get } from 'lodash';
 import { type CellMeta, CellTypes, type ViewMeta } from '../common';
 import { InteractionKeyboardKey, S2Event } from '../common/constant';
 import { calculateInViewIndexes } from '../facet/utils';
@@ -235,14 +236,21 @@ export class SelectedCellMove extends BaseEvent implements BaseEventImplement {
     const { colLeafNodes } = facet.layoutResult;
     const { scrollX, scrollY } = facet.getScrollOffset();
     const { viewportHeight: height, viewportWidth: width } = facet.panelBBox;
+    const splitLineStyle = get(spreadsheet, 'theme.splitLine');
     const frozenColWidth = frozenColGroup
-      ? Math.floor(frozenColGroup.getBBox().width)
+      ? Math.floor(
+          frozenColGroup.getBBox().width -
+            splitLineStyle.verticalBorderWidth / 2,
+        )
       : 0;
     const frozenTrailingColWidth = frozenTrailingColGroup
       ? Math.floor(frozenTrailingColGroup.getBBox().width)
       : 0;
     const frozenRowHeight = frozenRowGroup
-      ? Math.floor(frozenRowGroup.getBBox().height)
+      ? Math.floor(
+          frozenRowGroup.getBBox().height -
+            splitLineStyle.horizontalBorderWidth / 2,
+        )
       : 0;
     const frozenTrailingRowHeight = frozenTrailingRowGroup
       ? Math.floor(frozenTrailingRowGroup.getBBox().height)


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1597 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

场景：方向键向左移动之后选中了移动后的Cell（仅最左侧Cell有影响），但是ScrollX没有跟随着滚动过去。

原因：ScrollX比较的是移动后Cell的X和frozenColBBox.width, 这里会出现一种场景，冻结行的分割线是用冻结行右侧X作为中心往两边划的，计算frozenColBBox.width的时候会把verticalBorderWidth / 2 的宽度加上，和cell.x比较会有出入,导致无法正常向左滚动。
![image](https://user-images.githubusercontent.com/16497201/180679561-0984a3d3-416c-4a6c-b5b4-89836b6e8621.png)

解决方案：使用frozenColGroup.getBBox().width - splitLineStyle.verticalBorderWidth / 2来获得真实的冻结行的宽度。


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
