### PR TITLE
fix: 明细表复制时无需使用formatter格式化列头label

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/export-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-spec.ts
@@ -8,7 +8,13 @@ describe('TableSheet Export Test', () => {
     const s2 = new TableSheet(
       getContainer(),
       assembleDataCfg({
-        meta: [],
+        meta: [
+          {
+            field: 'type',
+            name: '产品类型',
+            formatter: (type) => `${type}产品`,
+          },
+        ],
         fields: {
           columns: ['province', 'city', 'type', 'sub_type', 'number'],
         },
@@ -18,7 +24,9 @@ describe('TableSheet Export Test', () => {
       }),
     );
     s2.render();
-    const data = copyData(s2, '\t');
+    const data = copyData(s2, '\t', {
+      isFormatHeader: true,
+    });
     const rows = data.split('\n');
     const headers = rows[0].split('\t');
     // 33行数据 包括一行列头
@@ -31,7 +39,7 @@ describe('TableSheet Export Test', () => {
       '序号',
       'province',
       'city',
-      'type',
+      '产品类型',
       'sub_type',
       'number',
     ]);

--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -358,7 +358,10 @@ export const copyData = (
           arrayLength = max([arrayLength, size(label)]);
         } else {
           // label 为数组时不进行格式化
-          label = isFormatHeader ? getNodeFormatLabel(curColItem) : label;
+          label =
+            isFormatHeader && sheetInstance.isPivotMode()
+              ? getNodeFormatLabel(curColItem)
+              : label;
         }
         tempCol.push(label);
         curColItem = curColItem.parent;


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
复制明细表数据时，`header ` 不应再被 formatter。
因为明细表中，colLeafNodes 各个 node 的 field 就是 fields.column 配置的 field，
表头如果按该 field 取 formatter，而该 formatter 应格式化的是整列的数据，而不是表头 label。
表头 label 直接取 name 即可。

### 🖼️ Screenshot
> console 打印了 `copyData` 的数据，注意表头

| Before | After |
| ------ | ----- |
|    ![CleanShot 2022-07-26 at 10 01 52](https://user-images.githubusercontent.com/6716092/180906447-a5cd472e-5629-4bef-a4e5-b174072d11d4.png)    |  ![CleanShot 2022-07-26 at 10 00 12](https://user-images.githubusercontent.com/6716092/180906281-9fad90b1-fb53-4713-8a35-dd0b251f36e7.png)    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
