### PR TITLE
fix(pagination): 透传组件分页参数 & 修复国际化不生效 close #1697

### DIFF
--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -204,14 +204,14 @@ export interface Style {
   device?: 'pc' | 'mobile'; // 设备，pc || mobile
 }
 
-export type Pagination = {
+export type Pagination<T = unknown> = {
   // 每页数量
   pageSize: number;
   // 当前页
   current: number; // 从 1 开始
   // 数据总条数
   total?: number;
-};
+} & T;
 
 export interface CustomSVGIcon {
   // icon 类型名

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -29,7 +29,7 @@ import type { Conditions } from './condition';
 import type { InteractionOptions } from './interaction';
 import type { Tooltip } from './tooltip';
 
-export interface S2BasicOptions<T = Element | string> {
+export interface S2BasicOptions<T = Element | string, P = unknown> {
   // canvas's width
   width?: number;
   // canvas's height
@@ -47,7 +47,7 @@ export interface S2BasicOptions<T = Element | string> {
   // interaction configs
   interaction?: InteractionOptions;
   // pagination config
-  pagination?: Pagination;
+  pagination?: Pagination<P>;
   // freeze row header
   frozenRowHeader?: boolean;
   // show series Number
@@ -119,8 +119,8 @@ export interface S2TableSheetOptions {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface S2PivotSheetOptions {}
 
-export interface S2Options<T = Element | string>
-  extends S2BasicOptions<T>,
+export interface S2Options<T = Element | string, P = unknown>
+  extends S2BasicOptions<T, P>,
     S2TableSheetOptions,
     S2PivotSheetOptions {
   // custom data set

--- a/packages/s2-react/__tests__/spreadsheet/__snapshots__/pagination-spec.tsx.snap
+++ b/packages/s2-react/__tests__/spreadsheet/__snapshots__/pagination-spec.tsx.snap
@@ -1,0 +1,468 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination Tests should receive antd <Pagination/> component extra props 1`] = `
+<div
+  class="antv-s2-pagination"
+>
+  <ul
+    class="ant-pagination"
+    unselectable="unselectable"
+  >
+    <li
+      aria-disabled="false"
+      class="ant-pagination-prev"
+      tabindex="0"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2 ant-pagination-item-active"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      aria-disabled="true"
+      class="ant-pagination-next ant-pagination-disabled"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        class="ant-pagination-options-quick-jumper"
+      >
+        Go to
+        <input
+          aria-label="Page"
+          type="text"
+          value=""
+        />
+        Page
+      </div>
+    </li>
+  </ul>
+  <span
+    class="antv-s2-pagination-count"
+    title="Total2"
+  >
+    Total
+    2
+    
+  </span>
+</div>
+`;
+
+exports[`Pagination Tests should render locale text for { locale: 'en_US', page: '1 / page', count: 'Total2' } 1`] = `
+<div
+  class="antv-s2-pagination"
+>
+  <ul
+    class="ant-pagination mini"
+    unselectable="unselectable"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="Previous Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="Next Page"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        aria-label="Page Size"
+        class="ant-select ant-select-sm ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-search"
+          >
+            <input
+              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+              aria-autocomplete="list"
+              aria-controls="rc_select_TEST_OR_SSR_list"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Page Size"
+              aria-owns="rc_select_TEST_OR_SSR_list"
+              autocomplete="off"
+              class="ant-select-selection-search-input"
+              id="rc_select_TEST_OR_SSR"
+              readonly=""
+              role="combobox"
+              style="opacity: 0;"
+              type="search"
+              unselectable="on"
+              value=""
+            />
+          </span>
+          <span
+            class="ant-select-selection-item"
+            title="1 / page"
+          >
+            1 / page
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select: none;"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down ant-select-suffix"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </li>
+  </ul>
+  <span
+    class="antv-s2-pagination-count"
+    title="Total2"
+  >
+    Total
+    2
+    
+  </span>
+</div>
+`;
+
+exports[`Pagination Tests should render locale text for { locale: 'zh_CN', page: '1 条/页', count: '共计2条' } 1`] = `
+<div
+  class="antv-s2-pagination"
+>
+  <ul
+    class="ant-pagination mini"
+    unselectable="unselectable"
+  >
+    <li
+      aria-disabled="true"
+      class="ant-pagination-prev ant-pagination-disabled"
+      title="上一页"
+    >
+      <button
+        class="ant-pagination-item-link"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="left"
+          class="anticon anticon-left"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="left"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M724 218.3V141c0-6.7-7.7-10.4-12.9-6.3L260.3 486.8a31.86 31.86 0 000 50.3l450.8 352.1c5.3 4.1 12.9.4 12.9-6.3v-77.3c0-4.9-2.3-9.6-6.1-12.6l-360-281 360-281.1c3.8-3 6.1-7.7 6.1-12.6z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-1 ant-pagination-item-active"
+      tabindex="0"
+      title="1"
+    >
+      <a
+        rel="nofollow"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="ant-pagination-item ant-pagination-item-2"
+      tabindex="0"
+      title="2"
+    >
+      <a
+        rel="nofollow"
+      >
+        2
+      </a>
+    </li>
+    <li
+      aria-disabled="false"
+      class="ant-pagination-next"
+      tabindex="0"
+      title="下一页"
+    >
+      <button
+        class="ant-pagination-item-link"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-label="right"
+          class="anticon anticon-right"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            data-icon="right"
+            fill="currentColor"
+            focusable="false"
+            height="1em"
+            viewBox="64 64 896 896"
+            width="1em"
+          >
+            <path
+              d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+            />
+          </svg>
+        </span>
+      </button>
+    </li>
+    <li
+      class="ant-pagination-options"
+    >
+      <div
+        aria-label="页码"
+        class="ant-select ant-select-sm ant-pagination-options-size-changer ant-select-single ant-select-show-arrow"
+      >
+        <div
+          class="ant-select-selector"
+        >
+          <span
+            class="ant-select-selection-search"
+          >
+            <input
+              aria-activedescendant="rc_select_TEST_OR_SSR_list_0"
+              aria-autocomplete="list"
+              aria-controls="rc_select_TEST_OR_SSR_list"
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="页码"
+              aria-owns="rc_select_TEST_OR_SSR_list"
+              autocomplete="off"
+              class="ant-select-selection-search-input"
+              id="rc_select_TEST_OR_SSR"
+              readonly=""
+              role="combobox"
+              style="opacity: 0;"
+              type="search"
+              unselectable="on"
+              value=""
+            />
+          </span>
+          <span
+            class="ant-select-selection-item"
+            title="1 条/页"
+          >
+            1 条/页
+          </span>
+        </div>
+        <span
+          aria-hidden="true"
+          class="ant-select-arrow"
+          style="user-select: none;"
+          unselectable="on"
+        >
+          <span
+            aria-label="down"
+            class="anticon anticon-down ant-select-suffix"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="64 64 896 896"
+              width="1em"
+            >
+              <path
+                d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+              />
+            </svg>
+          </span>
+        </span>
+      </div>
+    </li>
+  </ul>
+  <span
+    class="antv-s2-pagination-count"
+    title="共计2条"
+  >
+    共计
+    2
+    条
+  </span>
+</div>
+`;

--- a/packages/s2-react/__tests__/spreadsheet/pagination-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/pagination-spec.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import { LangType, S2Options, setLang } from '@antv/s2';
+import * as mockDataConfig from '../data/simple-data.json';
+import { SheetComponent } from '../../src';
+import { getContainer } from '../util/helpers';
+import 'antd/dist/antd.min.css';
+
+const s2Options: S2Options = {
+  width: 600,
+  height: 200,
+  pagination: {
+    current: 1,
+    pageSize: 1,
+  },
+  hierarchyType: 'grid',
+};
+
+describe('Pagination Tests', () => {
+  let container: HTMLDivElement;
+  beforeEach(() => {
+    container = getContainer();
+  });
+
+  afterEach(() => {
+    container?.remove();
+  });
+
+  // https://github.com/antvis/S2/issues/1697
+  test.each([
+    {
+      locale: 'zh_CN',
+      page: '1 条/页',
+      count: '共计2条',
+    },
+    {
+      locale: 'en_US',
+      page: '1 / page',
+      count: 'Total2',
+    },
+  ] as Array<{ locale: LangType; page: string; count: string }>)(
+    'should render locale text for %o',
+    ({ locale, page, count }) => {
+      setLang(locale);
+
+      act(() => {
+        ReactDOM.render(
+          <SheetComponent
+            options={s2Options}
+            dataCfg={mockDataConfig as any}
+            showPagination
+          />,
+          container,
+        );
+      });
+
+      expect(document.querySelector('.antv-s2-pagination')).toMatchSnapshot();
+      expect(
+        document.querySelector('.ant-select-selection-item')?.innerHTML,
+      ).toEqual(page);
+      expect(
+        document.querySelector('.antv-s2-pagination-count')?.innerHTML,
+      ).toEqual(count);
+    },
+  );
+
+  test('should receive antd <Pagination/> component extra props', () => {
+    act(() => {
+      ReactDOM.render(
+        <SheetComponent
+          options={{
+            ...s2Options,
+            pagination: {
+              ...s2Options.pagination,
+              current: 2,
+              showSizeChanger: false,
+              showQuickJumper: true,
+              size: 'large',
+            },
+          }}
+          dataCfg={mockDataConfig as any}
+          showPagination
+        />,
+        container,
+      );
+    });
+
+    expect(document.querySelector('.antv-s2-pagination')).toMatchSnapshot();
+    expect(
+      document.querySelector('.ant-pagination-options-quick-jumper'),
+    ).toBeTruthy();
+    expect(
+      document.querySelector('.ant-pagination-options-size-changer'),
+    ).toBeFalsy();
+  });
+});

--- a/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import type { S2Options } from '@antv/s2';
-import * as mockDataConfig from 'tests/data/simple-data.json';
+import * as mockDataConfig from '../data/simple-data.json';
 import { SheetComponent } from '../../src';
 import { getContainer } from '../util/helpers';
 

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -33,7 +33,7 @@ export const s2Options: S2Options = {
   interaction: {
     enableCopy: true,
     // 防止 mac 触摸板横向滚动触发浏览器返回, 和移动端下拉刷新
-    overscrollBehavior: 'contain',
+    overscrollBehavior: 'none',
   },
   tooltip: {
     operation: {

--- a/packages/s2-react/src/components/pagination/index.tsx
+++ b/packages/s2-react/src/components/pagination/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Pagination as AntDPagination } from 'antd';
+import { Pagination as AntdPagination } from 'antd';
 import { isEmpty } from 'lodash';
-import { i18n, S2_PREFIX_CLS, type Pagination } from '@antv/s2';
+import { i18n, S2_PREFIX_CLS } from '@antv/s2';
+import type { SheetComponentsProps } from '../sheets/interface';
 
 export interface S2PaginationProps {
-  pagination: Pagination;
+  pagination: SheetComponentsProps['options']['pagination'];
   current: number;
   total: number;
   pageSize?: number;
@@ -36,21 +37,24 @@ export const S2Pagination: React.FC<S2PaginationProps> = ({
 
   return (
     <div className={PRE_CLASS}>
-      <AntDPagination
+      <AntdPagination
         defaultCurrent={1}
         current={current}
         total={total}
         pageSize={pageSize}
         showSizeChanger
+        size="small"
+        showQuickJumper={showQuickJumper}
+        {...pagination}
         onShowSizeChange={(current, size) => {
           onShowSizeChange(size);
           setPageSize(size);
+          pagination.onShowSizeChange?.(current, size);
         }}
-        size={'small'}
-        showQuickJumper={showQuickJumper}
-        onChange={(page) => {
+        onChange={(page, pageSize) => {
           onChange(page);
           setCurrent(page);
+          pagination.onChange?.(page, pageSize);
         }}
       />
       <span

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -1,9 +1,4 @@
-import {
-  getSafetyDataConfig,
-  type S2Options,
-  S2_PREFIX_CLS,
-  SpreadSheet,
-} from '@antv/s2';
+import { getSafetyDataConfig, S2_PREFIX_CLS, SpreadSheet } from '@antv/s2';
 import { Spin } from 'antd';
 import { get } from 'lodash';
 import React from 'react';
@@ -59,7 +54,7 @@ export const BaseSheet = React.forwardRef(
 
 BaseSheet.displayName = 'BaseSheet';
 BaseSheet.defaultProps = {
-  options: {} as S2Options,
+  options: {} as SheetComponentsProps['options'],
   adaptive: false,
   showPagination: false,
 };

--- a/packages/s2-react/src/components/sheets/index.tsx
+++ b/packages/s2-react/src/components/sheets/index.tsx
@@ -1,5 +1,9 @@
 import type { SpreadSheet } from '@antv/s2';
 import React from 'react';
+import zhCN from 'antd/es/locale/zh_CN';
+import enUS from 'antd/es/locale/en_US';
+import { getLang } from '@antv/s2';
+import { ConfigProvider } from 'antd';
 import { GridAnalysisSheet } from './grid-analysis-sheet';
 import type { SheetComponentsProps } from './interface';
 import { PivotSheet } from './pivot-sheet';
@@ -35,7 +39,13 @@ const Sheet = React.forwardRef(
       }
     }, [sheetType, sheetProps]);
 
-    return <React.StrictMode>{CurrentSheet}</React.StrictMode>;
+    const locale = getLang() === 'zh_CN' ? zhCN : enUS;
+
+    return (
+      <React.StrictMode>
+        <ConfigProvider locale={locale}>{CurrentSheet}</ConfigProvider>
+      </React.StrictMode>
+    );
   },
 );
 

--- a/packages/s2-react/src/components/sheets/interface.ts
+++ b/packages/s2-react/src/components/sheets/interface.ts
@@ -1,5 +1,6 @@
 import type { Node } from '@antv/s2';
 import type { BaseSheetComponentProps } from '@antv/s2-shared';
+import type { PaginationProps as AntdPaginationProps } from 'antd';
 import type { DrillDownProps } from '../drill-down';
 import type { HeaderCfgProps } from '../header';
 
@@ -26,5 +27,6 @@ export interface PartDrillDown {
 
 export type SheetComponentsProps = BaseSheetComponentProps<
   PartDrillDown,
-  HeaderCfgProps
+  HeaderCfgProps,
+  AntdPaginationProps
 >;

--- a/packages/s2-react/src/utils/options.ts
+++ b/packages/s2-react/src/utils/options.ts
@@ -2,7 +2,9 @@ import type { S2Options } from '@antv/s2';
 import { getBaseSheetComponentOptions } from '@antv/s2-shared';
 import type React from 'react';
 import { RENDER_TOOLTIP_OPTION } from '../common';
+import type { SheetComponentsProps } from '../components';
 
 export const getSheetComponentOptions = (
   ...options: Partial<S2Options<React.ReactNode>>[]
-): S2Options => getBaseSheetComponentOptions(RENDER_TOOLTIP_OPTION, ...options);
+): SheetComponentsProps['options'] =>
+  getBaseSheetComponentOptions(RENDER_TOOLTIP_OPTION, ...options);

--- a/packages/s2-shared/src/interface.ts
+++ b/packages/s2-shared/src/interface.ts
@@ -41,15 +41,16 @@ export type SheetUpdateCallback = (params: S2RenderOptions) => S2RenderOptions;
 export interface BaseSheetComponentProps<
   PartialDrillDown = unknown,
   Header = unknown,
+  Pagination = unknown,
 > {
   sheetType?: SheetType;
   spreadsheet?: (
     container: S2MountContainer,
     dataCfg: S2DataConfig,
-    options: S2Options,
+    options: S2Options<Element | string, Pagination>,
   ) => SpreadSheet;
   dataCfg: S2DataConfig;
-  options?: S2Options;
+  options?: S2Options<Element | string, Pagination>;
   loading?: boolean;
   partDrillDown?: PartialDrillDown;
   adaptive?: Adaptive;
@@ -140,6 +141,7 @@ export interface BaseSheetComponentProps<
   }) => void;
   /** @deprecated 已废弃, 请使用 S2Event.GLOBAL_SCROLL 代替 */
   onLayoutCellScroll?: (position: CellScrollPosition) => void;
+  onLayoutCollapseRows?: (data: CollapsedRowsType) => void;
   onLayoutAfterCollapseRows?: (data: CollapsedRowsType) => void;
   onCollapseRowsAll?: (hierarchyCollapse: boolean) => void;
   onLayoutColsExpanded?: (node: Node) => void;
@@ -177,12 +179,16 @@ export interface BaseSheetComponentProps<
   onKeyBoardUp?: (event: KeyboardEvent) => void;
   onCopied?: (copyData: string) => void;
   onActionIconHover?: (event: GEvent) => void;
+  onActionIconHoverOff?: (event: GEvent) => void;
   onActionIconClick?: (event: GEvent) => void;
   onContextMenu?: (event: GEvent) => void;
   onClick?: (event: GEvent) => void;
+  onHover?: (event: GEvent) => void;
   onDoubleClick?: (event: GEvent) => void;
   onMouseHover?: (event: GEvent) => void;
   onMouseUp?: (event: MouseEvent) => void;
+  onMouseDown?: (event: MouseEvent) => void;
+  onMouseMove?: (event: MouseEvent) => void;
   onSelected?: (cells: DataCell[]) => void;
   onReset?: (event: KeyboardEvent) => void;
   onLinkFieldJump?: (data: { key: string; record: Data }) => void;

--- a/packages/s2-vue/src/interface.ts
+++ b/packages/s2-vue/src/interface.ts
@@ -4,6 +4,7 @@ import type {
   PartDrillDown,
 } from '@antv/s2-shared';
 import type { PropType } from 'vue';
+import type { PaginationProps } from 'ant-design-vue';
 import type { UnionToIntersection } from '@vue/shared';
 
 // 这个是vue中的类型，但是vue没有export
@@ -77,11 +78,14 @@ type GetInitEmits<T> = {
 /*                                    组件类型                                    */
 /* -------------------------------------------------------------------------- */
 
+export type SheetComponentProps = BaseSheetComponentProps<
+  PartDrillDown,
+  unknown,
+  PaginationProps
+>;
 export type BaseSheetInitPropKeys = GetPropKeys<BaseSheetComponentProps>;
 export type BaseSheetInitEmitKeys = GetEmitKeys<BaseSheetComponentProps>;
-export type BaseSheetInitProps = GetInitProps<
-  BaseSheetComponentProps<PartDrillDown>
->;
+export type BaseSheetInitProps = GetInitProps<SheetComponentProps>;
 export type BaseSheetInitEmits = GetInitEmits<BaseSheetComponentProps>;
 export type BaseDrillDownProps = GetInitProps<BaseDrillDownComponentProps>;
 export type BaseDrillDownEmitKeys = GetEmitKeys<BaseDrillDownComponentProps>;

--- a/packages/s2-vue/src/utils/initPropAndEmits.ts
+++ b/packages/s2-vue/src/utils/initPropAndEmits.ts
@@ -1,17 +1,13 @@
-import type { S2DataConfig, S2Options, ThemeCfg } from '@antv/s2';
+import type { S2DataConfig, ThemeCfg } from '@antv/s2';
 import { i18n } from '@antv/s2';
-import type {
-  Adaptive,
-  BaseSheetComponentProps,
-  BaseDataSet,
-  SheetType,
-} from '@antv/s2-shared';
+import type { Adaptive, BaseDataSet, SheetType } from '@antv/s2-shared';
 import type { ExtractPropTypes, PropType } from 'vue';
 import type {
   BaseDrillDownEmitKeys,
   BaseDrillDownEmits,
   BaseSheetInitEmitKeys,
   BaseSheetInitEmits,
+  SheetComponentProps,
 } from '../interface';
 
 export const initBaseSheetProps = () => ({
@@ -19,10 +15,8 @@ export const initBaseSheetProps = () => ({
   dataCfg: Object as PropType<S2DataConfig>,
   themeCfg: Object as PropType<ThemeCfg>,
   showPagination: {
-    type: [Object, Boolean] as PropType<
-      BaseSheetComponentProps['showPagination']
-    >,
-    default: false as BaseSheetComponentProps['showPagination'],
+    type: [Object, Boolean] as PropType<SheetComponentProps['showPagination']>,
+    default: false as SheetComponentProps['showPagination'],
   },
   loading: Boolean,
   // TODO: 待后续完善
@@ -30,17 +24,15 @@ export const initBaseSheetProps = () => ({
   header: Object,
 
   options: {
-    type: Object as PropType<S2Options>,
-    default: {} as S2Options,
+    type: Object as PropType<SheetComponentProps['options']>,
+    default: {} as SheetComponentProps['options'],
   },
   adaptive: {
     type: [Object, Boolean] as PropType<Adaptive>,
     default: false as Adaptive,
   },
-  onSpreadsheet: Function as PropType<BaseSheetComponentProps['spreadsheet']>,
-  onGetSpreadSheet: Function as PropType<
-    BaseSheetComponentProps['getSpreadSheet']
-  >,
+  onSpreadsheet: Function as PropType<SheetComponentProps['spreadsheet']>,
+  onGetSpreadSheet: Function as PropType<SheetComponentProps['getSpreadSheet']>,
 });
 
 export const initDrillDownProps = () => ({
@@ -82,18 +74,23 @@ export const initBaseSheetEmits = () => {
   const keys: Array<BaseSheetInitEmitKeys> = [
     'spreadsheet',
     'getSpreadSheet',
+
     // ============== Row Cell ====================
     'rowCellHover',
     'rowCellClick',
     'rowCellDoubleClick',
+    'rowCellContextMenu',
     'rowCellMouseDown',
     'rowCellMouseUp',
     'rowCellMouseMove',
     'rowCellCollapseTreeRows',
+    'rowCellScroll',
+
     // ============== Col Cell ====================
     'colCellHover',
     'colCellClick',
     'colCellDoubleClick',
+    'colCellContextMenu',
     'colCellMouseDown',
     'colCellMouseUp',
     'colCellMouseMove',
@@ -102,6 +99,7 @@ export const initBaseSheetEmits = () => {
     'dataCellHover',
     'dataCellClick',
     'dataCellDoubleClick',
+    'dataCellContextMenu',
     'dataCellMouseDown',
     'dataCellMouseUp',
     'dataCellMouseMove',
@@ -113,6 +111,7 @@ export const initBaseSheetEmits = () => {
     'cornerCellHover',
     'cornerCellClick',
     'cornerCellDoubleClick',
+    'cornerCellContextMenu',
     'cornerCellMouseDown',
     'cornerCellMouseUp',
     'cornerCellMouseMove',
@@ -121,6 +120,7 @@ export const initBaseSheetEmits = () => {
     'mergedCellsHover',
     'mergedCellsClick',
     'mergedCellsDoubleClick',
+    'mergedCellsContextMenu',
     'mergedCellsMouseDown',
     'mergedCellsMouseUp',
     'mergedCellsMouseMove',
@@ -137,6 +137,7 @@ export const initBaseSheetEmits = () => {
     'layoutAfterHeaderLayout',
     'layoutPagination',
     'layoutCellScroll',
+    'layoutCollapseRows',
     'layoutAfterCollapseRows',
     'collapseRowsAll',
     'layoutColsExpanded',
@@ -162,16 +163,19 @@ export const initBaseSheetEmits = () => {
     'keyBoardUp',
     'copied',
     'actionIconHover',
-    'contextMenu',
     'actionIconClick',
+    'contextMenu',
     'mouseHover',
     'mouseUp',
+    'mouseMove',
+    'mouseDown',
     'selected',
     'reset',
     'linkFieldJump',
     'click',
     'doubleClick',
     'scroll',
+    'hover',
   ];
   return keys as unknown as BaseSheetInitEmits;
 };

--- a/s2-site/docs/manual/basic/analysis/pagination.zh.md
+++ b/s2-site/docs/manual/basic/analysis/pagination.zh.md
@@ -9,13 +9,13 @@ S2 内置提供了分页能力。本质上是前端分页，点击下一页滚�
 
 ### 快速上手
 
-首先需要在 `S2Options` 中配置 `pagination` 属性
+首先需要在 `s2Options` 中配置 `pagination` 属性
 
 `markdown:docs/common/pagination.zh.md`
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/LVw2QOvjgW/b1563a7b-4070-4d61-a18b-6558e2c5b27b.png" width="600"  alt="preview" />
 
-如果基于 `@antv/s2-core` 开发，需要自行引入或实现分页组件，`core` 层仅提供分页能力，参考示例
+如果基于 `@antv/s2-core` 开发，需要**自行引入**或**实现分页组件**，`core` 层仅提供分页能力，参考示例
 
 * [React](https://github.com/antvis/S2/blob/master/packages/s2-react/src/components/pagination/index.tsx)
 * [Vue 3.0](https://github.com/antvis/S2/blob/master/packages/s2-vue/src/components/pagination/index.vue)
@@ -24,18 +24,41 @@ S2 内置提供了分页能力。本质上是前端分页，点击下一页滚�
 
 ### SpreadsheetProps
 
+```tsx
+<SheetComponent showPagination />
+```
+
 | 参数 | 说明 | 类型 | 默认值 | 必选 |
 | :-- | :-- | :-- | :-- | :-: | --- | --- | --- |
 | showPagination | 是否显示默认分页<br>（只有在 `options` 配置过 `pagination` 属性才会生效） | `boolean` \| \{ <br>onShowSizeChange?: (pageSize: number) => void,<br>onChange?: (current: number) => void <br>} | `false` |  |
 
 ### React 版
 
-> 使用的是 [Ant Design](https://ant.design/components/pagination-cn/) 分页组件，透传 `onChange` 和 `onShowSizeChange` 回调。需要修改样式直接写 CSS 覆盖即可。
+> 使用的是 [Ant Design](https://ant.design/components/pagination-cn/) Pagination 分页组件，支持 [透传 API](https://ant.design/components/pagination-cn/#API)。需要修改样式直接通过 CSS 覆盖即可。
+
+```tsx
+const s2Options = {
+  // https://ant.design/components/pagination-cn/#API
+  pagination: {}
+}
+
+<SheetComponent options={s2Options} />
+```
 
 <playground path='react-component/pagination/demo/pivot.tsx' rid='container'></playground>
 
 ### Vue 3.0 版
 
-> 使用的是 [Ant Design Vue](https://antdv.com/components/pagination) 分页组件，透传 `change` 和 `showSizeChange` 回调。需要修改样式直接写 CSS 覆盖即可。
+> 使用的是 [Ant Design Vue](https://antdv.com/components/pagination) 分页组件，支持 [透传 API](https://antdv.com/components/pagination#API)。需要修改样式直接通过 CSS 覆盖即可。
+
+```tsx
+const s2Options = {
+  // https://antdv.com/components/pagination#API
+  pagination: {}
+}
+
+<SheetComponent :options={s2Options} />
+
+```
 
 [Demo 地址](https://codesandbox.io/embed/nice-dijkstra-hzycy6?fontsize=14&hidenavigation=1&theme=dark)

--- a/s2-site/examples/react-component/pagination/demo/pivot.tsx
+++ b/s2-site/examples/react-component/pagination/demo/pivot.tsx
@@ -12,17 +12,14 @@ fetch(
       width: 600,
       height: 480,
       pagination: {
+        // API: https://ant.design/components/pagination-cn/#API
         pageSize: 4,
         current: 1,
       },
     };
 
     ReactDOM.render(
-      <SheetComponent
-        dataCfg={dataCfg}
-        options={s2Options}
-        showPagination={true}
-      />,
+      <SheetComponent dataCfg={dataCfg} options={s2Options} showPagination />,
       document.getElementById('container'),
     );
   });


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1697 

### 📝 Description

1. 组件层增加 LocaleProvider 的适配, 在配置 S2 国际化的同时, 也对 antd 的组件生效
2. 透传 antd 分页组件 props
3. 补充 vue 组件的 emit 定义

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/185585590-3b4e7ab3-1191-4e3e-b8d1-38979a03d44d.png) | ![image](https://user-images.githubusercontent.com/21015895/185585450-a0360434-bfac-4f88-ac80-5d3b12af0206.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
