### PR TITLE
fix(resize): 修复总计列存在子节点时无法调整宽度

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1668-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1668-spec.ts
@@ -1,0 +1,49 @@
+/**
+ * @description spec for issue #1668
+ * https://github.com/antvis/S2/issues/1668
+ */
+
+import type { IGroup } from '@antv/g-canvas';
+import { getContainer } from '../util/helpers';
+import * as mockDataConfig from '../data/data-issue-1668.json';
+import { type S2Options, KEY_GROUP_COL_RESIZE_AREA } from '@/index';
+import { PivotSheet } from '@/sheet-type';
+
+const s2Options: S2Options = {
+  width: 800,
+  height: 400,
+  totals: {
+    row: {
+      showGrandTotals: true,
+      showSubTotals: true,
+      reverseLayout: true,
+      reverseSubLayout: true,
+      subTotalsDimensions: ['province'],
+    },
+    col: {
+      showGrandTotals: true,
+      showSubTotals: true,
+      reverseLayout: true,
+      reverseSubLayout: true,
+      subTotalsDimensions: ['type'],
+    },
+  },
+};
+
+describe('Totals Cell Resize Tests', () => {
+  const s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
+  s2.render();
+
+  test('should render extra resize id for resize area handler', () => {
+    const resizeArea = s2.foregroundGroup.findById(
+      KEY_GROUP_COL_RESIZE_AREA,
+    ) as IGroup;
+    const resizeAreaList = resizeArea.getChildren();
+
+    expect(resizeAreaList).not.toHaveLength(0);
+
+    resizeAreaList.forEach((shape) => {
+      expect(shape.attr('appendInfo').id).toBeTruthy();
+    });
+  });
+});

--- a/packages/s2-core/__tests__/data/data-issue-1668.json
+++ b/packages/s2-core/__tests__/data/data-issue-1668.json
@@ -1,0 +1,271 @@
+{
+  "data": [
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "笔",
+      "price": "1"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "纸张",
+      "price": "2"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "笔",
+      "price": "2"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "纸张",
+      "price": "0.5"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "笔",
+      "price": "3"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "纸张",
+      "price": "2"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "笔",
+      "price": "4"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "纸张",
+      "price": "1"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "笔",
+      "price": "1"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "纸张",
+      "price": "2"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "笔",
+      "price": "2"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "纸张",
+      "price": "0.5"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "笔",
+      "price": "3"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "纸张",
+      "price": "2"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "笔",
+      "price": "4"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "纸张",
+      "price": "1"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "笔",
+      "cost": "0.5"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "纸张",
+      "cost": "1.5"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "笔",
+      "cost": "1.5"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "纸张",
+      "cost": "0.2"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "笔",
+      "cost": "2"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "纸张",
+      "cost": "1"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "笔",
+      "cost": "3"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "纸张",
+      "cost": "0.5"
+    },
+    {
+      "price": "15.5"
+    },
+    {
+      "province": "浙江",
+      "price": "5.5"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "price": "3"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "price": "2.5"
+    },
+    {
+      "province": "吉林",
+      "price": "10"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "price": "5"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "price": "5"
+    },
+    {
+      "type": "笔",
+      "price": "10"
+    },
+    {
+      "type": "笔",
+      "province": "浙江",
+      "price": "3"
+    },
+    {
+      "type": "笔",
+      "province": "吉林",
+      "price": "7"
+    },
+    {
+      "type": "纸张",
+      "price": "5.5"
+    },
+    {
+      "type": "纸张",
+      "province": "浙江",
+      "price": "2.5"
+    },
+    {
+      "type": "纸张",
+      "province": "吉林",
+      "price": "3"
+    },
+    {
+      "cost": "10.2"
+    },
+    {
+      "province": "浙江",
+      "cost": "3.7"
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "cost": "2"
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "cost": "1.7"
+    },
+    {
+      "province": "吉林",
+      "cost": "6.5"
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "cost": "3"
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "cost": "3.5"
+    },
+    {
+      "type": "笔",
+      "cost": "7"
+    },
+    {
+      "type": "笔",
+      "province": "浙江",
+      "cost": "2"
+    },
+    {
+      "type": "笔",
+      "province": "吉林",
+      "cost": "5"
+    },
+    {
+      "type": "纸张",
+      "cost": "3.2"
+    },
+    {
+      "type": "纸张",
+      "province": "浙江",
+      "cost": "1.7"
+    },
+    {
+      "type": "纸张",
+      "province": "吉林",
+      "cost": "1.5"
+    }
+  ],
+  "fields": {
+    "rows": ["province", "city"],
+    "columns": ["type"],
+    "values": ["price", "cost"]
+  }
+}

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -355,7 +355,7 @@ export class ColCell extends HeaderCell {
       return;
     }
 
-    const { label, width, height, parent } = this.meta;
+    const { label, width, height } = this.meta;
 
     const resizeStyle = this.getResizeAreaStyle();
     const resizeArea = this.getColResizeArea();
@@ -374,7 +374,7 @@ export class ColCell extends HeaderCell {
           theme: resizeStyle,
           type: ResizeDirectionType.Horizontal,
           effect: ResizeAreaEffect.Cell,
-          id: parent.isTotals ? '' : label,
+          id: label,
           offsetX,
           offsetY,
           width,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1668

### 📝 Description

![image](https://user-images.githubusercontent.com/21015895/184111397-6af7f71b-3a73-4d0f-837b-2a06e04508ad.png)

父节点是小/总计节点时, 没有添加 id 信息, 导致拖拽的时候无法更新宽度信息

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-08-11 at 18 08 56](https://user-images.githubusercontent.com/21015895/184111348-8b2b10de-6037-4843-9a7e-f0074cf0dfc0.gif) | 
![Kapture 2022-08-11 at 18 08 10](https://user-images.githubusercontent.com/21015895/184111193-bf12a4e3-70eb-4d60-82b0-bc635a4ce1be.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
