### PR TITLE
fix(scroll): 修复滚动条显示越界 & 优化滚动性能

### DIFF
--- a/packages/s2-core/src/common/interface/scroll.ts
+++ b/packages/s2-core/src/common/interface/scroll.ts
@@ -15,6 +15,9 @@ export interface CellScrollPosition {
 }
 
 export interface CellScrollOffset {
+  deltaX?: number;
+  deltaY?: number;
+  offset?: number;
   offsetX: number;
   offsetY: number;
 }

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -32,7 +32,7 @@ export const s2Options: S2Options = {
   showSeriesNumber: false,
   interaction: {
     enableCopy: true,
-    // 防止 mac 触摸板横向滚动触发浏览器返回
+    // 防止 mac 触摸板横向滚动触发浏览器返回, 和移动端下拉刷新
     overscrollBehavior: 'contain',
   },
   tooltip: {
@@ -48,7 +48,6 @@ export const s2Options: S2Options = {
     cellCfg: {
       height: 50,
     },
-    hierarchyCollapse: false,
   },
 };
 

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -279,6 +279,15 @@ function MainLayout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sheetType]);
 
+  React.useEffect(() => {
+    console.log(
+      s2Ref.current?.facet.hRowScrollBar.thumbShape,
+      s2Ref.current?.facet.hRowScrollBar.thumbLen,
+    );
+    console.log(s2Ref.current?.facet.hScrollBar.getCanvasBBox());
+    console.log(s2Ref.current?.facet.vScrollBar.getCanvasBBox());
+  }, []);
+
   //  ================== Config ========================
 
   const mergedOptions: S2Options<React.ReactNode> = customMerge(

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -279,15 +279,6 @@ function MainLayout() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sheetType]);
 
-  React.useEffect(() => {
-    console.log(
-      s2Ref.current?.facet.hRowScrollBar.thumbShape,
-      s2Ref.current?.facet.hRowScrollBar.thumbLen,
-    );
-    console.log(s2Ref.current?.facet.hScrollBar.getCanvasBBox());
-    console.log(s2Ref.current?.facet.vScrollBar.getCanvasBBox());
-  }, []);
-
   //  ================== Config ========================
 
   const mergedOptions: S2Options<React.ReactNode> = customMerge(

--- a/s2-site/docs/api/basic-class/base-facet.zh.md
+++ b/s2-site/docs/api/basic-class/base-facet.zh.md
@@ -51,19 +51,31 @@ s2.facet.xx()
 | getRealWidth | 获取实际渲染的宽度 | () => number |
 | getRealHeight | 获取实际渲染的高度 | () => number |
 | clearAllGroup | 清空所有 Group | () => void |
-| isScrollOverThePanelArea | 是否在数值区域滚动 | (options: { offsetX: number, offsetY: number }) => boolean |
-| isScrollOverTheCornerArea | 是否在角头区域滚动 | (options: { offsetX: number, offsetY: number }) => boolean |
-| isScrollToLeft | 是否滚动到了最左边 | (deltaX: number) => boolean |
-| isScrollToRight | 是否滚动到了最右边 | (deltaX: number) => boolean |
+| isScrollOverThePanelArea | 是否在数值区域滚动 | (cellScrollOffset: [CellScrollOffset](#cellscrolloffset)) => boolean |
+| isScrollOverTheCornerArea | 是否在角头区域滚动 | (cellScrollOffset: [CellScrollOffset](#cellscrolloffset)) => boolean |
+| isScrollToLeft | 是否滚动到了最左边 | (cellScrollOffset: [CellScrollOffset](#cellscrolloffset)) => boolean |
+| isScrollToRight | 是否滚动到了最右边 | (cellScrollOffset: [CellScrollOffset](#cellscrolloffset)) => boolean |
 | isScrollToTop | 是否滚动到了顶部 | (deltaY: number) => boolean |
 | isScrollToBottom | 是否滚动到了底部 |  (deltaY: number) => boolean|
 | isVerticalScrollOverTheViewport | 是否在数值单元格区域垂直滚动 | (deltaY: number) => boolean |
-| isHorizontalScrollOverTheViewport | 是否在数值单元格区域水平滚动 | (deltaX: number) => boolean |
-| isScrollOverTheViewport | 是否在数值单元格区域滚动 | (deltaX: number, deltaY: number, offsetY: number) => boolean |
+| isHorizontalScrollOverTheViewport | 是否在数值单元格区域水平滚动 | (scrollOffset: [CellScrollOffset](#cellscrolloffset)) => boolean |
+| isScrollOverTheViewport | 是否在数值单元格区域滚动 | (cellScrollOffset: [CellScrollOffset](#cellscrolloffset)) => boolean |
 | cancelScrollFrame | 取消当前滚动帧 | () => void |
 | clearScrollFrameIdOnMobile | 取消当前滚动帧 （移动端） | () => void |
 | addCell | 添加单元格 | (cell: [BaseCell](/zh/docs/api/basic-class/base-cell)) => void |
 | drawGrid | 绘制网格 | () => void |
+
+### CellScrollOffset
+
+```ts
+export interface CellScrollOffset {
+  deltaX?: number;
+  deltaY?: number;
+  offset?: number;
+  offsetX: number;
+  offsetY: number;
+}
+```
 
 ### LayoutResult
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1659 

### 📝 Description

背景

g 4.x 版本计算 BBox 包围盒有问题, 由于滚动条 lineCap 是 `round`, 导致实际渲染的宽度比传入的宽度大 (渲染宽度 = 给定宽度 + round 多出了那部分宽度)

![image](https://user-images.githubusercontent.com/21015895/184067615-69be12e4-7353-410c-9e8b-c08323fd1434.png)


解法

1. 参考以下处理方式, 修正渲染宽度, 减去 `round` 椭圆的一部分像素
https://github.com/antvis/S2/blob/77cd111ea4d01f86d29e384e564d761c0f6c0881/packages/s2-core/src/group/grid-group.ts#L52-L56

2. 修复冻结行头, 且是列紧凑模式 (数值单元格无滚动条) 情况下, 无法滚动
3. 修复横向滚动至边缘时, 表格依然在重新 render, 且 emit scroll event

### 🖼️ Screenshot

| 场景 | Before | After |
|  ------ | ------ | ----- |
| 横/竖滚动条重合 | ![image](https://user-images.githubusercontent.com/21015895/184065787-6bfc7fc3-e4e7-40bb-b4f8-ddcd9eeba47c.png) | ![image](https://user-images.githubusercontent.com/21015895/184061782-6a757a7b-0f61-4237-9f1c-bf2a0a418f87.png)   |
| 行头滚动条和 dataCell 滚动条重合 |![image](https://user-images.githubusercontent.com/21015895/184065839-c46a1753-2595-4ff9-af4b-6dc4b116e996.png) | ![image](https://user-images.githubusercontent.com/21015895/184061882-df54127c-d93d-4af8-a6fb-4a04c2e02fe2.png) |
| 行头滚动条 | ![image](https://user-images.githubusercontent.com/21015895/184065860-7c0b3267-3b69-4b2b-a962-a1afabf1e96c.png) | ![image](https://user-images.githubusercontent.com/21015895/184065646-fabd809e-cc8b-45a2-a59a-182e2c7ee9c9.png) |
| 横/竖滚动条 | ![image](https://user-images.githubusercontent.com/21015895/184065897-899dd587-c8e4-4d8a-b155-edfce064824b.png) | ![image](https://user-images.githubusercontent.com/21015895/184065696-8cc7b0cb-3e1b-4f31-a29d-09edb12ea251.png) |
| 只有行头有滚动条时, 无法滚动 | ![Kapture 2022-08-11 at 12 44 30](https://user-images.githubusercontent.com/21015895/184066157-999fd0b5-6438-4450-bce3-b4e60b9fa8a7.gif) | ![Kapture 2022-08-11 at 12 51 00](https://user-images.githubusercontent.com/21015895/184066673-1ef3cb6e-85a2-46b3-903f-75152bce0ed9.gif) |
| 横向滚动至边缘时, 表格依然在重新渲染 | ![Kapture 2022-08-11 at 12 47 32](https://user-images.githubusercontent.com/21015895/184066383-6850d710-69e2-46af-971d-004e95043eec.gif) | ![Kapture 2022-08-11 at 12 53 39](https://user-images.githubusercontent.com/21015895/184066938-6372441d-88ee-47d8-8522-ac02b89380fb.gif) | 


### 🔗 Related issue link

<!-- close #0 -->

ref https://github.com/antvis/S2/pull/1566

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
