### PR TITLE
feat: 刷选时支持高亮所有对应的行列头cell

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -78,6 +78,7 @@ const options: S2Options = {
   interaction: {
     enableCopy: true,
     hoverHighlight: false,
+    selectedCellHighlight: true,
     linkFields: ['order_id', 'customer_name'],
     hiddenColumnFields: ['order_date'],
     resize: {
@@ -97,7 +98,6 @@ const options: S2Options = {
 };
 
 describe('TableSheet normal spec', () => {
-
   test('scrollWithAnimation with duration and callback', async () => {
     const s2 = new TableSheet(getContainer(), dataCfg, options);
     s2.render();
@@ -146,11 +146,10 @@ describe('TableSheet normal spec', () => {
     );
     await sleep(30);
 
+    const firstColCell = s2.getColumnNodes()[1].belongsCell as any;
 
-    const firstColCell = s2.getColumnNodes()[1].belongsCell as any
-
-    expect(firstColCell.shouldAddVerticalResizeArea()).toBe(true)
-    expect(firstColCell.getVerticalResizeAreaOffset()).toEqual({ x: 80, y: 0 })
+    expect(firstColCell.shouldAddVerticalResizeArea()).toBe(true);
+    expect(firstColCell.getVerticalResizeAreaOffset()).toEqual({ x: 80, y: 0 });
 
     s2.destroy();
   });
@@ -161,32 +160,35 @@ describe('TableSheet normal spec', () => {
 
     await sleep(30);
 
-    const { x, width, top } = s2.getCanvasElement().getBoundingClientRect()
-    s2.getCanvasElement().dispatchEvent(new MouseEvent('mousedown', {
-      clientX: x + width - 1,
-      clientY: top + 25,
-    }))
+    const { x, width, top } = s2.getCanvasElement().getBoundingClientRect();
+    s2.getCanvasElement().dispatchEvent(
+      new MouseEvent('mousedown', {
+        clientX: x + width - 1,
+        clientY: top + 25,
+      }),
+    );
 
-
-    window.dispatchEvent(new MouseEvent('mousemove', {
-      clientX: x+ width + 100,
-      clientY: top + 25,
-
-    }))
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        clientX: x + width + 100,
+        clientY: top + 25,
+      }),
+    );
     await sleep(300);
 
-    window.dispatchEvent(new MouseEvent('mouseup', {
-      clientX: x + width + 100,
-      clientY: top + 25
-    }))
+    window.dispatchEvent(
+      new MouseEvent('mouseup', {
+        clientX: x + width + 100,
+        clientY: top + 25,
+      }),
+    );
 
     await sleep(300);
 
-    const columnNodes = s2.getColumnNodes()
-    const lastColumnCell = columnNodes[columnNodes.length - 1].belongsCell as ColCell
-    
-    expect(lastColumnCell.getMeta().width).toBe(199)
+    const columnNodes = s2.getColumnNodes();
+    const lastColumnCell = columnNodes[columnNodes.length - 1]
+      .belongsCell as ColCell;
+
+    expect(lastColumnCell.getMeta().width).toBe(199);
   });
-
-
 });

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection-spec.ts
@@ -154,6 +154,46 @@ describe('Interaction Brush Selection Tests', () => {
     ).toBeFalsy();
   });
 
+  test('should highlight relevant col&row header cell with selectedCellHighlight option toggled on', () => {
+    mockSpreadSheetInstance.setOptions({
+      interaction: { selectedCellHighlight: true },
+    });
+
+    brushSelectionInstance.getBrushRange = () => {
+      return {
+        start: {
+          rowIndex: 0,
+          colIndex: 0,
+          x: 0,
+          y: 0,
+        },
+        end: {
+          rowIndex: 5,
+          colIndex: 5,
+          x: 200,
+          y: 200,
+        },
+        width: 200,
+        height: 200,
+      };
+    };
+
+    (brushSelectionInstance as any).updateSelectedCells();
+
+    (mockRootInteraction.getAllColHeaderCells() || [])
+      .filter((cell, i) => i < 5)
+      .forEach((cell) => {
+        expect(cell.updateByState).toHaveBeenCalled();
+      });
+
+    mockRootInteraction.getAllCells();
+
+    (mockRootInteraction.getAllRowHeaderCells() || [])
+      .filter((cell, i) => i < 5)
+      .forEach((cell) => {
+        expect(cell.updateByState).toHaveBeenCalled();
+      });
+  });
   test('should get start brush point when mouse down', () => {
     emitEvent(S2Event.DATA_CELL_MOUSE_DOWN, {
       layerX: 10,

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -18,6 +18,7 @@ import type {
 import {
   getCellMeta,
   getRowCellForSelectedCell,
+  updateRowColCells,
 } from '../../../utils/interaction/select-event';
 import {
   getTooltipOptions,
@@ -67,29 +68,9 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
       this.spreadsheet.emit(S2Event.GLOBAL_SELECTED, [cell]);
       this.showTooltip(event, meta);
       if (options.interaction.selectedCellHighlight) {
-        this.updateRowColCells(meta);
+        updateRowColCells(meta, this.spreadsheet);
       }
     });
-  }
-
-  public updateRowColCells(meta: ViewMeta) {
-    const { rowId, colId } = meta;
-    const { interaction } = this.spreadsheet;
-    updateAllColHeaderCellState(
-      colId,
-      interaction.getAllColHeaderCells(),
-      InteractionStateName.SELECTED,
-    );
-
-    if (rowId) {
-      const allRowHeaderCells = getRowCellForSelectedCell(
-        meta,
-        this.spreadsheet,
-      );
-      forEach(allRowHeaderCells, (cell: RowCell) => {
-        cell.updateByState(InteractionStateName.SELECTED);
-      });
-    }
   }
 
   private getTooltipOperator(

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -68,7 +68,7 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
       this.spreadsheet.emit(S2Event.GLOBAL_SELECTED, [cell]);
       this.showTooltip(event, meta);
       if (options.interaction.selectedCellHighlight) {
-        updateRowColCells(meta, this.spreadsheet);
+        updateRowColCells(meta);
       }
     });
   }

--- a/packages/s2-core/src/interaction/brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection.ts
@@ -682,10 +682,10 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
         colIndex < range.end.colIndex + 1;
         colIndex++
       ) {
-        const colId = colLeafNodes[colIndex].id;
+        const colId = String(colLeafNodes[colIndex].id);
         let rowId = String(rowIndex);
         if (rowLeafNodes.length) {
-          rowId = rowLeafNodes[rowIndex].id;
+          rowId = String(rowLeafNodes[rowIndex].id);
         }
         metas.push({
           colIndex,
@@ -694,6 +694,7 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
           type: 'dataCell',
           rowId,
           colId,
+          spreadsheet: this.spreadsheet,
         });
       }
     }
@@ -714,7 +715,7 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
 
     if (options.interaction.selectedCellHighlight) {
       selectedCellMetas.forEach((meta) => {
-        updateRowColCells(meta, this.spreadsheet);
+        updateRowColCells(meta);
       });
     }
 

--- a/packages/s2-core/src/interaction/brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection.ts
@@ -30,7 +30,10 @@ import {
   getScrollOffsetForCol,
   getScrollOffsetForRow,
 } from '../utils/interaction/';
-import { getCellMeta } from '../utils/interaction/select-event';
+import {
+  getCellMeta,
+  updateRowColCells,
+} from '../utils/interaction/select-event';
 import { getValidFrozenOptions } from '../utils/layout/frozen';
 import { getActiveCellsTooltipData } from '../utils/tooltip';
 import type { BaseEventImplement } from './base-event';
@@ -689,6 +692,8 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
           rowIndex,
           id: `${rowId}-${colId}`,
           type: 'dataCell',
+          rowId,
+          colId,
         });
       }
     }
@@ -697,14 +702,22 @@ export class BrushSelection extends BaseEvent implements BaseEventImplement {
 
   // 最终刷选的cell
   private updateSelectedCells() {
-    const { interaction } = this.spreadsheet;
+    const { interaction, options } = this.spreadsheet;
 
     const range = this.getBrushRange();
 
+    const selectedCellMetas = this.getSelectedCellMetas(range);
     interaction.changeState({
-      cells: this.getSelectedCellMetas(range),
+      cells: selectedCellMetas,
       stateName: InteractionStateName.SELECTED,
     });
+
+    if (options.interaction.selectedCellHighlight) {
+      selectedCellMetas.forEach((meta) => {
+        updateRowColCells(meta, this.spreadsheet);
+      });
+    }
+
     this.spreadsheet.emit(
       S2Event.DATA_CELL_BRUSH_SELECTION,
       this.brushRangeDataCells,

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -1,3 +1,4 @@
+import { forEach } from 'lodash';
 import { ColCell, RowCell, TableSeriesCell } from '../../cell';
 import { getDataCellId } from '../cell/data-cell';
 import {
@@ -7,7 +8,10 @@ import {
 } from '../../common/constant';
 import type { CellMeta, S2CellType, ViewMeta } from '../../common/interface';
 import type { SpreadSheet } from '../../sheet-type';
-import { getActiveHoverRowColCells } from './hover-event';
+import {
+  getActiveHoverRowColCells,
+  updateAllColHeaderCellState,
+} from './hover-event';
 
 export const isMultiSelectionKey = (e: KeyboardEvent) => {
   return [InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL].includes(
@@ -80,4 +84,21 @@ export function getRowCellForSelectedCell(
     interaction.getAllRowHeaderCells(),
     spreadsheet.isHierarchyTreeType(),
   );
+}
+
+export function updateRowColCells(meta: ViewMeta, spreadsheet: SpreadSheet) {
+  const { rowId, colId } = meta;
+  const { interaction } = spreadsheet;
+  updateAllColHeaderCellState(
+    colId,
+    interaction.getAllColHeaderCells(),
+    InteractionStateName.SELECTED,
+  );
+
+  if (rowId) {
+    const allRowHeaderCells = getRowCellForSelectedCell(meta, spreadsheet);
+    forEach(allRowHeaderCells, (cell: RowCell) => {
+      cell.updateByState(InteractionStateName.SELECTED);
+    });
+  }
 }

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -86,8 +86,8 @@ export function getRowCellForSelectedCell(
   );
 }
 
-export function updateRowColCells(meta: ViewMeta, spreadsheet: SpreadSheet) {
-  const { rowId, colId } = meta;
+export function updateRowColCells(meta: ViewMeta) {
+  const { rowId, colId, spreadsheet } = meta;
   const { interaction } = spreadsheet;
   updateAllColHeaderCellState(
     colId,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -812,6 +812,20 @@ function MainLayout() {
                     }}
                   />
                 </Tooltip>
+                <Tooltip title="高亮选中单元格">
+                  <Switch
+                    checkedChildren="选中高亮开"
+                    unCheckedChildren="选中高亮关"
+                    checked={mergedOptions.interaction?.selectedCellHighlight}
+                    onChange={(checked) => {
+                      updateOptions({
+                        interaction: {
+                          selectedCellHighlight: checked,
+                        },
+                      });
+                    }}
+                  />
+                </Tooltip>
                 <Tooltip title="高亮当前行列单元格">
                   <Switch
                     checkedChildren="hover十字器开"

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -164,7 +164,7 @@ const s2Options = {
 
 ### 单选后行列头高亮
 
-在鼠标选中单元格后时，高亮当前单元格对应的行列头单元格，利于快速定位单元格所在行列。默认关闭，可配置 `selectedCellHighlight` 开启：
+在鼠标选中单元格或刷选选中单元格时，高亮当前单元格对应的行列头单元格，利于快速定位单元格所在行列。默认关闭，可配置 `selectedCellHighlight` 开启：
 
 <img src="https://gw.alipayobjects.com/mdn/rms_28a65c/afts/img/A*bqsoRpdz8mgAAAAAAAAAAAAAARQnAQ" alt="preview" width="600" />
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #1667 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
Before：selectedHighlight仅作用于data-cell-click事件，导致刷选情况无法触发高亮行列头
<img width="803" alt="image" src="https://user-images.githubusercontent.com/9219215/184280919-58572b8b-aee9-4bbd-aa80-96866934d488.png">



将高亮对应行列头function抽离至
https://github.com/antvis/S2/blob/c5335badf47ccc89246c5a6d0575395bbb453f36/packages/s2-core/src/utils/interaction/select-event.ts

在brush-selection中调用

After: 刷选会更新所有的对应cell
<img width="667" alt="image" src="https://user-images.githubusercontent.com/9219215/184280906-5b9f64bf-af2b-41de-9e5b-1bd85db0fb84.png">


### 🖼️ Screenshot



### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
