### PR TITLE
perf: 优化生成grid模式时性能问题

### DIFF
--- a/packages/s2-core/src/facet/layout/build-gird-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-gird-hierarchy.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isUndefined, uniqWith } from 'lodash';
+import { isEmpty, isUndefined } from 'lodash';
 import { EXTRA_COLUMN_FIELD, EXTRA_FIELD } from '../../common/constant';
 import type { SpreadSheetFacetCfg } from '../../common/interface';
 import { addTotals } from '../../utils/layout/add-totals';
@@ -7,6 +7,7 @@ import { getDimsCondition } from '../../utils/layout/get-dims-condition-by-node'
 import type { FieldValue, GridHeaderParams } from '../layout/interface';
 import { layoutArrange } from '../layout/layout-hooks';
 import { TotalMeasure } from '../layout/total-measure';
+import type { SpreadSheet } from '../../sheet-type';
 
 const hideMeasureColumn = (
   fieldValues: FieldValue[],
@@ -20,6 +21,18 @@ const hideMeasureColumn = (
       fieldValues.splice(fieldValues.indexOf(value), 1);
     }
   }
+};
+
+const getIsEqualValueLeafNode = (spreadsheet: SpreadSheet) => {
+  const leafNodes = spreadsheet.getColumnLeafNodes();
+  const values = new Set();
+  for (let i = 0; i < leafNodes.length; i++) {
+    values.add(leafNodes[i].value);
+    if (values.size > 1) {
+      return false;
+    }
+  }
+  return values.size === 1;
 };
 
 /**
@@ -89,10 +102,7 @@ export const buildGridHierarchy = (params: GridHeaderParams) => {
   }
 
   const hiddenColumnsDetail = spreadsheet.store.get('hiddenColumnsDetail');
-  const isEqualValueLeafNode =
-    uniqWith(spreadsheet.getColumnLeafNodes(), (prev, next) => {
-      return prev.value === next.value;
-    }).length === 1;
+  const isEqualValueLeafNode = getIsEqualValueLeafNode(spreadsheet);
 
   const displayFieldValues = fieldValues.filter((value) => {
     // 去除多余的节点


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
在DI侧，从明细模式切换到聚合模式时，如果数据量比较大，整个转换过程耗时非常久，排查原因是`uniqWith`函数耗时特别久
![image](https://user-images.githubusercontent.com/17964556/184336363-defde973-1a11-45f2-b40b-eb2c83284e9e.png)

![image](https://user-images.githubusercontent.com/17964556/184336339-7924543b-faf5-48eb-b59d-881be7dfca29.png)

使用for来提前退出，减少开销

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
