### PR TITLE
fix: 修复明细表 onRaneSort 失效问题

### DIFF
--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -177,12 +177,6 @@ export class TableFacet extends BaseFacet {
     this.cornerBBox.maxY = height;
   }
 
-  public destroy() {
-    super.destroy();
-    this.spreadsheet.off(S2Event.RANGE_SORT);
-    this.spreadsheet.off(S2Event.RANGE_FILTER);
-  }
-
   protected doLayout(): LayoutResult {
     const { dataSet, spreadsheet } = this.cfg;
 

--- a/packages/s2-core/src/sheet-type/table-sheet.ts
+++ b/packages/s2-core/src/sheet-type/table-sheet.ts
@@ -152,6 +152,8 @@ export class TableSheet extends SpreadSheet {
   public destroy() {
     super.destroy();
     this.clearFrozenGroups();
+    this.off(S2Event.RANGE_SORT);
+    this.off(S2Event.RANGE_FILTER);
   }
 
   public onSortTooltipClick = ({ key }, meta) => {

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -933,6 +933,7 @@ function MainLayout() {
               }}
               onDataCellTrendIconClick={logHandler('onDataCellTrendIconClick')}
               onAfterRender={logHandler('onAfterRender')}
+              onRangeSort={logHandler('onRangeSort')}
               onDestroy={logHandler('onDestroy')}
               onColCellClick={onColCellClick}
               onRowCellClick={logHandler('onRowCellClick')}


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

![image](https://user-images.githubusercontent.com/10885578/184140073-641b5b5c-4984-46f6-a74f-a86321d9ad2a.png)

明细表排序后会reload data 导致 table-facet rebuild，而原来在 table-facet destroy 的时候 解绑了 RANGE_SORT 和 RANGE_FILTER，导致外部用户使用时无法监听到这两个事件。 因此将逻辑挪到 TableSheet destory 的时候进行。

### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/10885578/184139912-cb5e12f4-43d5-4148-88bc-041b15c279d6.png)

