### PR TITLE
fix: text居中居右时link绘制错位

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/row-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/row-cell-spec.ts
@@ -1,4 +1,6 @@
+import _ from 'lodash';
 import { createPivotSheet } from 'tests/util/helpers';
+import type { RowCell } from '@antv/s2';
 import type { SpreadSheet } from '@/sheet-type';
 import type { TextAlign } from '@/common';
 
@@ -32,13 +34,13 @@ describe('Row Cell Tests', () => {
         });
         s2.render();
 
-        const provinceCell = s2.facet.rowHeader.getChildByIndex(0);
-        const { minX, maxX } = provinceCell.linkFieldShape.getBBox();
+        const provinceCell = s2.facet.rowHeader.getChildByIndex(0) as RowCell;
+        const { minX, maxX } = (provinceCell as any).linkFieldShape.getBBox();
 
         // 宽度相当
         const linkLength = maxX - minX;
         expect(
-          Math.abs(linkLength - provinceCell.actualTextWidth),
+          Math.abs(linkLength - _.get(provinceCell, 'actualTextWidth')),
         ).toBeLessThanOrEqual(2);
 
         // link shape 的中点坐标与 text 中点对齐

--- a/packages/s2-core/__tests__/unit/cell/row-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/row-cell-spec.ts
@@ -1,0 +1,50 @@
+import { createPivotSheet } from 'tests/util/helpers';
+import type { SpreadSheet } from '@/sheet-type';
+import type { TextAlign } from '@/common';
+
+describe('Row Cell Tests', () => {
+  describe('Link Shape Tests', () => {
+    let s2: SpreadSheet;
+
+    beforeEach(() => {
+      s2 = createPivotSheet({});
+      s2.render();
+    });
+
+    test.each([
+      ['left', 20],
+      ['center', 77],
+      ['right', 130],
+    ])(
+      'should align link shape with text',
+      (textAlign: TextAlign, textCenterX: number) => {
+        s2.setOptions({
+          interaction: {
+            linkFields: ['province'],
+          },
+        });
+        s2.setTheme({
+          rowCell: {
+            bolderText: {
+              textAlign,
+            },
+          },
+        });
+        s2.render();
+
+        const provinceCell = s2.facet.rowHeader.getChildByIndex(0);
+        const { minX, maxX } = provinceCell.linkFieldShape.getBBox();
+
+        // 宽度相当
+        const linkLength = maxX - minX;
+        expect(
+          Math.abs(linkLength - provinceCell.actualTextWidth),
+        ).toBeLessThanOrEqual(2);
+
+        // link shape 的中点坐标与 text 中点对齐
+        const linkCenterX = minX + linkLength / 2;
+        expect(linkCenterX).toEqual(textCenterX);
+      },
+    );
+  });
+});

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -233,13 +233,23 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     const device = this.spreadsheet.options.style.device;
     // 配置了链接跳转
     if (!isMobile(device)) {
-      const { minX, maxY }: BBox = this.textShape.getBBox();
+      const textStyle = this.getTextStyle();
+      const position = this.getTextPosition();
+
+      let startX = position.x; // 默认居左，其他align方式需要调整
+      if (textStyle.textAlign === 'center') {
+        startX -= this.actualTextWidth / 2;
+      } else if (textStyle.textAlign === 'right') {
+        startX -= this.actualTextWidth;
+      }
+
+      const { maxY }: BBox = this.textShape.getBBox();
       this.linkFieldShape = renderLine(
         this,
         {
-          x1: minX,
+          x1: startX,
           y1: maxY + 1,
-          x2: minX + this.actualTextWidth, // 不用 bbox 的 maxX，因为 g-base 文字宽度预估偏差较大
+          x2: startX + this.actualTextWidth, // 不用 bbox 的 maxX，因为 g-base 文字宽度预估偏差较大
           y2: maxY + 1,
         },
         { stroke: linkFillColor, lineWidth: 1 },


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
#### 背景
#1562 中修复了 link 无法对齐的问题，但未测试文字 `居中`、`居右` 的情况。

#### 原因
因为底层 g-base 计算文字 bbox 已经有误，所以使用它提供的 minX 作为 linkShape 的开始点并不正确
例如在居中的情况下，文字整体是在 bbox 的中间，左右两侧各有空隙。

#### 方案
使用 s2 自己计算的 textPosition 进行定位

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-08-24 at 15 14 02](https://user-images.githubusercontent.com/6716092/186354806-40bcb309-feee-4940-bc08-0e2b360b2ad7.png)      |   ![CleanShot 2022-08-24 at 15 13 16](https://user-images.githubusercontent.com/6716092/186354640-85910bbc-01e8-4301-9669-4039c0f86e11.png)    |
|   ![CleanShot 2022-08-24 at 15 14 31](https://user-images.githubusercontent.com/6716092/186354886-692c111e-471a-4788-850c-b4a916804dd1.png)     |  ![CleanShot 2022-08-24 at 15 12 44](https://user-images.githubusercontent.com/6716092/186354544-5d8cae31-8eb9-41d4-945b-da8840d69725.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
