### PR TITLE
fix: 链接字段高亮下划线过长

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -68,6 +68,8 @@ jest.mock('@/sheet-type', () => {
         interaction: {
           clearHoverTimer: jest.fn(),
         },
+        measureTextWidth:
+          jest.fn() as unknown as SpreadSheet['measureTextWidth'],
       };
     }),
   };
@@ -189,6 +191,7 @@ describe('Pivot Mode Facet Test', () => {
 
   describe('should get correct result when tree mode', () => {
     s2.isHierarchyTreeType = jest.fn().mockReturnValue(true);
+    const spy = jest.spyOn(s2, 'measureTextWidth').mockReturnValue(30); // 小于 DEFAULT_TREE_ROW_WIDTH
     const mockDataSet = new MockPivotDataSet(s2);
     const treeFacet = new PivotFacet({
       spreadsheet: s2,
@@ -199,6 +202,10 @@ describe('Pivot Mode Facet Test', () => {
       hierarchyType: 'tree',
     });
     const { rowsHierarchy } = treeFacet.layoutResult;
+
+    afterAll(() => {
+      spy.mockRestore();
+    });
 
     test('row hierarchy when tree mode', () => {
       const { cellCfg, spreadsheet } = facet.cfg;

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -173,11 +173,33 @@ describe('Table Mode Facet Test With Adaptive Layout', () => {
 
 describe('Table Mode Facet Test With Compact Layout', () => {
   describe('should get correct col layout', () => {
+    const LABEL_WIDTH = [36, 36, 48, 24, 56]; // 采样的文本宽度
     const ss: SpreadSheet = new MockSpreadSheet();
     const dataSet: TableDataSet = new MockTableDataSet(ss);
     ss.getLayoutWidthType = () => {
       return 'compact';
     };
+
+    const mockMeasureFunc = (text: string | number) => {
+      switch (text) {
+        case '浙江省':
+          return LABEL_WIDTH[0];
+        case '杭州市':
+          return LABEL_WIDTH[1];
+        case '办公用品':
+          return LABEL_WIDTH[2];
+        case '沙发':
+          return LABEL_WIDTH[3];
+        case 'undefined':
+          return LABEL_WIDTH[4];
+        default:
+          return 0;
+      }
+    };
+    ss.measureTextWidth =
+      mockMeasureFunc as unknown as SpreadSheet['measureTextWidth'];
+    ss.measureTextWidthRoughly = mockMeasureFunc;
+
     const facet: TableFacet = new TableFacet({
       spreadsheet: ss,
       dataSet,
@@ -190,7 +212,6 @@ describe('Table Mode Facet Test With Compact Layout', () => {
 
     test('col hierarchy coordinate with compact layout', () => {
       const { colLeafNodes } = facet.layoutResult;
-
       const COMPACT_WIDTH = [53, 53, 65, 41, 73];
 
       let lastX = 0;
@@ -205,11 +226,32 @@ describe('Table Mode Facet Test With Compact Layout', () => {
   });
 
   describe('should get correct col layout with seriesNumber', () => {
+    const LABEL_WIDTH = [36, 36, 48, 24, 56]; // 采样的文本宽度
     const ss: SpreadSheet = new MockSpreadSheet();
     const dataSet: TableDataSet = new MockTableDataSet(ss);
     ss.getLayoutWidthType = () => {
       return 'compact';
     };
+    const mockMeasureFunc = (text: string | number) => {
+      switch (text) {
+        case '浙江省':
+          return LABEL_WIDTH[0];
+        case '杭州市':
+          return LABEL_WIDTH[1];
+        case '办公用品':
+          return LABEL_WIDTH[2];
+        case '沙发':
+          return LABEL_WIDTH[3];
+        case 'undefined': // seriesnumber & price
+          return LABEL_WIDTH[4];
+        default:
+          return 0;
+      }
+    };
+    ss.measureTextWidth =
+      mockMeasureFunc as unknown as SpreadSheet['measureTextWidth'];
+    ss.measureTextWidthRoughly = mockMeasureFunc;
+
     const facet: TableFacet = new TableFacet({
       spreadsheet: ss,
       dataSet,

--- a/packages/s2-core/__tests__/unit/utils/text-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/text-spec.ts
@@ -1,8 +1,8 @@
+import { createPivotSheet } from 'tests/util/helpers';
 import {
   getEllipsisText,
   getEllipsisTextInner,
   isUpDataValue,
-  measureTextWidth,
   getCellWidth,
   getEmptyPlaceholder,
 } from '@/utils/text';
@@ -16,74 +16,91 @@ describe('Text Utils Tests', () => {
     fontWeight: 'normal',
   } as unknown as CSSStyleDeclaration;
 
-  test('should get correct text', () => {
-    const text = getEllipsisText({
-      text: '12',
-      maxWidth: 200,
-      placeholder: '--',
+  describe('Test Widths Tests', () => {
+    let measureTextWidth: (text: number | string, font: unknown) => number;
+
+    beforeEach(() => {
+      measureTextWidth = createPivotSheet(
+        {},
+        { useSimpleData: true },
+      ).measureTextWidth;
     });
 
-    expect(text).toEqual('12');
-  });
+    test('should get correct text', () => {
+      const text = getEllipsisText({
+        measureTextWidth,
+        text: '12',
+        maxWidth: 200,
+        placeholder: '--',
+      });
 
-  test('should get correct text ellipsis', () => {
-    const text = getEllipsisText({
-      text: '12121212121212121212',
-      maxWidth: 20,
-      placeholder: '--',
+      expect(text).toEqual('12');
     });
 
-    expect(text).toEndWith('...');
-    expect(text.length).toBeLessThanOrEqual(5);
-  });
+    test('should get correct text ellipsis', () => {
+      const text = getEllipsisText({
+        measureTextWidth,
+        text: '12121212121212121212',
+        maxWidth: 20,
+        placeholder: '--',
+      });
 
-  test('should get correct placeholder text with ""', () => {
-    const text = getEllipsisText({
-      text: '',
-      maxWidth: 20,
-      placeholder: '--',
-    });
-    expect(text).toEqual('--');
-  });
-
-  test('should get correct placeholder text with 0', () => {
-    const text = getEllipsisText({
-      text: 0 as unknown as string,
-      maxWidth: 20,
-      placeholder: '--',
+      expect(text).toEndWith('...');
+      expect(text.length).toBeLessThanOrEqual(5);
     });
 
-    expect(text).toEqual('0');
-  });
-
-  test('should get correct placeholder text with null', () => {
-    const text = getEllipsisText({
-      text: null,
-      maxWidth: 20,
-      placeholder: '--',
+    test('should get correct placeholder text with ""', () => {
+      const text = getEllipsisText({
+        measureTextWidth,
+        text: '',
+        maxWidth: 20,
+        placeholder: '--',
+      });
+      expect(text).toEqual('--');
     });
 
-    expect(text).toEqual('--');
-  });
+    test('should get correct placeholder text with 0', () => {
+      const text = getEllipsisText({
+        measureTextWidth,
+        text: 0 as unknown as string,
+        maxWidth: 20,
+        placeholder: '--',
+      });
 
-  test('should get correct ellipsis text', () => {
-    const text = getEllipsisText({
-      text: '长度测试',
-      maxWidth: 24,
+      expect(text).toEqual('0');
     });
 
-    expect(text).toEndWith('...');
-    expect(text.length).toBeLessThanOrEqual(4);
-  });
+    test('should get correct placeholder text with null', () => {
+      const text = getEllipsisText({
+        measureTextWidth,
+        text: null,
+        maxWidth: 20,
+        placeholder: '--',
+      });
 
-  test('should get correct text width', () => {
-    const width = measureTextWidth('test', font);
-    expect(Math.floor(width)).toEqual(isHD ? 21 : 16);
-  });
+      expect(text).toEqual('--');
+    });
 
-  test('should get correct ellipsis text inner', () => {
-    const text = getEllipsisTextInner('test', 15, font);
-    expect(text).toEqual('t...');
+    test('should get correct ellipsis text', () => {
+      const text = getEllipsisText({
+        measureTextWidth,
+        text: '长度测试',
+        maxWidth: 24,
+      });
+
+      expect(text).toEndWith('...');
+      expect(text.length).toBeLessThanOrEqual(4);
+    });
+
+    test('should get correct text width', () => {
+      const width = measureTextWidth('test', font);
+      expect(Math.floor(width)).toEqual(isHD ? 21 : 16);
+    });
+
+    test('should get correct ellipsis text inner', () => {
+      const text = getEllipsisTextInner(measureTextWidth, 'test', 15, font);
+      expect(text).toEqual('t...');
+    });
   });
 
   test.each`

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -239,7 +239,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
         {
           x1: minX,
           y1: maxY + 1,
-          x2: minX + this.actualTextWidth, // 不用 bbox 的 maxX，因为文字宽度预估偏差较大
+          x2: minX + this.actualTextWidth, // 不用 bbox 的 maxX，因为 g-base 文字宽度预估偏差较大
           y2: maxY + 1,
         },
         { stroke: linkFillColor, lineWidth: 1 },

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -34,11 +34,7 @@ import {
 } from '../utils/cell/cell';
 import { renderLine, renderText, updateShapeAttr } from '../utils/g-renders';
 import { isMobile } from '../utils/is-mobile';
-import {
-  getEllipsisText,
-  getEmptyPlaceholder,
-  measureTextWidth,
-} from '../utils/text';
+import { getEllipsisText, getEmptyPlaceholder } from '../utils/text';
 
 export abstract class BaseCell<T extends SimpleBBox> extends Group {
   // cell's data meta info
@@ -201,9 +197,13 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     const { formattedValue } = this.getFormattedFieldValue();
     const maxTextWidth = this.getMaxTextWidth();
     const textStyle = this.getTextStyle();
-    const { placeholder } = this.spreadsheet.options;
+    const {
+      options: { placeholder },
+      measureTextWidth,
+    } = this.spreadsheet;
     const emptyPlaceholder = getEmptyPlaceholder(this, placeholder);
     const ellipsisText = getEllipsisText({
+      measureTextWidth,
       text: formattedValue,
       maxWidth: maxTextWidth,
       fontParam: textStyle,
@@ -233,13 +233,13 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     const device = this.spreadsheet.options.style.device;
     // 配置了链接跳转
     if (!isMobile(device)) {
-      const { minX, maxX, maxY }: BBox = this.textShape.getBBox();
+      const { minX, maxY }: BBox = this.textShape.getBBox();
       this.linkFieldShape = renderLine(
         this,
         {
           x1: minX,
           y1: maxY + 1,
-          x2: maxX,
+          x2: minX + this.actualTextWidth, // 不用 bbox 的 maxX，因为文字宽度预估偏差较大
           y2: maxY + 1,
         },
         { stroke: linkFillColor, lineWidth: 1 },

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -38,11 +38,7 @@ import {
   getResizeAreaAttrs,
 } from '../utils/interaction/resize';
 import { isIPhoneX } from '../utils/is-mobile';
-import {
-  getEllipsisText,
-  getEmptyPlaceholder,
-  measureTextWidth,
-} from '../utils/text';
+import { getEllipsisText, getEmptyPlaceholder } from '../utils/text';
 import { i18n } from './../common/i18n';
 import { shouldAddResizeArea } from './../utils/interaction/resize';
 import { HeaderCell } from './header-cell';
@@ -86,7 +82,9 @@ export class CornerCell extends HeaderCell {
       this.meta,
       this.spreadsheet.options.placeholder,
     );
+    const { measureTextWidth } = this.spreadsheet;
     const text = getEllipsisText({
+      measureTextWidth,
       text: cornerText,
       maxWidth,
       fontParam: textStyle,
@@ -106,6 +104,7 @@ export class CornerCell extends HeaderCell {
       secondLine = cornerText.slice(lastIndex);
       // 第二行重新计算...逻辑
       secondLine = getEllipsisText({
+        measureTextWidth,
         text: secondLine,
         maxWidth,
         fontParam: textStyle,

--- a/packages/s2-core/src/facet/header/series-number.ts
+++ b/packages/s2-core/src/facet/header/series-number.ts
@@ -1,14 +1,9 @@
 import type { Group, IGroup, IShape } from '@antv/g-canvas';
 import { each } from 'lodash';
-import {
-  CellBorderPosition,
-  type Padding,
-  type ViewMeta,
-} from '../../common/interface';
+import { CellBorderPosition, type Padding } from '../../common/interface';
 import type { SpreadSheet } from '../../sheet-type/index';
 import { getBorderPositionAndStyle } from '../../utils/cell/cell';
 import { renderLine, renderRect } from '../../utils/g-renders';
-import { measureTextWidth } from '../../utils/text';
 import { getAdjustPosition } from '../../utils/text-absorption';
 import type { PanelBBox } from '../bbox/panelBBox';
 import { Node } from '../layout/node';
@@ -198,7 +193,10 @@ export class SeriesNumberHeader extends BaseHeader<BaseHeaderConfig> {
 
   private getTextPadding(text: string, cellWidth: number): Padding {
     const rowCellTheme = this.getStyle();
-    const textWidth = measureTextWidth(text, rowCellTheme.seriesText);
+    const textWidth = this.headerConfig.spreadsheet.measureTextWidth(
+      text,
+      rowCellTheme.seriesText,
+    );
     const padding = Math.max(Math.abs((cellWidth - textWidth) / 2), 4);
     return {
       ...rowCellTheme.cell.padding,

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -4,7 +4,6 @@ import {
   get,
   isArray,
   isEmpty,
-  isFunction,
   isNil,
   keys,
   last,
@@ -14,14 +13,10 @@ import {
   size,
 } from 'lodash';
 import {
-  DEFAULT_STYLE,
   DEFAULT_TREE_ROW_WIDTH,
   LAYOUT_SAMPLE_COUNT,
-  type CellCustomWidth,
-  type ColCfg,
   type IconTheme,
   type MultiData,
-  type RowCfg,
 } from '../common';
 import { EXTRA_FIELD, LayoutWidthTypes, VALUE_FIELD } from '../common/constant';
 import { CellTypes } from '../common/constant/interaction';
@@ -34,12 +29,7 @@ import {
   getIndexRangeWithOffsets,
   getSubTotalNodeWidthOrHeightByLevel,
 } from '../utils/facet';
-import {
-  getCellWidth,
-  measureTextWidth,
-  measureTextWidthRoughly,
-  safeJsonParse,
-} from '../utils/text';
+import { getCellWidth, safeJsonParse } from '../utils/text';
 import { BaseFacet } from './base-facet';
 import { buildHeaderHierarchy } from './layout/build-header-hierarchy';
 import type { Hierarchy } from './layout/hierarchy';
@@ -290,7 +280,7 @@ export class PivotFacet extends BaseFacet {
         colIconStyle,
       );
       const leafNodeRoughWidth =
-        measureTextWidthRoughly(leafNodeLabel) + iconWidth;
+        this.spreadsheet.measureTextWidthRoughly(leafNodeLabel) + iconWidth;
 
       // 采样 50 个 label，逐个计算找出最长的 label
       let maxDataLabel: string;
@@ -314,7 +304,8 @@ export class PivotFacet extends BaseFacet {
               cellData,
               filterDisplayDataItem,
             )}`;
-            const cellLabelWidth = measureTextWidthRoughly(cellLabel);
+            const cellLabelWidth =
+              this.spreadsheet.measureTextWidthRoughly(cellLabel);
 
             if (cellLabelWidth > maxDataLabelWidth) {
               maxDataLabel = cellLabel;
@@ -336,7 +327,7 @@ export class PivotFacet extends BaseFacet {
       );
 
       return (
-        measureTextWidth(maxLabel, colCellTextStyle) +
+        this.spreadsheet.measureTextWidth(maxLabel, colCellTextStyle) +
         colCellStyle.padding?.left +
         colCellStyle.padding?.right +
         appendedWidth
@@ -751,7 +742,7 @@ export class PivotFacet extends BaseFacet {
       this.spreadsheet.theme.cornerCell;
     // 初始化角头时，保证其在树形模式下不换行，给与两个icon的宽度空余（tree icon 和 action icon），减少复杂的 action icon 判断
     const maxLabelWidth =
-      measureTextWidth(treeHeaderLabel, cornerCellTextStyle) +
+      this.spreadsheet.measureTextWidth(treeHeaderLabel, cornerCellTextStyle) +
       cornerIconStyle.size * 2 +
       cornerIconStyle.margin?.left +
       cornerIconStyle.margin?.right +
@@ -808,7 +799,7 @@ export class PivotFacet extends BaseFacet {
       );
     const maxLabel = maxBy(allLabels, (label) => `${label}`.length);
     const rowNodeWidth =
-      measureTextWidth(maxLabel, rowTextStyle) +
+      spreadsheet.measureTextWidth(maxLabel, rowTextStyle) +
       rowIconWidth +
       rowCellStyle.padding.left +
       rowCellStyle.padding.right;
@@ -821,7 +812,7 @@ export class PivotFacet extends BaseFacet {
       cornerIconStyle,
     );
     const fieldNameNodeWidth =
-      measureTextWidth(fieldName, cornerTextStyle) +
+      spreadsheet.measureTextWidth(fieldName, cornerTextStyle) +
       cornerIconWidth +
       cornerCellStyle.padding.left +
       cornerCellStyle.padding.right;

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -1,5 +1,14 @@
 import type { Group, IElement, IGroup } from '@antv/g-canvas';
-import { get, isBoolean, isNil, last, maxBy, set, values } from 'lodash';
+import {
+  get,
+  isBoolean,
+  isNil,
+  last,
+  maxBy,
+  set,
+  spread,
+  values,
+} from 'lodash';
 import { TableSeriesCell } from '../cell';
 import {
   FRONT_GROUND_GROUP_COL_FROZEN_Z_INDEX,
@@ -35,7 +44,6 @@ import {
 } from '../utils/grid';
 import type { PanelIndexes } from '../utils/indexes';
 import { getValidFrozenOptions } from '../utils/layout/frozen';
-import { measureTextWidth, measureTextWidthRoughly } from '../utils/text';
 import { BaseFacet } from './base-facet';
 import { CornerBBox } from './bbox/cornerBBox';
 import type { SeriesNumberHeader } from './header';
@@ -375,7 +383,7 @@ export class TableFacet extends BaseFacet {
         datas?.map((data) => `${data[col.key]}`)?.slice(0, 50) || []; // 采样取了前50
       allLabels.push(colLabel);
       const maxLabel = maxBy(allLabels, (label) =>
-        measureTextWidthRoughly(label),
+        spreadsheet.measureTextWidthRoughly(label),
       );
 
       const { bolderText: colCellTextStyle } = spreadsheet.theme.colCell;
@@ -391,7 +399,7 @@ export class TableFacet extends BaseFacet {
       // 最长的 Label 如果是列名，按列名的标准计算宽度
       if (colLabel === maxLabel) {
         colWidth =
-          measureTextWidth(maxLabel, colCellTextStyle) +
+          spreadsheet.measureTextWidth(maxLabel, colCellTextStyle) +
           getOccupiedWidthForTableCol(
             this.spreadsheet,
             col,
@@ -401,7 +409,7 @@ export class TableFacet extends BaseFacet {
         // 额外添加一像素余量，防止 maxLabel 有多个同样长度情况下，一些 label 不能展示完全
         const EXTRA_PIXEL = 1;
         colWidth =
-          measureTextWidth(maxLabel, dataCellTextStyle) +
+          spreadsheet.measureTextWidth(maxLabel, dataCellTextStyle) +
           cellStyle.padding.left +
           cellStyle.padding.right +
           EXTRA_PIXEL;

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -705,7 +705,7 @@ export abstract class SpreadSheet extends EE {
         .join(' ')
         .trim();
 
-      return ctx.measureText(`${text}`).width;
+      return ctx.measureText(String(text)).width;
     },
     (text: any, font) => [text, ...values(font)].join(''),
   );

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -1,10 +1,5 @@
 import EE from '@antv/event-emitter';
-import {
-  Canvas,
-  Event as CanvasEvent,
-  Group,
-  type IGroup,
-} from '@antv/g-canvas';
+import { Canvas, Event as CanvasEvent, type IGroup } from '@antv/g-canvas';
 import {
   forEach,
   forIn,
@@ -13,6 +8,8 @@ import {
   isEmpty,
   isFunction,
   isString,
+  memoize,
+  values,
 } from 'lodash';
 import { BaseCell } from '../cell';
 import {
@@ -681,4 +678,61 @@ export abstract class SpreadSheet extends EE {
       this.off(event);
     });
   }
+
+  /**
+   * 计算文本在画布中的宽度
+   * @param text 待计算的文本
+   * @param font 文本 css 样式
+   * @returns 文本宽度
+   */
+  public measureTextWidth = memoize(
+    (text: number | string = '', font: unknown): number => {
+      if (!font) {
+        return 0;
+      }
+
+      const ctx = this.getCanvasElement()?.getContext('2d');
+      const { fontSize, fontFamily, fontWeight, fontStyle, fontVariant } =
+        font as CSSStyleDeclaration;
+
+      ctx.font = [
+        fontStyle,
+        fontVariant,
+        fontWeight,
+        `${fontSize}px`,
+        fontFamily,
+      ]
+        .join(' ')
+        .trim();
+
+      return ctx.measureText(`${text}`).width;
+    },
+    (text: any, font) => [text, ...values(font)].join(''),
+  );
+
+  /**
+   * 粗略计算文本在画布中的宽度
+   * @param text 待计算的文本
+   * @param font 文本 css 样式
+   * @returns 文本宽度
+   */
+  public measureTextWidthRoughly = (text: any, font: any = {}): number => {
+    const alphaWidth = this.measureTextWidth('a', font);
+    const chineseWidth = this.measureTextWidth('蚂', font);
+
+    let w = 0;
+    if (!text) {
+      return w;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const char of text) {
+      const code = char.charCodeAt(0);
+
+      // /[\u0000-\u00ff]/
+      w += code >= 0 && code <= 255 ? alphaWidth : chineseWidth;
+    }
+
+    return w;
+  };
 }

--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -19,7 +19,7 @@ import {
   renderText,
 } from '../utils/g-renders';
 import { CellTypes, MiniChartTypes } from '../common/constant';
-import { getEllipsisText, measureTextWidth } from './text';
+import { getEllipsisText } from './text';
 
 interface FractionDigitsOptions {
   min: number;
@@ -231,7 +231,7 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
 
   const dataCellStyle = cell.getStyle(CellTypes.DATA_CELL);
   const bulletStyle = dataCellStyle.miniChart.bullet;
-  const { x, y, height, width } = cell.getMeta();
+  const { x, y, height, width, spreadsheet } = cell.getMeta();
   const { progressBar, comparativeMeasure, rangeColors, backgroundColor } =
     bulletStyle;
 
@@ -245,7 +245,7 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
   // 对于负数, 进度条计算按照 0 处理, 但是展示还是要显示原来的百分比
   const measurePercent = transformRatioToPercent(measure, 2);
   const measurePercentWidth = Math.ceil(
-    measureTextWidth(measurePercent, dataCellStyle),
+    spreadsheet.measureTextWidth(measurePercent, dataCellStyle),
   );
 
   const bulletWidth = progressBar.widthPercent * width - measurePercentWidth;
@@ -316,6 +316,7 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     positionX - padding.right,
     y + height / 2,
     getEllipsisText({
+      measureTextWidth: spreadsheet.measureTextWidth,
       text: measurePercent,
       maxWidth: measureWidth,
       fontParam: dataCellStyle.text,

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -28,7 +28,7 @@ import { renderMiniChart } from './g-mini-charts';
 
 /**
  * 计算文本在画布中的宽度
- * @deprecated 已废弃，该方法计算宽度不准确，请使用 spreadsheet 实例上的同名方法
+ * @deprecated 已废弃，1.30.0 版本后移除。该方法计算宽度不准确，请使用 spreadsheet 实例上的同名方法
  */
 export const measureTextWidth = memoize(
   (text: number | string = '', font: unknown): number => {
@@ -151,7 +151,7 @@ export const getEllipsisTextInner = (
  * 然后分别乘以中文、符号的宽度
  * @param text
  * @param font
- * @deprecated 已废弃，该方法计算宽度不准确，请使用 spreadsheet 实例上的同名方法
+ * @deprecated 已废弃，1.30.0 版本后移除。该方法计算宽度不准确，请使用 spreadsheet 实例上的同名方法
  */
 export const measureTextWidthRoughly = (text: any, font: any = {}): number => {
   const alphaWidth = measureTextWidth('a', font);


### PR DESCRIPTION
### 👀 PR includes

🎨 Enhance

- [ ] Code style optimization
- [x] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

#### 背景
当 spreadsheet container 被应用了特殊的文字样式后（如 `letter-spacing`）
`drawLinkFieldShape@base-cell.ts` 绘制 `链接下划线` 会超过文字实际长度

#### 原因
drawLinkFieldShape 绘制下划线时，使用的是 g-base (`textShape.getBBox()`) 计算出的文字宽度
而 g-base 使用的是 [离屏 canvas](https://github.com/antvis/G/blob/0.5.12/packages/g-base/src/util/offscreen.ts)，不会应用 html 中任何样式，当 [计算文字尺寸](https://github.com/antvis/G/blob/a7f058fcec85457c65500226d1aca5c4a9cce0d1/packages/g-base/src/util/text.ts#L38) 时，与实际渲染有较大差距（如宽度）

之前在修复 [列头文字&icon](https://github.com/antvis/S2/pull/1515) 时，也发现了类似的问题。
当时把 s2 内部计算文字宽度的 offscreen canvas 放置到了 body，但实际场景中，特殊的文字样式是会设置到 container 这层，仅 body 的样式是不够的。

#### 方案
直接使用 spreadsheet container 挂载的 canvas 作为文字宽度计算的 ctx：
- 废弃 `utils/text.ts` 中的 `measureTextWidth`、`measureTextWidthRoughly` 函数使用（有 export 暂不移除源码）
- 移动 `measureTextWidth`、`measureTextWidthRoughly` 逻辑，作为 spreadsheet 的实例方法
- `getEllipsisText` 等文字工具函数，接受宽度计算函数 `measureTextWidth` 作为参数
- drawLinkFieldShape 使用 this.actualTextWidth（由 s2 计算） 作为超链接绘制宽度


### 🖼️ Screenshot

> playground `#root` 设置了样式 `letter-spacing: -1px;`

| Before | After |
| ------ | ----- |
|  <img width="617" alt="CleanShot 2022-08-08 at 10 37 29@2x" src="https://user-images.githubusercontent.com/6716092/183327244-17dfc789-6419-47ac-a001-dc6290839753.png">      |  <img width="616" alt="CleanShot 2022-08-08 at 10 36 53@2x" src="https://user-images.githubusercontent.com/6716092/183327144-b409cb67-cac5-4762-9a39-1bc9f3dcd8d9.png">     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
