### PR TITLE
fix: 修复趋势分析表对于不同个数同环比列头复制时，数据不对齐的问题

### DIFF
--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -234,10 +234,10 @@ const getHeaderLabel = (val: string) => {
  * 当列头label存在数组情况，需要将其他层级补齐空格
  * eg [ ['数值', '环比'], '2021'] => [ ['数值', '环比'], ['2021', '']
  */
-const processColHeaders = (headers: any[][], arrayLength: number) => {
+const processColHeaders = (headers: any[][]) => {
   const result = headers.map((header) =>
     header.map((item) =>
-      isArray(item) ? item : [item, ...new Array(arrayLength - 1)],
+      isArray(item) ? item : [item, ...new Array(header[0].length - 1)],
     ),
   );
   return result;
@@ -408,7 +408,7 @@ export const copyData = (
     });
 
     if (arrayLength > 1) {
-      tempColHeader = processColHeaders(tempColHeader, arrayLength);
+      tempColHeader = processColHeaders(tempColHeader);
     }
 
     const colLevels = tempColHeader.map((colHeader) => colHeader.length);

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -239,6 +239,31 @@ export const StrategySheetDataConfig: S2DataConfig = {
     getMiniChartMockData(),
     {
       'measure-a': {
+        originalValues: [[377, '']],
+        values: [[377, '']],
+      },
+      'measure-b': {
+        originalValues: [[377, 324]],
+        values: [[377, 324]],
+      },
+      'measure-c': {
+        originalValues: [[null, 324]],
+        values: [[null, 324]],
+      },
+      'measure-d': {
+        originalValues: [[377, 324]],
+        values: [[377, 324]],
+      },
+      'measure-f': {
+        originalValues: [[377, 324]],
+        values: [[377, 324]],
+      },
+      date: '2022',
+      [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比']),
+    },
+
+    {
+      'measure-a': {
         originalValues: [[377, '', 0.02]],
         values: [[377, '', '0.02']],
       },
@@ -258,7 +283,7 @@ export const StrategySheetDataConfig: S2DataConfig = {
         originalValues: [[377, 324, 0.02]],
         values: [[377, 324, '0.02']],
       },
-      date: '2022',
+      date: '2022-10',
       [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比', '同比']),
     },
   ],

--- a/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
@@ -9,44 +9,61 @@ import {
 import { SheetComponent } from '../../src';
 import { getContainer } from '../util/helpers';
 
-describe('Spread Sheet Tests', () => {
-  describe('Mount Sheet tests', () => {
-    let container: HTMLDivElement;
-    beforeEach(() => {
-      container = getContainer();
+describe('Strategy Sheet Export Tests', () => {
+  let container: HTMLDivElement;
+  let s2Instance: SpreadSheet;
+
+  beforeEach(() => {
+    container = getContainer();
+    act(() => {
+      ReactDOM.render(
+        <SheetComponent
+          getSpreadSheet={(s2) => {
+            s2Instance = s2;
+          }}
+          sheetType="strategy"
+          options={StrategyOptions}
+          dataCfg={StrategySheetDataConfig}
+        />,
+        container,
+      );
     });
+  });
 
-    afterEach(() => {
-      container?.remove();
-    });
+  afterEach(() => {
+    container?.remove();
+  });
 
-    test('should export correct data of strategy sheet', () => {
-      let s2Instance: SpreadSheet;
+  test('should export correct data', () => {
+    // 角头部分展示如下：
+    // ["", "","日期"]
+    // ["", "","数值"]
+    const result = copyData(s2Instance, '\t');
 
-      act(() => {
-        ReactDOM.render(
-          <SheetComponent
-            getSpreadSheet={(s2) => {
-              s2Instance = s2;
-            }}
-            sheetType="strategy"
-            options={StrategyOptions}
-            dataCfg={StrategySheetDataConfig}
-          />,
-          container,
-        );
-      });
+    const rows = result.split('\n');
+    const corner1 = rows[0].split('\t').slice(0, 3);
+    const corner2 = rows[1].split('\t').slice(0, 3);
+    expect(corner1).toEqual(['', '', `"日期"`]);
+    expect(corner2).toEqual(['', '', `"数值"`]);
+  });
 
-      // 角头部分展示如下：
-      // ["", "","日期"]
-      // ["", "","数值"]
-      const result = copyData(s2Instance, '\t');
+  test('should export correct data for multi different cycle compare data', () => {
+    // 列头部分不同粒度的列头包含不同的同环比个数
+    // 2022 包含 [数值，环比]
+    // 2022-10 包含 [数值，环比，同比]
+    // 它们都应和各自的列头数值一栏对齐
+    const result = copyData(s2Instance, '\t');
 
-      const rows = result.split('\n');
-      const corner1 = rows[0].split('\t').slice(0, 3);
-      const corner2 = rows[1].split('\t').slice(0, 3);
-      expect(corner1).toEqual(['', '', `"日期"`]);
-      expect(corner2).toEqual(['', '', `"数值"`]);
-    });
+    const rows = result.split('\n');
+    const col1: string[] = rows[0].split('\t').slice(3);
+    const col2: string[] = rows[1].split('\t').slice(3);
+
+    expect(col1.length).toEqual(col2.length);
+    // 2022 对齐其数值
+    const idx1 = col1.findIndex((col) => col === `"2022"`);
+    expect(col2[idx1]).toEqual(`"数值"`);
+    // 2022-10 对齐其数值
+    const idx2 = col1.findIndex((col) => col === `"2022-10"`);
+    expect(col2[idx2]).toEqual(`"数值"`);
   });
 });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
趋势分析表每一个列头下可以包含不同的个数的同环比，而`export`时都是按照最大的同环比个数来做的日期列头后空格子补全。
一旦出现列头同环比数量不一致，就会出现复制的列头和数据对不齐的问题
### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/17964556/184272294-8f4a6ad1-cf22-40a6-a07c-dfc03e0becfb.png)

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/184272417-7f96efda-fbc7-4b12-af4d-faca59dcde98.png)    | ![image](https://user-images.githubusercontent.com/17964556/184272541-2d980442-f87b-4310-a9ec-79ffacb60061.png)   |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
