### PR TITLE
fix(strategysheet): 修复趋势分析表列头格式化不生效

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/col-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/col-cell-spec.ts
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import type { Node } from '@/facet/layout/node';
 import { PivotDataSet } from '@/data-set';
 import { SpreadSheet, PivotSheet } from '@/sheet-type';
+import type { Formatter, TextAlign } from '@/common';
 import { ColCell } from '@/cell';
-import type { TextAlign } from '@/common';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
@@ -104,5 +104,36 @@ describe('Col Cell Tests', () => {
         });
       },
     );
+  });
+
+  describe('Col Cell Formatter Test', () => {
+    const node = {
+      id: 1,
+      label: 'label',
+      fieldValue: 'fieldValue',
+      value: 'value',
+    } as unknown as Node;
+
+    test('should get correct col cell formatter', () => {
+      const formatter = jest.fn();
+      jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const colCell = new ColCell(node, s2);
+
+      expect(formatter).toHaveBeenCalledWith(node.label, undefined, node);
+    });
+
+    test('should return correct formatted value', () => {
+      const formatter: Formatter = jest.fn(() => 'test');
+
+      jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
+
+      const colCell = new ColCell(node, s2);
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      expect(colCell.textShape.attr('text')).toEqual('test');
+    });
   });
 });

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -7,8 +7,12 @@ import { DataCell } from '@/cell';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
+
 describe('data cell formatter test', () => {
   const meta = {
+    fieldValue: 'fieldValue',
+    label: 'label',
+    value: 'value',
     data: {
       city: 'chengdu',
       value: 12,
@@ -27,18 +31,14 @@ describe('data cell formatter test', () => {
     s2.dataSet = dataSet;
   });
 
-  test('should pass complete data into formater', () => {
+  test('should pass complete data into formatter', () => {
     const formatter = jest.fn();
     jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const dataCell = new DataCell(meta, s2);
 
-    expect(formatter).toHaveBeenCalledWith(undefined, {
-      city: 'chengdu',
-      value: 12,
-      [VALUE_FIELD]: 'value',
-      [EXTRA_FIELD]: 12,
-    });
+    expect(formatter).toHaveBeenCalledWith(meta.fieldValue, meta.data, meta);
   });
 
   test('should return correct formatted value', () => {

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -219,15 +219,11 @@ export class DataCell extends BaseCell<ViewMeta> {
   protected getFormattedFieldValue(): FormatResult {
     const { rowId, valueField, fieldValue, data } = this.meta;
     const rowMeta = this.spreadsheet.dataSet.getFieldMeta(rowId);
-    let formatter: Formatter;
-    if (rowMeta) {
-      // format by row field
-      formatter = this.spreadsheet.dataSet.getFieldFormatter(rowId);
-    } else {
-      // format by value field
-      formatter = this.spreadsheet.dataSet.getFieldFormatter(valueField);
-    }
-    const formattedValue = formatter(fieldValue, data);
+    const fieldId = rowMeta ? rowId : valueField;
+    const formatter = this.spreadsheet.dataSet.getFieldFormatter(fieldId);
+    // TODO: 这里只用 formatter(fieldValue, this.meta) 即可, 为了保持兼容, 暂时在第三个参入传入 meta 信息
+    const formattedValue = formatter(fieldValue, data, this.meta);
+
     return {
       value: fieldValue,
       formattedValue,

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -64,10 +64,8 @@ export abstract class HeaderCell extends BaseCell<Node> {
     this.actionIcons = [];
   }
 
-  // 这个的 getFormattedFieldValue 主要是 row 和 col header 的格式化，这里不需要传递 data info
   protected getFormattedFieldValue(): FormatResult {
     const { label } = this.meta;
-    let content = label;
 
     const formatter = this.spreadsheet.dataSet.getFieldFormatter(
       this.meta.field,
@@ -75,12 +73,13 @@ export abstract class HeaderCell extends BaseCell<Node> {
 
     const isTableMode = this.spreadsheet.isTableMode();
     // 如果是 table mode，列头不需要被格式化
-    if (formatter && !isTableMode) {
-      content = formatter(label);
-    }
+    const formattedValue =
+      formatter && !isTableMode
+        ? formatter(label, undefined, this.meta)
+        : label;
 
     return {
-      formattedValue: content,
+      formattedValue,
       value: label,
     };
   }

--- a/packages/s2-core/src/cell/table-col-cell.ts
+++ b/packages/s2-core/src/cell/table-col-cell.ts
@@ -51,8 +51,10 @@ export class TableColCell extends ColCell {
   }
 
   protected shouldAddVerticalResizeArea() {
-    if (this.isFrozenCell()) return true
-    return super.shouldAddVerticalResizeArea()
+    if (this.isFrozenCell()) {
+      return true;
+    }
+    return super.shouldAddVerticalResizeArea();
   }
 
   protected getVerticalResizeAreaOffset() {
@@ -70,7 +72,6 @@ export class TableColCell extends ColCell {
       y: position.y + y,
     };
   }
-
 
   protected getColResizeArea() {
     const isFrozenCell = this.isFrozenCell();

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -19,7 +19,11 @@ import type { DataItem } from './s2DataConfig';
 // 1. data cell 格式化
 // 2. copy/export
 // 3. tooltip, 且仅在选择多个单元格时，data 类型为数组
-export type Formatter = (v: unknown, data?: Data | Data[]) => string;
+export type Formatter = (
+  v: unknown,
+  data?: Data | Data[],
+  meta?: Node | ViewMeta,
+) => string;
 
 export interface FormatResult {
   formattedValue: string;

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -265,7 +265,7 @@ export const StrategySheetDataConfig: S2DataConfig = {
   meta: [
     {
       field: 'date',
-      name: '时间',
+      name: '日期',
     },
   ],
   fields: {

--- a/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import { copyData, type PivotSheet } from '@antv/s2';
+import { copyData, SpreadSheet } from '@antv/s2';
 import {
   StrategySheetDataConfig,
   StrategyOptions,
@@ -21,7 +21,8 @@ describe('Spread Sheet Tests', () => {
     });
 
     test('should export correct data of strategy sheet', () => {
-      let s2Instance: PivotSheet;
+      let s2Instance: SpreadSheet;
+
       act(() => {
         ReactDOM.render(
           <SheetComponent
@@ -37,14 +38,14 @@ describe('Spread Sheet Tests', () => {
       });
 
       // 角头部分展示如下：
-      // ["", "","时间"]
+      // ["", "","日期"]
       // ["", "","数值"]
       const result = copyData(s2Instance, '\t');
 
       const rows = result.split('\n');
       const corner1 = rows[0].split('\t').slice(0, 3);
       const corner2 = rows[1].split('\t').slice(0, 3);
-      expect(corner1).toEqual(['', '', `"时间"`]);
+      expect(corner1).toEqual(['', '', `"日期"`]);
       expect(corner2).toEqual(['', '', `"数值"`]);
     });
   });

--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -6,8 +6,6 @@ import {
   type S2DataConfig,
   customMerge,
   CellTypes,
-  EXTRA_COLUMN_FIELD,
-  Formatter,
 } from '@antv/s2';
 import { SheetType } from '@antv/s2-shared';
 import type { Event as GEvent } from '@antv/g-canvas';
@@ -37,7 +35,7 @@ describe('<SheetComponent/> Tests', () => {
             <SheetComponent
               sheetType={sheetType}
               options={{ width: 200, height: 200 }}
-              dataCfg={null}
+              dataCfg={null as unknown as S2DataConfig}
             />,
             container,
           );
@@ -50,7 +48,7 @@ describe('<SheetComponent/> Tests', () => {
 
   describe('<StrategySheet/> Tests', () => {
     const renderStrategySheet = (
-      options: SheetComponentsProps['options'],
+      options: SheetComponentsProps['options'] | null,
       dataCfg?: S2DataConfig,
     ) => {
       act(() => {
@@ -218,37 +216,6 @@ describe('<SheetComponent/> Tests', () => {
         .map((element) => (element as any).actualText);
 
       expect(textList).toEqual(['数值', '日期']);
-    });
-
-    test('should format extra column field', () => {
-      const MOCK_NAME = 'test';
-
-      const formatter = jest.fn((value, data, meta) => {
-        return meta?.colIndex === 0 ? MOCK_NAME : value;
-      });
-
-      renderStrategySheet(
-        {
-          width: 600,
-          height: 600,
-        },
-        {
-          ...StrategySheetDataConfig,
-          meta: [
-            {
-              field: EXTRA_COLUMN_FIELD,
-              formatter: formatter as unknown as Formatter,
-            },
-          ],
-        },
-      );
-
-      const { colLeafNodes } = s2.facet.layoutResult;
-
-      expect(formatter).toHaveBeenCalledWith(expect.anything(), undefined, {
-        ...expect.anything(),
-        field: EXTRA_COLUMN_FIELD,
-      });
     });
   });
 });

--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -6,6 +6,8 @@ import {
   type S2DataConfig,
   customMerge,
   CellTypes,
+  EXTRA_COLUMN_FIELD,
+  Formatter,
 } from '@antv/s2';
 import { SheetType } from '@antv/s2-shared';
 import type { Event as GEvent } from '@antv/g-canvas';
@@ -49,7 +51,7 @@ describe('<SheetComponent/> Tests', () => {
   describe('<StrategySheet/> Tests', () => {
     const renderStrategySheet = (
       options: SheetComponentsProps['options'],
-      dataCfg: S2DataConfig = null,
+      dataCfg?: S2DataConfig,
     ) => {
       act(() => {
         ReactDOM.render(
@@ -62,7 +64,7 @@ describe('<SheetComponent/> Tests', () => {
               },
               options,
             )}
-            dataCfg={dataCfg}
+            dataCfg={dataCfg as S2DataConfig}
             getSpreadSheet={(instance) => {
               s2 = instance;
             }}
@@ -94,6 +96,7 @@ describe('<SheetComponent/> Tests', () => {
       };
 
       const s2DataConfig: S2DataConfig = {
+        data: [],
         fields: {
           rows: [],
           customTreeItems: [
@@ -116,6 +119,7 @@ describe('<SheetComponent/> Tests', () => {
       };
 
       const s2DataConfig: S2DataConfig = {
+        data: [],
         fields: {
           values: ['a'],
         },
@@ -190,6 +194,61 @@ describe('<SheetComponent/> Tests', () => {
         '50.00%',
         '9.78%',
       ]);
+    });
+
+    test('should format corner date field', () => {
+      renderStrategySheet(
+        {
+          width: 600,
+          height: 600,
+        },
+        {
+          ...StrategySheetDataConfig,
+          meta: [
+            {
+              field: 'date',
+              name: '日期',
+            },
+          ],
+        },
+      );
+
+      const textList = s2.facet.cornerHeader
+        .getChildren()
+        .map((element) => (element as any).actualText);
+
+      expect(textList).toEqual(['数值', '日期']);
+    });
+
+    test('should format extra column field', () => {
+      const MOCK_NAME = 'test';
+
+      const formatter = jest.fn((value, data, meta) => {
+        return meta?.colIndex === 0 ? MOCK_NAME : value;
+      });
+
+      renderStrategySheet(
+        {
+          width: 600,
+          height: 600,
+        },
+        {
+          ...StrategySheetDataConfig,
+          meta: [
+            {
+              field: EXTRA_COLUMN_FIELD,
+              formatter: formatter as unknown as Formatter,
+            },
+          ],
+        },
+      );
+
+      const { colLeafNodes } = s2.facet.layoutResult;
+
+      expect(formatter).toHaveBeenCalledWith(expect.anything(), undefined, {
+        ...expect.anything(),
+        field: EXTRA_COLUMN_FIELD,
+      });
     });
   });
 });

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -2,7 +2,6 @@ import { isUpDataValue } from '@antv/s2';
 import type { S2DataConfig, S2Options } from '@antv/s2';
 import { getBaseSheetComponentOptions } from '@antv/s2-shared';
 import type { SliderSingleProps } from 'antd';
-import { isNil } from 'lodash';
 import {
   data,
   totalData,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -955,22 +955,6 @@ function MainLayout() {
             dataCfg={{
               data: dataCustomTrees,
               fields: customTreeFields,
-              meta: [
-                {
-                  field: 'type',
-                  formatter: (v, vv) => {
-                    console.log(v, vv);
-                    return 11;
-                  },
-                },
-                {
-                  field: 'sub_type',
-                  formatter: (v, vv) => {
-                    console.log(v, vv);
-                    return 22;
-                  },
-                },
-              ],
             }}
             options={{ width: 600, height: 480, hierarchyType: 'customTree' }}
           />

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -952,7 +952,26 @@ function MainLayout() {
         </TabPane>
         <TabPane tab="自定义目录树" key="customTree">
           <SheetComponent
-            dataCfg={{ data: dataCustomTrees, fields: customTreeFields }}
+            dataCfg={{
+              data: dataCustomTrees,
+              fields: customTreeFields,
+              meta: [
+                {
+                  field: 'type',
+                  formatter: (v, vv) => {
+                    console.log(v, vv);
+                    return 11;
+                  },
+                },
+                {
+                  field: 'sub_type',
+                  formatter: (v, vv) => {
+                    console.log(v, vv);
+                    return 22;
+                  },
+                },
+              ],
+            }}
             options={{ width: 600, height: 480, hierarchyType: 'customTree' }}
           />
         </TabPane>

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-col-cell.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-col-cell.ts
@@ -5,6 +5,7 @@ import {
   Node,
   safeJsonParse,
   SpreadSheet,
+  type MultiData,
 } from '@antv/s2';
 import { isArray } from 'lodash';
 
@@ -25,12 +26,17 @@ export class CustomColCell extends ColCell {
   }
 
   protected drawTextShape() {
-    const fieldValue = this.getMeta()?.value;
-    const values = safeJsonParse(fieldValue);
-    if (isArray(values)) {
-      drawObjectText(this, { values: [values] }, false);
-    } else {
-      super.drawTextShape();
+    const meta = this.getMeta();
+    const value = safeJsonParse(meta?.value) as MultiData;
+
+    if (!isArray(value)) {
+      return super.drawTextShape();
     }
+
+    const { formattedValue } = this.getFormattedFieldValue();
+    const displayValues =
+      formattedValue !== meta?.value ? [[formattedValue]] : [value];
+
+    drawObjectText(this, { values: displayValues }, false);
   }
 }

--- a/s2-site/docs/api/general/S2DataConfig.zh.md
+++ b/s2-site/docs/api/general/S2DataConfig.zh.md
@@ -68,7 +68,7 @@ array object **必选**,_default：null_
 | field  | 字段 id | `string` | |    |
 | name | 字段名称 | `string`|  |   |
 | description | 字段描述，会显示在行头、列头、单元格对应的 tooltip 中 | `string`|  |   |
-| formatter | 格式化 <br/> 单元格、行头和列头支持格式化，角头不支持格式化。只有单元格存在第二个参数。 <br/>数值字段：一般用于格式化数字单位<br/>文本字段：一般用于做字段枚举值的别名<br/> 第二个参数在以下情况会传入：data cell 格式化，复制/导出，tooltip 展示（**且仅在选择多个单元格时，data 类型为数组**） | `(value: unknown, data?: Data | Data[]) => string` | | |
+| formatter | 格式化 <br/> 单元格、行头和列头支持格式化，角头不支持格式化。只有单元格存在第二个参数。 <br/>数值字段：一般用于格式化数字单位<br/>文本字段：一般用于做字段枚举值的别名<br/> 第二个参数在以下情况会传入：data cell 格式化，复制/导出，tooltip 展示（**且仅在选择多个单元格时，data 类型为数组**） | `(value: unknown, data?: Data | Data[], meta?: Node | ViewMeta) => string` | | |
 
 ### MultiData
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close

### 📝 Description

1. 趋势分析表是自定义列头, 渲染文本没有适配 `meta.formatter`

```ts
  meta: [
    {
      field: 'date',
      name: '日期',
    },
    {
      field: EXTRA_COLUMN_FIELD,
      formatter: (value, data, meta) => {
        return meta.colIndex === 0 ? 'test' : value;
      },
    },
  ],
```

2. formmater 增加第三个参数 `meta`, 用于根据当前单元格信息进行格式化

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/180984980-7d0176dd-9c2a-4e8e-8e8f-17227c18633e.png) | ![image](https://user-images.githubusercontent.com/21015895/180984925-c5690be7-89cd-444f-9ea4-789c59609299.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
