### PR TITLE
feat: actionIcons支持细粒度展示控制

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/cell/header-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/cell/header-cell-spec.ts
@@ -1,0 +1,59 @@
+import type { Node } from '@antv/s2';
+import { CellTypes, type HeaderActionIcon } from '@/common';
+import { getActionIconConfig } from '@/utils/cell/header-cell';
+
+describe('Header Cell Utils Tests', () => {
+  describe('getActionIconConfig Tests', () => {
+    test('should return config', () => {
+      const actionConfig: HeaderActionIcon[] = [
+        {
+          iconNames: ['SortUp', 'SortDown'],
+          belongsCell: 'rowCell',
+          displayCondition: jest.fn().mockReturnValue(true),
+        },
+        {
+          iconNames: ['DrillDown', 'Star'],
+          belongsCell: 'colCell',
+        },
+      ];
+
+      // 行头 icon 条件返回
+      const rowMeta = { id: 'test-col' } as Node;
+      const rowConfig = getActionIconConfig(
+        actionConfig,
+        rowMeta,
+        CellTypes.ROW_CELL,
+      );
+      expect(rowConfig).toEqual(actionConfig[0]);
+      expect(rowConfig.displayCondition).toBeCalledWith(rowMeta, 'SortUp');
+      expect(rowConfig.displayCondition).toBeCalledWith(rowMeta, 'SortDown');
+
+      // 列头 icon
+      expect(
+        getActionIconConfig(actionConfig, null, CellTypes.COL_CELL),
+      ).toEqual(actionConfig[1]);
+
+      // 未命中
+      expect(
+        getActionIconConfig(actionConfig, null, CellTypes.CORNER_CELL),
+      ).toBeUndefined();
+    });
+
+    test('should filter invisible icons', () => {
+      const actionConfig: HeaderActionIcon[] = [
+        {
+          iconNames: ['SortUp', 'SortDown'],
+          belongsCell: 'rowCell',
+          displayCondition: (meta, iconName) => iconName === 'SortDown',
+        },
+      ];
+
+      const rowConfig = getActionIconConfig(
+        actionConfig,
+        null,
+        CellTypes.ROW_CELL,
+      );
+      expect(rowConfig.iconNames).toEqual(['SortDown']);
+    });
+  });
+});

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -163,7 +163,7 @@ export abstract class HeaderCell extends BaseCell<Node> {
   }
 
   protected addActionIcon(options: HeaderActionIconOptions) {
-    const { x, y, iconName, defaultHide, action } = options;
+    const { x, y, iconName, defaultHide, action, onClick, onHover } = options;
     const { icon: iconTheme, text: textTheme } = this.getStyle();
     // 未配置 icon 颜色, 默认使用文字颜色
     const actionIconColor = iconTheme?.fill || textTheme?.fill;
@@ -181,10 +181,25 @@ export abstract class HeaderCell extends BaseCell<Node> {
     icon.set('visible', !defaultHide);
     icon.on('mouseover', (event: CanvasEvent) => {
       this.spreadsheet.emit(S2Event.GLOBAL_ACTION_ICON_HOVER, event);
+      onHover?.({
+        hovering: true,
+        iconName,
+        meta: this.meta,
+        event,
+      });
+    });
+    icon.on('mouseleave', (event: CanvasEvent) => {
+      this.spreadsheet.emit(S2Event.GLOBAL_ACTION_ICON_HOVER_OFF, event);
+      onHover?.({
+        hovering: false,
+        iconName,
+        meta: this.meta,
+        event,
+      });
     });
     icon.on('click', (event: CanvasEvent) => {
       this.spreadsheet.emit(S2Event.GLOBAL_ACTION_ICON_CLICK, event);
-      action?.({
+      (onClick || action)?.({
         iconName,
         meta: this.meta,
         event,
@@ -206,7 +221,7 @@ export abstract class HeaderCell extends BaseCell<Node> {
       return;
     }
 
-    const { iconNames, action, defaultHide } = actionIconCfg;
+    const { iconNames, action, onClick, onHover, defaultHide } = actionIconCfg;
 
     const position = this.getIconPosition(iconNames.length);
 
@@ -229,6 +244,8 @@ export abstract class HeaderCell extends BaseCell<Node> {
         y,
         defaultHide: iconDefaultHide,
         action,
+        onClick,
+        onHover,
       });
     });
   }

--- a/packages/s2-core/src/common/constant/events/basic.ts
+++ b/packages/s2-core/src/common/constant/events/basic.ts
@@ -91,6 +91,7 @@ export enum S2Event {
   GLOBAL_MOUSE_MOVE = 'global:mouse-move',
   GLOBAL_ACTION_ICON_CLICK = 'global:action-icon-click',
   GLOBAL_ACTION_ICON_HOVER = 'global:action-icon-hover',
+  GLOBAL_ACTION_ICON_HOVER_OFF = 'global:action-icon-hover-off',
   GLOBAL_CONTEXT_MENU = 'global:context-menu',
   GLOBAL_CLICK = 'global:click',
   GLOBAL_DOUBLE_CLICK = 'global:double-click',

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -222,17 +222,26 @@ export interface CustomSVGIcon {
   svg: string;
 }
 
-export interface HeaderActionIconProps {
+export interface HeaderIconClickParams {
   iconName: string;
   meta: Node;
   event?: Event;
+}
+
+export type HeaderActionIconProps = HeaderIconClickParams;
+
+export interface HeaderIconHoverParams extends HeaderIconClickParams {
+  hovering: boolean;
 }
 
 export interface HeaderActionIconOptions {
   iconName: string;
   x: number;
   y: number;
-  action: (props: HeaderActionIconProps) => void;
+  /** @deprecated 使用 onClick 代替 */
+  action: (props: HeaderIconClickParams) => void;
+  onClick: (headerIconClickParams: HeaderIconClickParams) => void;
+  onHover: (headerIconHoverParams: HeaderIconHoverParams) => void;
   defaultHide?: boolean;
 }
 
@@ -245,8 +254,15 @@ export interface HeaderActionIcon {
   defaultHide?: boolean | ((meta: Node, iconName: string) => boolean);
   // 是否展示当前 iconNames 配置的 icon
   displayCondition?: (mete: Node, iconName: string) => boolean;
-  // 点击后的执行函数
-  action?: (headerActionIconProps: HeaderActionIconProps) => void;
+  /**
+   * 点击后的执行函数
+   * @deprecated 使用 onClick 代替
+   */
+  action?: (headerIconClickParams: HeaderIconClickParams) => void;
+  // 点击回调函数
+  onClick?: (headerIconClickParams: HeaderIconClickParams) => void;
+  // hover 回调函数
+  onHover?: (headerIconHoverParams: HeaderIconHoverParams) => void;
 }
 
 // Hook 渲染和布局相关的函数类型定义

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -242,9 +242,9 @@ export interface HeaderActionIcon {
   // 所属的 cell 类型
   belongsCell: Omit<CellTypes, 'dataCell'>;
   // 是否默认隐藏， true 为 hover后显示, false 为一直显示
-  defaultHide?: boolean;
-  // 需要展示的层级(行头/列头) 如果没有改配置则默认全部打开
-  displayCondition?: (mete: Node) => boolean;
+  defaultHide?: boolean | ((meta: Node, iconName: string) => boolean);
+  // 是否展示当前 iconNames 配置的 icon
+  displayCondition?: (mete: Node, iconName: string) => boolean;
   // 点击后的执行函数
   action?: (headerActionIconProps: HeaderActionIconProps) => void;
 }

--- a/packages/s2-core/src/common/interface/emitter.ts
+++ b/packages/s2-core/src/common/interface/emitter.ts
@@ -47,6 +47,7 @@ export interface EmitterType {
   /** ================ Global ================  */
   [S2Event.GLOBAL_ACTION_ICON_CLICK]: CanvasEventHandler;
   [S2Event.GLOBAL_ACTION_ICON_HOVER]: CanvasEventHandler;
+  [S2Event.GLOBAL_ACTION_ICON_HOVER_OFF]: CanvasEventHandler;
   [S2Event.GLOBAL_COPIED]: (data: string) => void;
   [S2Event.GLOBAL_KEYBOARD_DOWN]: KeyboardEventHandler;
   [S2Event.GLOBAL_KEYBOARD_UP]: KeyboardEventHandler;

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -7,6 +7,7 @@ import {
   isNil,
   keys,
   last,
+  map,
   maxBy,
   merge,
   reduce,
@@ -22,9 +23,8 @@ import { EXTRA_FIELD, LayoutWidthTypes, VALUE_FIELD } from '../common/constant';
 import { CellTypes } from '../common/constant/interaction';
 import { DebuggerUtil } from '../common/debug';
 import type { LayoutResult, ViewMeta } from '../common/interface';
-import type { HeaderActionIcon } from '../common/interface/basic';
 import { getDataCellId, handleDataItem } from '../utils/cell/data-cell';
-import { shouldShowActionIcons } from '../utils/cell/header-cell';
+import { getActionIconConfig } from '../utils/cell/header-cell';
 import {
   getIndexRangeWithOffsets,
   getSubTotalNodeWidthOrHeightByLevel,
@@ -365,18 +365,14 @@ export class PivotFacet extends BaseFacet {
     if (useDefaultIcon) {
       iconCount = 1;
     } else {
-      const customIcons = find(
-        this.spreadsheet.options.headerActionIcons,
-        (headerActionIcon: HeaderActionIcon) =>
-          shouldShowActionIcons(
-            {
-              ...headerActionIcon,
-              // ignore condition func when layout calc
-              displayCondition: () => true,
-            },
-            null,
-            cellType,
-          ),
+      const customIcons = getActionIconConfig(
+        map(this.spreadsheet.options.headerActionIcons, (iconCfg) => ({
+          ...iconCfg,
+          // ignore condition func when layout calc
+          displayCondition: () => true,
+        })),
+        null,
+        cellType,
       );
 
       iconCount = customIcons?.iconNames.length ?? 0;

--- a/packages/s2-core/src/utils/cell/header-cell.ts
+++ b/packages/s2-core/src/utils/cell/header-cell.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isEqual } from 'lodash';
+import { find, isEmpty, isEqual } from 'lodash';
 import { CellTypes, EXTRA_FIELD } from '../../common/constant';
 import type {
   FormatResult,
@@ -26,7 +26,43 @@ export const shouldShowActionIcons = (
     // 没有展示条件参数默认全展示
     return true;
   }
-  return displayCondition(meta);
+
+  // 有任意 iconName 命中展示，则使用当前 headerActionIcon config
+  return iconNames.some((iconName) => displayCondition(meta, iconName));
+};
+
+/**
+ * 返回可用的 icon 配置
+ * @param actionIconCfgList icon 配置列表
+ * @param meta 单元格 meta
+ * @param cellType 单元格类型
+ * @returns icon 配置
+ */
+export const getActionIconConfig = (
+  actionIconCfgList: HeaderActionIcon[],
+  meta: Node,
+  cellType: CellTypes,
+): HeaderActionIcon | undefined => {
+  const iconConfig = find(actionIconCfgList, (cfg) =>
+    shouldShowActionIcons(cfg, meta, cellType),
+  );
+
+  if (!iconConfig) {
+    return;
+  }
+
+  // 使用配置的 displayCondition 进一步筛选需要展示的 icon
+  let nextIconNames = iconConfig.iconNames;
+  if (iconConfig.displayCondition) {
+    nextIconNames = nextIconNames.filter((iconName) =>
+      iconConfig.displayCondition(meta, iconName),
+    );
+  }
+
+  return {
+    ...iconConfig,
+    iconNames: nextIconNames,
+  };
 };
 
 /**

--- a/packages/s2-core/src/utils/cell/table-col-cell.ts
+++ b/packages/s2-core/src/utils/cell/table-col-cell.ts
@@ -1,10 +1,9 @@
-import { find, get } from 'lodash';
+import { get } from 'lodash';
 import { CellTypes } from '../../common/constant';
-import type { HeaderActionIcon } from '../../common/interface/basic';
 import type { DefaultCellTheme, IconTheme } from '../../common/interface/theme';
 import type { Node } from '../../facet/layout/node';
 import type { SpreadSheet } from '../../sheet-type';
-import { shouldShowActionIcons } from './header-cell';
+import { getActionIconConfig } from './header-cell';
 
 export const getTableColIconsWidth = (
   ss: SpreadSheet,
@@ -19,11 +18,9 @@ export const getTableColIconsWidth = (
   if (ss.options.showDefaultHeaderActionIcon) {
     iconNums = 1;
   } else {
-    iconNums = (
-      find(ss.options.headerActionIcons, (headerActionIcon: HeaderActionIcon) =>
-        shouldShowActionIcons(headerActionIcon, meta, cellType),
-      )?.iconNames ?? []
-    ).length;
+    iconNums =
+      getActionIconConfig(ss.options.headerActionIcons, meta, cellType)
+        ?.iconNames.length ?? 0;
   }
 
   return (

--- a/packages/s2-core/src/utils/cell/table-col-cell.ts
+++ b/packages/s2-core/src/utils/cell/table-col-cell.ts
@@ -6,7 +6,7 @@ import type { SpreadSheet } from '../../sheet-type';
 import { getActionIconConfig } from './header-cell';
 
 export const getTableColIconsWidth = (
-  ss: SpreadSheet,
+  s2: SpreadSheet,
   meta: Node,
   cellType: CellTypes,
   iconStyle: IconTheme,
@@ -15,11 +15,11 @@ export const getTableColIconsWidth = (
   const iconMargin = get(iconStyle, 'margin');
 
   let iconNums = 0;
-  if (ss.options.showDefaultHeaderActionIcon) {
+  if (s2.options.showDefaultHeaderActionIcon) {
     iconNums = 1;
   } else {
     iconNums =
-      getActionIconConfig(ss.options.headerActionIcons, meta, cellType)
+      getActionIconConfig(s2.options.headerActionIcons, meta, cellType)
         ?.iconNames.length ?? 0;
   }
 
@@ -30,13 +30,13 @@ export const getTableColIconsWidth = (
 };
 
 export const getExtraPaddingForExpandIcon = (
-  ss: SpreadSheet,
+  s2: SpreadSheet,
   field: string,
   style: DefaultCellTheme,
 ) => {
   const iconMarginLeft = style.icon.margin?.left || 0;
   const iconMarginRight = style.icon.margin?.right || 0;
-  const hiddenColumnsDetail = ss.store.get('hiddenColumnsDetail', []);
+  const hiddenColumnsDetail = s2.store.get('hiddenColumnsDetail', []);
 
   let hasPrevSiblingCell = false;
   let hasNextSiblingCell = false;

--- a/s2-site/docs/api/components/drill-down.zh.md
+++ b/s2-site/docs/api/components/drill-down.zh.md
@@ -58,7 +58,7 @@ const s2Options = {
 | drillItemsNum | 下钻完成后展示的个数，默认全部展示 | `number` | -1 |  |                   |
 | fetchData | 点击下钻后的回调 | [FetchCallBack](#fetchcallback) | - | ✓ |                   |
 | clearDrillDown | 清除下钻信息，当有指定的 rowId 传递时清除对应 rowId 的下钻信息；如果参数是 空对象 {}，则清空所有的下钻信息 | `{rowId: string;}` | - |  | 仅 `React` 组件支持此属性 |
-| displayCondition | 配置下钻 `icon` 的展示条件， 同 HeaderActionIcon | `(meta: Node) => boolean` | - |  | 仅 `React` 组件支持此属性 |
+| displayCondition | 配置下钻 `icon` 的展示条件， 同 HeaderActionIcon | `(meta: Node, iconName: string) => boolean` | - |  | 仅 `React` 组件支持此属性 |
 
 注意：PartDrillDown 中 `drillConfig`、`displayCondition` 字段会影响下钻模式的重渲，请注意使用 memo 或 state 控制其可变性。
 

--- a/s2-site/docs/api/components/drill-down.zh.md
+++ b/s2-site/docs/api/components/drill-down.zh.md
@@ -52,13 +52,13 @@ const s2Options = {
 
 类型：`object`，**可选**，默认值：`{}`
 
-| 参数 | 说明 | 类型 | 默认值 | 必选 | 备注                |
-| --- | --- | --- | --- | --- |-------------------|
-| drillConfig | 下钻菜单组件配置项 | [DrillDownProps](#drilldownprops) | - | ✓ |                   |
-| drillItemsNum | 下钻完成后展示的个数，默认全部展示 | `number` | -1 |  |                   |
-| fetchData | 点击下钻后的回调 | [FetchCallBack](#fetchcallback) | - | ✓ |                   |
-| clearDrillDown | 清除下钻信息，当有指定的 rowId 传递时清除对应 rowId 的下钻信息；如果参数是 空对象 {}，则清空所有的下钻信息 | `{rowId: string;}` | - |  | 仅 `React` 组件支持此属性 |
-| displayCondition | 配置下钻 `icon` 的展示条件， 同 HeaderActionIcon | `(meta: Node, iconName: string) => boolean` | - |  | 仅 `React` 组件支持此属性 |
+| 参数 | 说明 | 类型 | 默认值 | 必选 | 备注                | 版本 |
+| --- | --- | --- | --- | --- |-------------------| --- |
+| drillConfig | 下钻菜单组件配置项 | [DrillDownProps] (#drilldownprops) | - | ✓ |     | |
+| drillItemsNum | 下钻完成后展示的个数，默认全部展示 | `number` | -1 |  |                   | |
+| fetchData | 点击下钻后的回调 | [FetchCallBack](#fetchcallback) | - | ✓ |                   | |
+| clearDrillDown | 清除下钻信息，当有指定的 rowId 传递时清除对应 rowId 的下钻信息；如果参数是 空对象 {}，则清空所有的下钻信息 | `{rowId: string;}` | - |  | 仅 `React` 组件支持此属性 | |
+| displayCondition | 配置下钻 `icon` 的展示条件， 同 HeaderActionIcon | `(meta: Node, iconName: string) => boolean` | - |  | 仅 `React` 组件支持此属性 | `1.26.0` 回传 `iconName` 并按单个 icon 控制显隐 |
 
 注意：PartDrillDown 中 `drillConfig`、`displayCondition` 字段会影响下钻模式的重渲，请注意使用 memo 或 state 控制其可变性。
 

--- a/s2-site/docs/common/custom/headerActionIcons.zh.md
+++ b/s2-site/docs/common/custom/headerActionIcons.zh.md
@@ -7,10 +7,12 @@ order: 6
 
 功能描述：为表格行列头角头注册自定义操作 `icon`。如果该配置位空，则展示透视表默认操作icon。
 
-| 参数 | 类型 | 必选  | 默认值 | 功能描述 |
-| --- | --- | :-:  | --- | --- |
-| iconNames | string[] | ✓ |    | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 |
-| belongsCell | string[] | ✓ | |   需要增加操作图标的单元格名称 cornerCell、colCell、rowCell |
-| defaultHide | boolean \|(mete: Node, iconName: string)=> boolean  |  |  |   是否默认隐藏, 如果为 true 则为 hover 后再显示；false 则始终显示  |
-| displayCondition | (mete: Node, iconName: string)=> boolean |  |  | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 |
-| action | (headerActionIconProps: HeaderActionIconProps) => void; | ✓ |  | icon 点击之后的执行函数 |
+| 参数 | 类型 | 必选  | 默认值 | 功能描述 | 版本 |
+| --- | --- | :-:  | --- | --- | --- |
+| iconNames | string[] | ✓ |    | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 | |
+| belongsCell | string[] | ✓ | |   需要增加操作图标的单元格名称 cornerCell、colCell、rowCell | |
+| defaultHide | boolean \|(mete: Node, iconName: string)=> boolean  |  |  |   是否默认隐藏, 如果为 true 则为 hover 后再显示；false 则始终显示  | `1.26.0` 支持配置为一个函数 |
+| displayCondition | (mete: Node, iconName: string)=> boolean |  |  | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 | `1.26.0` 回传 `iconName` 并按单个 icon 控制显隐 |
+| action | (headerActionIconProps: HeaderActionIconProps) => void; | ✓ |  | icon 点击之后的执行函数 | 已废弃，请使用 `onClick` |
+| onClick    | `(headerIconClickParams: HeaderIconClickParams) => void;` |   ✓      |     |    | `1.26.0` |
+| onHover   | `(headerIconHoverParams: HeaderIconHoverParams) => void;` |        |     |    | `1.26.0` |

--- a/s2-site/docs/common/custom/headerActionIcons.zh.md
+++ b/s2-site/docs/common/custom/headerActionIcons.zh.md
@@ -11,7 +11,7 @@ order: 6
 | --- | --- | :-:  | --- | --- | --- |
 | iconNames | string[] | ✓ |    | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 | |
 | belongsCell | string[] | ✓ | |   需要增加操作图标的单元格名称 cornerCell、colCell、rowCell | |
-| defaultHide | boolean \|(mete: Node, iconName: string)=> boolean  |  |  |   是否默认隐藏, 如果为 true 则为 hover 后再显示；false 则始终显示  | `1.26.0` 支持配置为一个函数 |
+| defaultHide | boolean \| (mete: Node, iconName: string)=> boolean  |  |  |   是否默认隐藏, 如果为 true 则为 hover 后再显示；false 则始终显示  | `1.26.0` 支持配置为一个函数 |
 | displayCondition | (mete: Node, iconName: string)=> boolean |  |  | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 | `1.26.0` 回传 `iconName` 并按单个 icon 控制显隐 |
 | action | (headerActionIconProps: HeaderActionIconProps) => void; | ✓ |  | icon 点击之后的执行函数 | 已废弃，请使用 `onClick` |
 | onClick    | `(headerIconClickParams: HeaderIconClickParams) => void;` |   ✓      |     |    | `1.26.0` |

--- a/s2-site/docs/common/custom/headerActionIcons.zh.md
+++ b/s2-site/docs/common/custom/headerActionIcons.zh.md
@@ -11,6 +11,6 @@ order: 6
 | --- | --- | :-:  | --- | --- |
 | iconNames | string[] | ✓ |    | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 |
 | belongsCell | string[] | ✓ | |   需要增加操作图标的单元格名称 cornerCell、colCell、rowCell |
-| defaultHide | boolean |  |  |   是否默认隐藏, 如果为 true 则为 hover 后再显示；false 则始终显示  |
-| displayCondition | (mete: Node)=> boolean; |  |  | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的单元格会展示 icon，反之则无 |
+| defaultHide | boolean \|(mete: Node, iconName: string)=> boolean  |  |  |   是否默认隐藏, 如果为 true 则为 hover 后再显示；false 则始终显示  |
+| displayCondition | (mete: Node, iconName: string)=> boolean |  |  | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 |
 | action | (headerActionIconProps: HeaderActionIconProps) => void; | ✓ |  | icon 点击之后的执行函数 |

--- a/s2-site/docs/common/header-action-icon.zh.md
+++ b/s2-site/docs/common/header-action-icon.zh.md
@@ -4,13 +4,15 @@
 
 功能描述：为表格行列头角头注册自定义操作 icon。
 
-| 参数             | 说明                                                         | 类型                                                    | 默认值 | 必选 | 取值                                                       |
-| ---------------- | ------------------------------------------------------------ | ------------------------------------------------------- | ------ | ---- | ---------------------------------------------------------- |
-| iconNames        | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 | `string[]`                                              |        | ✓    |                                                            |
-| belongsCell      | 需要增加操作图标的单元格名称                                 | `string[]`                                              |        | ✓    | 角头：'cornerCell';<br>列头：'colCell';<br>行头：'rowCell' |
-| defaultHide      | 控制是否 hover 才展示 icon                                                        | `boolean \| (meta: Node, iconName: string) => boolean`                                                | false  |      | true                                                       |
-| displayCondition | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 | `(mete: Node, iconName: string) => boolean;`                               |        |      |                                                            |
-| action           | icon 点击之后的执行函数                                      | `(headerActionIconProps: HeaderActionIconProps) => void;` |        |     |                                                            |
+| 参数             | 说明                                                         | 类型                                                    | 默认值 | 必选 | 取值                                                       |     版本     |
+| ---------------- | ------------------------------------------------------------ | ------------------------------------------------------- | ------ | ---- | ---------------------------------------------------------- | --- |
+| iconNames        | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 | `string[]`                                              |        | ✓    |                                                            | |
+| belongsCell      | 需要增加操作图标的单元格名称                                 | `string[]`                                              |        | ✓    | 角头：'cornerCell';<br>列头：'colCell';<br>行头：'rowCell' | |
+| defaultHide      | 控制是否 hover 才展示 icon  | `boolean | (meta: Node, iconName: string) => boolean`          | false  |      | true | `1.26.0` 支持配置为一个函数 |
+| displayCondition | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 | `(mete: Node, iconName: string) => boolean;`         |        |      |  | `1.26.0` 回传 `iconName` 并按单个 icon 控制显隐 |
+| action           | icon 点击之后的执行函数                                      | `(headerActionIconProps: HeaderActionIconProps) => void;` |        |     |    | 已废弃，请使用 `onClick`  |
+| onClick           | icon 点击之后的执行函数                                      | `(headerIconClickParams: HeaderIconClickParams) => void;` |        |     |    | `1.26.0` |
+| onHover           | icon hover 开始及结束之后的执行函数                    | `(headerIconHoverParams: HeaderIconHoverParams) => void;` |        |     |    | `1.26.0` |
 
 ​
 

--- a/s2-site/docs/common/header-action-icon.zh.md
+++ b/s2-site/docs/common/header-action-icon.zh.md
@@ -8,8 +8,8 @@
 | ---------------- | ------------------------------------------------------------ | ------------------------------------------------------- | ------ | ---- | ---------------------------------------------------------- |
 | iconNames        | 已经注册的 icon 名称，或用户通过 customSVGIcons 注册的 icon 名称 | `string[]`                                              |        | ✓    |                                                            |
 | belongsCell      | 需要增加操作图标的单元格名称                                 | `string[]`                                              |        | ✓    | 角头：'cornerCell';<br>列头：'colCell';<br>行头：'rowCell' |
-| defaultHide      | false                                                        | `boolean`                                               | false  |      | true                                                       |
-| displayCondition | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的单元格会展示 icon，反之则无 | `(mete: Node) => boolean;`                               |        |      |                                                            |
+| defaultHide      | 控制是否 hover 才展示 icon                                                        | `boolean \| (meta: Node, iconName: string) => boolean`                                                | false  |      | true                                                       |
+| displayCondition | 展示的过滤条件，可以通过该回调函数用户自定义行列头哪些层级或单元格需要展示 icon。 所有返回值为 true 的 icon 会展示给用户。 | `(mete: Node, iconName: string) => boolean;`                               |        |      |                                                            |
 | action           | icon 点击之后的执行函数                                      | `(headerActionIconProps: HeaderActionIconProps) => void;` |        |     |                                                            |
 
 ​


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description
#### 背景
当前的 `options.headerActionIcons` 配置，属于同一个 config 下的图标 iconNames：
- 只能统一 `展示/隐藏`，通过 displayCondition 判断
- 只能统一设置是否 hover 展示，通过 defaultHide 判断

#### 方案
displayCondition、defaultHide 支持更细粒度的判断
- boolean 或判断回调函数
- 判断回调函数增加 actionName 参数


### 🖼️ Screenshot

> 1. 省维度：隐藏 config 中单个 icon
> 2. 市维度：defaultHide 第二个 icon

| Before | After |
| ------ | ----- |
|  ![image](https://user-images.githubusercontent.com/6716092/184634395-62ce149c-4510-4208-a920-795a2078a34e.png) | ![image](https://user-images.githubusercontent.com/6716092/184634742-b00fcd65-866e-4433-9ef7-579b2598d978.png)  |
|  ![CleanShot 2022-08-15 at 20 24 23](https://user-images.githubusercontent.com/6716092/184634582-214a1b64-f469-4eeb-b222-ea2c0c8a84dc.gif)     |   ![CleanShot 2022-08-15 at 20 31 39](https://user-images.githubusercontent.com/6716092/184635524-9ad2ae40-11e2-4cf1-afc8-9d11105a2a7d.gif)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
