### PR TITLE
fix(interaction): 优化resetSheetStyle性能

### DIFF
--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -445,8 +445,9 @@ export class RootInteraction {
   }
 
   public clearState() {
-    clearState(this.spreadsheet);
-    this.draw();
+    if (clearState(this.spreadsheet)) {
+      this.draw();
+    }
   }
 
   public changeState(interactionStateInfo: InteractionStateInfo) {

--- a/packages/s2-core/src/utils/interaction/state-controller.ts
+++ b/packages/s2-core/src/utils/interaction/state-controller.ts
@@ -7,7 +7,7 @@ import type { SpreadSheet } from '../../sheet-type';
  * @desc clear the interaction state information
  * @param spreadsheet sheet instance
  */
-export const clearState = (spreadsheet: SpreadSheet) => {
+export const clearState = (spreadsheet: SpreadSheet): boolean => {
   const activeIcons = spreadsheet.store.get('visibleActionIcons');
   forEach(activeIcons, (icon) => {
     icon.set('visible', false);
@@ -31,7 +31,9 @@ export const clearState = (spreadsheet: SpreadSheet) => {
         cell.clearUnselectedState();
       });
     }
+    return true;
   }
+  return false;
 };
 
 /**

--- a/packages/s2-core/src/utils/interaction/state-controller.ts
+++ b/packages/s2-core/src/utils/interaction/state-controller.ts
@@ -9,31 +9,35 @@ import type { SpreadSheet } from '../../sheet-type';
  */
 export const clearState = (spreadsheet: SpreadSheet): boolean => {
   const activeIcons = spreadsheet.store.get('visibleActionIcons');
+  const allInteractedCells = spreadsheet.interaction.getInteractedCells();
+  const cellMetas = spreadsheet.interaction.getState().cells;
+  // 如果都处于初始化状态 不需要clear
+  if (
+    isEmpty(allInteractedCells) &&
+    isEmpty(cellMetas) &&
+    isEmpty(activeIcons)
+  ) {
+    return false;
+  }
   forEach(activeIcons, (icon) => {
     icon.set('visible', false);
   });
   spreadsheet.store.set('visibleActionIcons', []);
 
-  const allInteractedCells = spreadsheet.interaction.getInteractedCells();
-  const cellMetas = spreadsheet.interaction.getState().cells;
+  forEach(allInteractedCells, (cell: S2CellType) => {
+    cell.hideInteractionShape();
+  });
 
-  if (!isEmpty(allInteractedCells) || !isEmpty(cellMetas)) {
-    forEach(allInteractedCells, (cell: S2CellType) => {
-      cell.hideInteractionShape();
+  spreadsheet.interaction.resetState();
+  if (spreadsheet.options.interaction.selectedCellsSpotlight) {
+    const unSelectedCells =
+      spreadsheet.interaction.getPanelGroupAllUnSelectedDataCells() || [];
+
+    forEach(unSelectedCells, (cell) => {
+      cell.clearUnselectedState();
     });
-
-    spreadsheet.interaction.resetState();
-    if (spreadsheet.options.interaction.selectedCellsSpotlight) {
-      const unSelectedCells =
-        spreadsheet.interaction.getPanelGroupAllUnSelectedDataCells() || [];
-
-      forEach(unSelectedCells, (cell) => {
-        cell.clearUnselectedState();
-      });
-    }
-    return true;
   }
-  return false;
+  return true;
 };
 
 /**


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [x] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

场景：window.click每次都会触发reset操作，如果S2实例多的时候，draw的性能较差。
![image](https://user-images.githubusercontent.com/16497201/183327308-b5c80606-6e58-4eab-953c-2c6545f61b09.png)

![image](https://user-images.githubusercontent.com/16497201/183327188-2f361881-cbd6-49f1-906c-ded4c7d3d6a1.png)

原因分析：主要耗时在clearState里面draw调用的requestAnimationFrame（后续还有消耗）

解决思路：clearState的时候做个判断，如果都是初始状态，不需要clear的情况，return false 然后不掉用draw方法





### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
