### PR TITLE
chore: facet.startsScroll添加被动参数

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -396,7 +396,7 @@ describe('Scroll Tests', () => {
     jest.spyOn(sheet.facet as any, 'dynamicRenderCell');
     jest.spyOn(sheet.facet as any, 'emitScrollEvent');
 
-    sheet.facet.startScroll(1, 1, true);
+    sheet.facet.startScroll(true);
 
     expect((sheet.facet as any).dynamicRenderCell).toHaveBeenCalledWith(true);
     expect((sheet.facet as any).emitScrollEvent).not.toBeCalled();

--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -387,6 +387,21 @@ describe('Scroll Tests', () => {
     },
   );
 
+  test('should not trigger scroll event on passive renders', () => {
+    const sheet = new PivotSheet(getContainer(), mockDataConfig, {
+      ...s2Options,
+    });
+    sheet.render();
+
+    jest.spyOn(sheet.facet as any, 'dynamicRenderCell');
+    jest.spyOn(sheet.facet as any, 'emitScrollEvent');
+
+    sheet.facet.startScroll(1, 1, true);
+
+    expect((sheet.facet as any).dynamicRenderCell).toHaveBeenCalledWith(true);
+    expect((sheet.facet as any).emitScrollEvent).not.toBeCalled();
+  });
+
   test('should render correct scroll position', () => {
     s2.setOptions({
       interaction: {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -487,7 +487,13 @@ export abstract class BaseFacet {
     this.startScroll(scrollX, scrollY);
   };
 
-  startScroll = (newX: number, newY: number) => {
+  /**
+   *
+   * @param newX 是否更新水平滚动条
+   * @param newY 是否更新纵向滚动条
+   * @param passive 被动更新不触发S2Event.GLOBAL_SCROLL
+   */
+  startScroll = (newX: number, newY: number, passive = false) => {
     const { scrollX, scrollY } = this.getScrollOffset();
     if (newX !== undefined) {
       this.hScrollBar?.onlyUpdateThumbOffset(
@@ -499,7 +505,7 @@ export abstract class BaseFacet {
         this.getScrollBarOffset(scrollY, this.vScrollBar),
       );
     }
-    this.dynamicRenderCell();
+    this.dynamicRenderCell(passive);
   };
 
   getRendererHeight = () => {
@@ -1243,11 +1249,12 @@ export abstract class BaseFacet {
   }
 
   /**
-   * When scroll behavior happened, only render one time in a period,
-   * but render immediately in initiate
+   *
+   * @param passive: 如被动则不触发GLOBAL_SCROLL事件
+   * During scroll behavior, first call to this method fires immediately and then on interval.
    * @protected
    */
-  protected dynamicRenderCell() {
+  protected dynamicRenderCell(passive?: boolean) {
     const {
       scrollX,
       scrollY: originalScrollY,
@@ -1267,7 +1274,7 @@ export abstract class BaseFacet {
     this.updatePanelScrollGroup();
     this.translateRelatedGroups(scrollX, scrollY, hRowScrollX);
     this.clip(scrollX, scrollY);
-    this.emitScrollEvent({ scrollX, scrollY });
+    if (!passive) this.emitScrollEvent({ scrollX, scrollY });
     this.onAfterScroll();
   }
 

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -470,7 +470,7 @@ export abstract class BaseFacet {
       const ratio = Math.min(elapsed / duration, 1);
       const [scrollX, scrollY] = interpolate(ratio);
       this.setScrollOffset({ scrollX, scrollY });
-      this.startScroll(adjustedScrollX, adjustedScrollY);
+      this.startScroll();
       if (elapsed > duration) {
         this.timer.stop();
         cb?.();
@@ -484,27 +484,23 @@ export abstract class BaseFacet {
       scrollY: offsetConfig.offsetY?.value || 0,
     });
     this.setScrollOffset({ scrollX, scrollY });
-    this.startScroll(scrollX, scrollY);
+    this.startScroll();
   };
 
   /**
    *
-   * @param newX 是否更新水平滚动条
-   * @param newY 是否更新纵向滚动条
    * @param passive 被动更新不触发S2Event.GLOBAL_SCROLL
    */
-  startScroll = (newX: number, newY: number, passive = false) => {
+  startScroll = (passive = false) => {
     const { scrollX, scrollY } = this.getScrollOffset();
-    if (newX !== undefined) {
-      this.hScrollBar?.onlyUpdateThumbOffset(
-        this.getScrollBarOffset(scrollX, this.hScrollBar),
-      );
-    }
-    if (newY !== undefined) {
-      this.vScrollBar?.onlyUpdateThumbOffset(
-        this.getScrollBarOffset(scrollY, this.vScrollBar),
-      );
-    }
+
+    this.hScrollBar?.onlyUpdateThumbOffset(
+      this.getScrollBarOffset(scrollX, this.hScrollBar),
+    );
+
+    this.vScrollBar?.onlyUpdateThumbOffset(
+      this.getScrollBarOffset(scrollY, this.vScrollBar),
+    );
     this.dynamicRenderCell(passive);
   };
 
@@ -1274,7 +1270,9 @@ export abstract class BaseFacet {
     this.updatePanelScrollGroup();
     this.translateRelatedGroups(scrollX, scrollY, hRowScrollX);
     this.clip(scrollX, scrollY);
-    if (!passive) this.emitScrollEvent({ scrollX, scrollY });
+    if (!passive) {
+      this.emitScrollEvent({ scrollX, scrollY });
+    }
     this.onAfterScroll();
   }
 

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -1270,7 +1270,7 @@ export abstract class BaseFacet {
     this.updatePanelScrollGroup();
     this.translateRelatedGroups(scrollX, scrollY, hRowScrollX);
     this.clip(scrollX, scrollY);
-    if (!passive) {
+    if (!skipSrollEvent) {
       this.emitScrollEvent({ scrollX, scrollY });
     }
     this.onAfterScroll();

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -489,9 +489,9 @@ export abstract class BaseFacet {
 
   /**
    *
-   * @param passive 被动更新不触发S2Event.GLOBAL_SCROLL
+   * @param skipSrollEvent 如为true则不触发S2Event.GLOBAL_SCROLL
    */
-  startScroll = (passive = false) => {
+  startScroll = (skipSrollEvent = false) => {
     const { scrollX, scrollY } = this.getScrollOffset();
 
     this.hScrollBar?.onlyUpdateThumbOffset(
@@ -501,7 +501,7 @@ export abstract class BaseFacet {
     this.vScrollBar?.onlyUpdateThumbOffset(
       this.getScrollBarOffset(scrollY, this.vScrollBar),
     );
-    this.dynamicRenderCell(passive);
+    this.dynamicRenderCell(skipSrollEvent);
   };
 
   getRendererHeight = () => {
@@ -1246,11 +1246,11 @@ export abstract class BaseFacet {
 
   /**
    *
-   * @param passive: 如被动则不触发GLOBAL_SCROLL事件
+   * @param skipSrollEvent: 如true则不触发GLOBAL_SCROLL事件
    * During scroll behavior, first call to this method fires immediately and then on interval.
    * @protected
    */
-  protected dynamicRenderCell(passive?: boolean) {
+  protected dynamicRenderCell(skipSrollEvent?: boolean) {
     const {
       scrollX,
       scrollY: originalScrollY,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [x] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [x] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
DP中s2会有数据比对场景，类似monaco的diffEditor，左右实例同步滚动，需要在被动滚动时防止scrollEvent的触发。
因此在facet.startsScroll添加了被动参数，如为true则不emit事件



### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
