### PR TITLE
feat: 支持resize最右侧column

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -1,4 +1,3 @@
-import { fireEvent } from '@testing-library/dom';
 import { getContainer, getMockData, sleep } from 'tests/util/helpers';
 import {
   TableSheet,
@@ -162,19 +161,20 @@ describe('TableSheet normal spec', () => {
 
     await sleep(30);
 
-    fireEvent(s2.getCanvasElement(), new MouseEvent('mousedown', {
+    s2.getCanvasElement().dispatchEvent(new MouseEvent('mousedown', {
       clientX: 839,
       clientY: 88,
     }))
 
-    fireEvent(window, new MouseEvent('mousemove', {
+
+    window.dispatchEvent(new MouseEvent('mousemove', {
       clientX: 900,
       clientY: 88,
 
     }))
     await sleep(300);
 
-    fireEvent(window, new MouseEvent('mouseup', {
+    window.dispatchEvent(new MouseEvent('mouseup', {
       clientX: 900,
       clientY: 88
     }))

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/dom';
 import { getContainer, getMockData, sleep } from 'tests/util/helpers';
 import {
   TableSheet,
@@ -6,7 +7,6 @@ import {
   ResizeType,
   ColCell,
 } from '@/index';
-import { fireEvent } from '@testing-library/dom';
 
 const data = getMockData(
   '../../../s2-react/__tests__/data/tableau-supermarket.csv',
@@ -172,14 +172,14 @@ describe('TableSheet normal spec', () => {
       clientY: 88,
 
     }))
-    await sleep(50);
+    await sleep(300);
 
     fireEvent(window, new MouseEvent('mouseup', {
       clientX: 900,
       clientY: 88
     }))
 
-    await sleep(50);
+    await sleep(300);
 
     const columnNodes = s2.getColumnNodes()
     const lastColumnCell = columnNodes[columnNodes.length - 1].belongsCell as ColCell

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -6,6 +6,7 @@ import {
   ResizeType,
   ColCell,
 } from '@/index';
+import { fireEvent } from '@testing-library/dom';
 
 const data = getMockData(
   '../../../s2-react/__tests__/data/tableau-supermarket.csv',
@@ -97,6 +98,7 @@ const options: S2Options = {
 };
 
 describe('TableSheet normal spec', () => {
+
   test('scrollWithAnimation with duration and callback', async () => {
     const s2 = new TableSheet(getContainer(), dataCfg, options);
     s2.render();
@@ -151,6 +153,38 @@ describe('TableSheet normal spec', () => {
     expect(firstColCell.shouldAddVerticalResizeArea()).toBe(true)
     expect(firstColCell.getVerticalResizeAreaOffset()).toEqual({ x: 80, y: 0 })
 
+    s2.destroy();
   });
+
+  test('should be able to resize last column', async () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, options);
+    s2.render();
+
+    await sleep(30);
+
+    fireEvent(s2.getCanvasElement(), new MouseEvent('mousedown', {
+      clientX: 839,
+      clientY: 88,
+    }))
+
+    fireEvent(window, new MouseEvent('mousemove', {
+      clientX: 900,
+      clientY: 88,
+
+    }))
+    await sleep(50);
+
+    fireEvent(window, new MouseEvent('mouseup', {
+      clientX: 900,
+      clientY: 88
+    }))
+
+    await sleep(50);
+
+    const columnNodes = s2.getColumnNodes()
+    const lastColumnCell = columnNodes[columnNodes.length - 1].belongsCell as ColCell
+    expect(lastColumnCell.getMeta().width).toBe(159)
+  });
+
 
 });

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -161,29 +161,31 @@ describe('TableSheet normal spec', () => {
 
     await sleep(30);
 
+    const { x, width, top } = s2.getCanvasElement().getBoundingClientRect()
     s2.getCanvasElement().dispatchEvent(new MouseEvent('mousedown', {
-      clientX: 839,
-      clientY: 88,
+      clientX: x + width - 1,
+      clientY: top + 25,
     }))
 
 
     window.dispatchEvent(new MouseEvent('mousemove', {
-      clientX: 900,
-      clientY: 88,
+      clientX: x+ width + 100,
+      clientY: top + 25,
 
     }))
     await sleep(300);
 
     window.dispatchEvent(new MouseEvent('mouseup', {
-      clientX: 900,
-      clientY: 88
+      clientX: x + width + 100,
+      clientY: top + 25
     }))
 
     await sleep(300);
 
     const columnNodes = s2.getColumnNodes()
     const lastColumnCell = columnNodes[columnNodes.length - 1].belongsCell as ColCell
-    expect(lastColumnCell.getMeta().width).toBe(159)
+    
+    expect(lastColumnCell.getMeta().width).toBe(199)
   });
 
 

--- a/packages/s2-core/package.json
+++ b/packages/s2-core/package.json
@@ -69,13 +69,15 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "csstype": "^3.0.11",
+    "@testing-library/dom": "^8.16.0",
     "@types/d3-interpolate": "^3.0.1",
     "@types/d3-timer": "^3.0.0",
+    "csstype": "^3.0.11",
+    
     "d3-dsv": "^1.1.1",
-    "tinycolor2": "^1.4.2",
     "inquirer": "^8.2.0",
-    "inquirer-autocomplete-prompt": "^2.0.0"
+    "inquirer-autocomplete-prompt": "^2.0.0",
+    "tinycolor2": "^1.4.2"
   },
   "sideEffects": [
     "*.css",

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -268,6 +268,23 @@ export class EventController {
 
     if (this.isResizeArea(event)) {
       this.spreadsheet.emit(S2Event.LAYOUT_RESIZE_MOUSE_DOWN, event);
+      
+      // 仅捕获在canvas之外触发的事件     https://github.com/antvis/S2/issues/1592
+      const resizeMouseMoveCapture = (mouseEvent: MouseEvent) => {
+        if (!this.spreadsheet.getCanvasElement()) return false;
+        if (this.spreadsheet.getCanvasElement() !== mouseEvent.target) {
+
+          event.clientX = mouseEvent.clientX;
+          event.clientY = mouseEvent.clientY;
+          event.originalEvent = mouseEvent
+          this.spreadsheet.emit(S2Event.LAYOUT_RESIZE_MOUSE_MOVE, event);
+        }
+      }
+
+      window.addEventListener('mousemove', resizeMouseMoveCapture);
+      window.addEventListener('mouseup', () => {
+        window.removeEventListener('mousemove', resizeMouseMoveCapture)
+      }, { once: true })
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,6 +2746,20 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
+"@testing-library/dom@^8.16.0":
+  version "8.16.0"
+  resolved "https://registry.npm.alibaba-inc.com/@testing-library/dom/download/@testing-library/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
+  integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/react-hooks@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,20 +2746,6 @@
     lz-string "^1.4.4"
     pretty-format "^27.0.2"
 
-"@testing-library/dom@^8.16.0":
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/download/@testing-library/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
-  integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^5.0.0"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.9"
-    lz-string "^1.4.4"
-    pretty-format "^27.0.2"
-
 "@testing-library/react-hooks@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2748,7 +2748,7 @@
 
 "@testing-library/dom@^8.16.0":
   version "8.16.0"
-  resolved "https://registry.npm.alibaba-inc.com/@testing-library/dom/download/@testing-library/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/download/@testing-library/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
   integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
   dependencies:
     "@babel/code-frame" "^7.10.4"


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature


🐛 Bugfix

- [x] Solve the issue and close #1592 

🔧 Chore

- [x] Test case

### 📝 Description
原有逻辑对于最右侧column无法resize，因为事件挂载在canvas上，改为mousedown后监听window上的mousemove事件，并在mouseup时销毁


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

![Screen Recording 2022-07-25 at 8 50 07 PM](https://user-images.githubusercontent.com/9219215/180781451-ceef1c3d-6dec-4f19-ab15-68af84756b91.gif)


### 🔗 Related issue link

<!-- close #1592  -->

### 🔍 Self-Check before the merge

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
