### PR TITLE
fix(types): 修复严格模式下 S2Options 类型报错

### DIFF
--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -206,14 +206,14 @@ export interface Style {
   device?: 'pc' | 'mobile'; // 设备，pc || mobile
 }
 
-export type Pagination<T = unknown> = {
+export interface Pagination {
   // 每页数量
   pageSize: number;
   // 当前页
   current: number; // 从 1 开始
   // 数据总条数
   total?: number;
-} & T;
+}
 
 export interface CustomSVGIcon {
   // icon 类型名

--- a/packages/s2-core/src/common/interface/interaction.ts
+++ b/packages/s2-core/src/common/interface/interaction.ts
@@ -41,6 +41,7 @@ export type OnUpdateCells = (
   root: RootInteraction,
   defaultOnUpdateCells: () => void,
 ) => void;
+
 export interface InteractionStateInfo {
   // current state name
   stateName?: InteractionStateName;

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -27,9 +27,9 @@ import type {
 } from './basic';
 import type { Conditions } from './condition';
 import type { InteractionOptions } from './interaction';
-import type { Tooltip } from './tooltip';
+import type { Tooltip, TooltipContentType } from './tooltip';
 
-export interface S2BasicOptions<T = Element | string, P = unknown> {
+export interface S2BasicOptions<T = TooltipContentType, P = Pagination> {
   // canvas's width
   width?: number;
   // canvas's height
@@ -47,7 +47,7 @@ export interface S2BasicOptions<T = Element | string, P = unknown> {
   // interaction configs
   interaction?: InteractionOptions;
   // pagination config
-  pagination?: Pagination<P>;
+  pagination?: P;
   // freeze row header
   frozenRowHeader?: boolean;
   // show series Number
@@ -119,7 +119,7 @@ export interface S2TableSheetOptions {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface S2PivotSheetOptions {}
 
-export interface S2Options<T = Element | string, P = unknown>
+export interface S2Options<T = TooltipContentType, P = Pagination>
   extends S2BasicOptions<T, P>,
     S2TableSheetOptions,
     S2PivotSheetOptions {

--- a/packages/s2-react/__tests__/data/grid-analysis-data.ts
+++ b/packages/s2-react/__tests__/data/grid-analysis-data.ts
@@ -1,4 +1,7 @@
-export const mockGridAnalysisDataCfg = {
+import { S2DataConfig } from '@antv/s2';
+import { SheetComponentOptions } from '../../src';
+
+export const mockGridAnalysisDataCfg: S2DataConfig = {
   fields: {
     rows: ['level'],
     columns: ['group'],
@@ -118,14 +121,4 @@ export const mockGridAnalysisDataCfg = {
       },
     },
   ],
-};
-export const mockTabularOptions = {
-  width: 800,
-  height: 600,
-  style: {
-    cellCfg: {
-      width: 400,
-      height: 300,
-    },
-  },
 };

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -1,10 +1,6 @@
-import {
-  EXTRA_COLUMN_FIELD,
-  isUpDataValue,
-  type S2DataConfig,
-  type S2Options,
-} from '@antv/s2';
+import { EXTRA_COLUMN_FIELD, isUpDataValue, type S2DataConfig } from '@antv/s2';
 import { isNil } from 'lodash';
+import { SheetComponentOptions } from '../../src';
 
 const getKPIMockData = () => {
   return {
@@ -380,7 +376,7 @@ export const StrategySheetDataConfig: S2DataConfig = {
   },
 };
 
-export const StrategyOptions: S2Options = {
+export const StrategyOptions: SheetComponentOptions = {
   width: 800,
   height: 800,
   cornerText: '指标',

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -96,4 +96,5 @@ export const mockGridAnalysisOptions: SheetComponentOptions = {
   },
 };
 
-export const defaultOptions = getBaseSheetComponentOptions(s2Options);
+export const defaultOptions =
+  getBaseSheetComponentOptions<SheetComponentOptions>(s2Options);

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -1,5 +1,5 @@
 import { isUpDataValue } from '@antv/s2';
-import type { S2DataConfig, S2Options } from '@antv/s2';
+import type { S2DataConfig } from '@antv/s2';
 import { getBaseSheetComponentOptions } from '@antv/s2-shared';
 import type { SliderSingleProps } from 'antd';
 import {
@@ -8,6 +8,7 @@ import {
   meta,
   fields,
 } from '../__tests__/data/mock-dataset.json';
+import { SheetComponentOptions } from '../src/components';
 
 export const tableSheetDataCfg: S2DataConfig = {
   data,
@@ -25,7 +26,7 @@ export const pivotSheetDataCfg: S2DataConfig = {
   fields,
 };
 
-export const s2Options: S2Options = {
+export const s2Options: SheetComponentOptions = {
   debug: true,
   width: 600,
   height: 400,
@@ -63,7 +64,7 @@ export const sliderOptions: SliderSingleProps = {
   },
 };
 
-export const mockGridAnalysisOptions: S2Options = {
+export const mockGridAnalysisOptions: SheetComponentOptions = {
   width: 1600,
   height: 600,
   style: {
@@ -95,5 +96,4 @@ export const mockGridAnalysisOptions: S2Options = {
   },
 };
 
-export const defaultOptions: S2Options =
-  getBaseSheetComponentOptions(s2Options);
+export const defaultOptions = getBaseSheetComponentOptions(s2Options);

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -44,7 +44,7 @@ import reactPkg from '../package.json';
 import type {
   PartDrillDown,
   PartDrillDownInfo,
-  SheetComponentsProps,
+  SheetComponentOptions,
 } from '../src';
 import { SheetComponent } from '../src';
 import { customTreeFields } from '../__tests__/data/custom-tree-fields';
@@ -284,7 +284,7 @@ function MainLayout() {
 
   //  ================== Config ========================
 
-  const mergedOptions: SheetComponentsProps['options'] = customMerge(
+  const mergedOptions: SheetComponentOptions = customMerge(
     {},
     {
       pagination: showPagination && {

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -7,7 +7,6 @@ import {
   type HeaderActionIconProps,
   Node,
   type S2DataConfig,
-  type S2Options,
   SpreadSheet,
   type TargetCellInfo,
   type ThemeCfg,
@@ -157,7 +156,7 @@ function MainLayout() {
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
-    React.useState<S2Options<React.ReactNode>>(defaultOptions);
+    React.useState<SheetComponentOptions>(defaultOptions);
   const [dataCfg, setDataCfg] = React.useState<S2DataConfig>(pivotSheetDataCfg);
   const [strategyDataCfg, setStrategyDataCfg] = React.useState<S2DataConfig>(
     StrategySheetDataConfig,
@@ -169,7 +168,7 @@ function MainLayout() {
   const scrollTimer = React.useRef<NodeJS.Timer>();
 
   //  ================== Callback ========================
-  const updateOptions = (newOptions: Partial<S2Options<React.ReactNode>>) => {
+  const updateOptions = (newOptions: Partial<SheetComponentOptions>) => {
     setOptions(customMerge(options, newOptions));
   };
 

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -41,7 +41,11 @@ import React from 'react';
 import { ChromePicker } from 'react-color';
 import ReactDOM from 'react-dom';
 import reactPkg from '../package.json';
-import type { PartDrillDown, PartDrillDownInfo } from '../src';
+import type {
+  PartDrillDown,
+  PartDrillDownInfo,
+  SheetComponentsProps,
+} from '../src';
 import { SheetComponent } from '../src';
 import { customTreeFields } from '../__tests__/data/custom-tree-fields';
 import { dataCustomTrees } from '../__tests__/data/data-custom-trees';
@@ -153,9 +157,8 @@ function MainLayout() {
   const [showCustomTooltip, setShowCustomTooltip] = React.useState(false);
   const [adaptive, setAdaptive] = React.useState<Adaptive>(false);
   const [options, setOptions] =
-    React.useState<Partial<S2Options<React.ReactNode>>>(defaultOptions);
-  const [dataCfg, setDataCfg] =
-    React.useState<Partial<S2DataConfig>>(pivotSheetDataCfg);
+    React.useState<S2Options<React.ReactNode>>(defaultOptions);
+  const [dataCfg, setDataCfg] = React.useState<S2DataConfig>(pivotSheetDataCfg);
   const [strategyDataCfg, setStrategyDataCfg] = React.useState<S2DataConfig>(
     StrategySheetDataConfig,
   );
@@ -281,7 +284,7 @@ function MainLayout() {
 
   //  ================== Config ========================
 
-  const mergedOptions: S2Options<React.ReactNode> = customMerge(
+  const mergedOptions: SheetComponentsProps['options'] = customMerge(
     {},
     {
       pagination: showPagination && {

--- a/packages/s2-react/playground/resize.tsx
+++ b/packages/s2-react/playground/resize.tsx
@@ -1,16 +1,12 @@
-import {
-  customMerge,
-  type ResizeActiveOptions,
-  type S2Options,
-  type ThemeCfg,
-  ResizeType,
-} from '@antv/s2';
+import { customMerge, type ThemeCfg, ResizeType } from '@antv/s2';
 import { Checkbox, Switch } from 'antd';
-import React, { type FC } from 'react';
+import { CheckboxValueType } from 'antd/lib/checkbox/Group';
+import React from 'react';
+import { SheetComponentOptions } from '../src/components';
 
 const RESIZE_CONFIG: Array<{
   label: string;
-  value: keyof ResizeActiveOptions;
+  value: string;
 }> = [
   { label: '角头热区', value: 'cornerCellHorizontal' },
   { label: '行头热区', value: 'rowCellVertical' },
@@ -18,9 +14,11 @@ const RESIZE_CONFIG: Array<{
   { label: '列头垂直方向resize热区', value: 'colCellVertical' },
 ];
 
-export const ResizeConfig: FC<{
+export const ResizeConfig: React.FC<{
   setThemeCfg: (cb: (theme: ThemeCfg) => ThemeCfg) => void;
-  setOptions: (cb: (prev: S2Options) => S2Options) => void;
+  setOptions: (
+    cb: (prev: SheetComponentOptions) => SheetComponentOptions,
+  ) => void;
 }> = ({ setThemeCfg, setOptions }) => {
   const [showResizeArea, setShowResizeArea] = React.useState(false);
   const [rowResizeAffectCurrent, setRowResizeAffectCurrent] =
@@ -48,18 +46,18 @@ export const ResizeConfig: FC<{
     setOptions((prev) => customMerge({}, prev, opts));
   };
 
-  const onResizeActiveChange = (checkedAreas: string[]) => {
+  const onResizeActiveChange = (checkedAreas: CheckboxValueType[]) => {
     const resize = RESIZE_CONFIG.reduce((cfg, item) => {
       const type = item.value;
       cfg[type] = checkedAreas.includes(type);
       return cfg;
     }, {});
 
-    const updatedOptions = {
+    const updatedOptions: SheetComponentOptions = {
       interaction: {
         resize,
       },
-    } as S2Options;
+    };
 
     setOptions((prev) => customMerge({}, prev, updatedOptions));
   };

--- a/packages/s2-react/src/components/header/index.tsx
+++ b/packages/s2-react/src/components/header/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { PageHeader, type PageHeaderProps } from 'antd';
 import cx from 'classnames';
-import type { S2DataConfig, S2Options, SpreadSheet } from '@antv/s2';
+import type { S2DataConfig, SpreadSheet } from '@antv/s2';
 import { Export, type ExportCfgProps } from '../export';
 import { AdvancedSort, type AdvancedSortCfgProps } from '../advanced-sort';
 import { type SwitcherCfgProps, SwitcherHeader } from '../switcher/header';
 import './index.less';
+import type { SheetComponentOptions } from '../sheets/interface';
 
 export interface HeaderCfgProps extends PageHeaderProps {
   width?: React.CSSProperties['width'];
@@ -17,7 +18,7 @@ export interface HeaderCfgProps extends PageHeaderProps {
 
 export interface HeaderProps extends HeaderCfgProps {
   dataCfg?: S2DataConfig;
-  options?: S2Options;
+  options?: SheetComponentOptions;
   sheet: SpreadSheet;
 }
 

--- a/packages/s2-react/src/components/sheets/interface.ts
+++ b/packages/s2-react/src/components/sheets/interface.ts
@@ -1,6 +1,8 @@
-import type { Node } from '@antv/s2';
+import type { Pagination } from '@antv/s2';
+import type { Node, S2Options } from '@antv/s2';
 import type { BaseSheetComponentProps } from '@antv/s2-shared';
 import type { PaginationProps as AntdPaginationProps } from 'antd';
+import type { ReactNode } from 'react';
 import type { DrillDownProps } from '../drill-down';
 import type { HeaderCfgProps } from '../header';
 
@@ -25,8 +27,13 @@ export interface PartDrillDown {
   displayCondition?: (meta: Node) => boolean;
 }
 
+export type SheetComponentOptions = S2Options<
+  ReactNode,
+  Pagination & AntdPaginationProps
+>;
+
 export type SheetComponentsProps = BaseSheetComponentProps<
   PartDrillDown,
   HeaderCfgProps,
-  AntdPaginationProps
+  SheetComponentOptions
 >;

--- a/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/pivot-sheet/index.tsx
@@ -10,7 +10,7 @@ import {
 import { BaseSheet } from '../base-sheet';
 import { usePivotSheetUpdate } from '../../../hooks';
 import { DrillDown } from '../../drill-down';
-import type { SheetComponentsProps } from '../interface';
+import type { SheetComponentOptions, SheetComponentsProps } from '../interface';
 
 export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
   (props) => {
@@ -49,8 +49,10 @@ export const PivotSheet: React.FC<SheetComponentsProps> = React.memo(
 
     /** 基于 props.options 来构造新的 options 传递给 base-sheet */
     const options = React.useMemo(() => {
-      return buildDrillDownOptions(pivotOptions, partDrillDown, (params) =>
-        onDrillDownIconClick.current(params),
+      return buildDrillDownOptions<SheetComponentOptions>(
+        pivotOptions,
+        partDrillDown,
+        (params) => onDrillDownIconClick.current(params),
       );
     }, [pivotOptions, partDrillDown, onDrillDownIconClick]);
 

--- a/packages/s2-react/src/components/switcher/header.tsx
+++ b/packages/s2-react/src/components/switcher/header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import type { S2DataConfig, S2Options, SpreadSheet } from '@antv/s2';
+import type { S2DataConfig, SpreadSheet } from '@antv/s2';
 import { useUpdateEffect } from 'ahooks';
+import type { SheetComponentOptions } from '../sheets/interface';
 import {
   generateSheetConfig,
   generateSwitcherFields,
@@ -8,7 +9,7 @@ import {
   getSheetType,
 } from './headerUtil';
 import type { SwitcherResult } from './interface';
-import { Switcher, type SwitcherProps } from '.';
+import { Switcher, type SwitcherProps } from './';
 import './index.less';
 
 type SwitcherBasicCfg = Pick<
@@ -29,7 +30,7 @@ export interface SwitcherCfgProps extends SwitcherBasicCfg {
 export interface SwitcherHeaderProps extends SwitcherBasicCfg {
   sheet: SpreadSheet;
   dataCfg: S2DataConfig;
-  options: S2Options;
+  options: SheetComponentOptions;
 }
 
 export const SwitcherHeader: React.FC<SwitcherHeaderProps> = ({

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -3,7 +3,10 @@ import type { S2DataConfig, S2Options, ThemeCfg } from '@antv/s2';
 import { useUpdate, useUpdateEffect } from 'ahooks';
 import { identity } from 'lodash';
 import React from 'react';
-import type { SheetComponentsProps } from '../components';
+import type {
+  SheetComponentOptions,
+  SheetComponentsProps,
+} from '../components';
 import { getSheetComponentOptions } from '../utils';
 import { useEvents } from './useEvents';
 import { useLoading } from './useLoading';
@@ -25,11 +28,9 @@ export function useSpreadSheet(props: SheetComponentsProps) {
     onSheetUpdate = identity,
   } = props;
   /** 保存重渲 effect 的 deps */
-  const updatePrevDepsRef = React.useRef<[S2DataConfig, S2Options, ThemeCfg]>([
-    dataCfg,
-    options,
-    themeCfg,
-  ]);
+  const updatePrevDepsRef = React.useRef<
+    [S2DataConfig, SheetComponentOptions, ThemeCfg]
+  >([dataCfg, options, themeCfg]);
 
   const { loading, setLoading } = useLoading(s2Ref.current, props.loading);
   const pagination = usePagination(s2Ref.current, props);
@@ -43,9 +44,9 @@ export function useSpreadSheet(props: SheetComponentsProps) {
         return customSpreadSheet(container, dataCfg, s2Options);
       }
       if (sheetType === 'table') {
-        return new TableSheet(container, dataCfg, s2Options);
+        return new TableSheet(container, dataCfg, s2Options as S2Options);
       }
-      return new PivotSheet(container, dataCfg, s2Options);
+      return new PivotSheet(container, dataCfg, s2Options as S2Options);
     },
     [sheetType, options, dataCfg, customSpreadSheet],
   );
@@ -100,7 +101,7 @@ export function useSpreadSheet(props: SheetComponentsProps) {
         reloadData = true;
         s2Ref.current?.setDataCfg(dataCfg);
       }
-      s2Ref.current?.setOptions(options);
+      s2Ref.current?.setOptions(options as S2Options);
       s2Ref.current?.changeSheetSize(options.width, options.height);
     }
 

--- a/packages/s2-react/src/utils/options.ts
+++ b/packages/s2-react/src/utils/options.ts
@@ -1,10 +1,11 @@
-import type { S2Options } from '@antv/s2';
 import { getBaseSheetComponentOptions } from '@antv/s2-shared';
-import type React from 'react';
 import { RENDER_TOOLTIP_OPTION } from '../common';
-import type { SheetComponentsProps } from '../components';
+import type { SheetComponentOptions } from '../components';
 
 export const getSheetComponentOptions = (
-  ...options: Partial<S2Options<React.ReactNode>>[]
-): SheetComponentsProps['options'] =>
-  getBaseSheetComponentOptions(RENDER_TOOLTIP_OPTION, ...options);
+  ...options: Partial<SheetComponentOptions>[]
+) =>
+  getBaseSheetComponentOptions<SheetComponentOptions>(
+    RENDER_TOOLTIP_OPTION,
+    ...options,
+  );

--- a/packages/s2-shared/src/interface.ts
+++ b/packages/s2-shared/src/interface.ts
@@ -22,6 +22,7 @@ import type {
   S2RenderOptions,
   S2MountContainer,
   CellMeta,
+  TooltipContentType,
 } from '@antv/s2';
 
 // 是否开启自适应宽高，并指定容器
@@ -41,16 +42,16 @@ export type SheetUpdateCallback = (params: S2RenderOptions) => S2RenderOptions;
 export interface BaseSheetComponentProps<
   PartialDrillDown = unknown,
   Header = unknown,
-  Pagination = unknown,
+  Options = S2Options<TooltipContentType, any>,
 > {
   sheetType?: SheetType;
   spreadsheet?: (
     container: S2MountContainer,
     dataCfg: S2DataConfig,
-    options: S2Options<Element | string, Pagination>,
+    options: Options,
   ) => SpreadSheet;
   dataCfg: S2DataConfig;
-  options?: S2Options<Element | string, Pagination>;
+  options?: Options;
   loading?: boolean;
   partDrillDown?: PartialDrillDown;
   adaptive?: Adaptive;

--- a/packages/s2-shared/src/interface.ts
+++ b/packages/s2-shared/src/interface.ts
@@ -23,6 +23,7 @@ import type {
   S2MountContainer,
   CellMeta,
   TooltipContentType,
+  Pagination,
 } from '@antv/s2';
 
 // 是否开启自适应宽高，并指定容器
@@ -42,7 +43,7 @@ export type SheetUpdateCallback = (params: S2RenderOptions) => S2RenderOptions;
 export interface BaseSheetComponentProps<
   PartialDrillDown = unknown,
   Header = unknown,
-  Options = S2Options<TooltipContentType, any>,
+  Options = S2Options<TooltipContentType, Pagination>,
 > {
   sheetType?: SheetType;
   spreadsheet?: (

--- a/packages/s2-shared/src/utils/drill-down.ts
+++ b/packages/s2-shared/src/utils/drill-down.ts
@@ -122,11 +122,11 @@ const defaultPartDrillDownDisplayCondition = (meta: Node) => {
  * @param callback 下钻点击事件
  * @returns 新 options
  */
-export const buildDrillDownOptions = (
-  options: S2Options,
+export const buildDrillDownOptions = <T extends Omit<S2Options, 'tooltip'>>(
+  options: T,
   partDrillDown: PartDrillDown,
   callback: ActionIconCallback,
-): S2Options => {
+): T => {
   const nextHeaderIcons = options.headerActionIcons?.length
     ? [...options.headerActionIcons]
     : [];

--- a/packages/s2-shared/src/utils/options.ts
+++ b/packages/s2-shared/src/utils/options.ts
@@ -1,7 +1,7 @@
 import { customMerge, DEFAULT_OPTIONS, type S2Options } from '@antv/s2';
 import { SHEET_COMPONENT_DEFAULT_OPTIONS } from '../constant/option';
 
-export const getBaseSheetComponentOptions = (
-  ...options: Partial<S2Options<any>>[]
-): S2Options =>
+export const getBaseSheetComponentOptions = <Options = S2Options>(
+  ...options: Partial<Options>[]
+): Options =>
   customMerge(DEFAULT_OPTIONS, SHEET_COMPONENT_DEFAULT_OPTIONS, ...options);

--- a/packages/s2-vue/src/interface.ts
+++ b/packages/s2-vue/src/interface.ts
@@ -6,6 +6,7 @@ import type {
 import type { PropType } from 'vue';
 import type { PaginationProps } from 'ant-design-vue';
 import type { UnionToIntersection } from '@vue/shared';
+import type { TooltipContentType, S2Options, Pagination } from '@antv/s2';
 
 // 这个是vue中的类型，但是vue没有export
 // reference: @vue/runtime-core/dist/runtime-core.d.ts L1351
@@ -78,10 +79,14 @@ type GetInitEmits<T> = {
 /*                                    组件类型                                    */
 /* -------------------------------------------------------------------------- */
 
+export type SheetComponentOptions = S2Options<
+  TooltipContentType,
+  Pagination & PaginationProps
+>;
 export type SheetComponentProps = BaseSheetComponentProps<
   PartDrillDown,
   unknown,
-  PaginationProps
+  SheetComponentOptions
 >;
 export type BaseSheetInitPropKeys = GetPropKeys<BaseSheetComponentProps>;
 export type BaseSheetInitEmitKeys = GetEmitKeys<BaseSheetComponentProps>;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🎨 Enhance

- [x] Type optimization

### 📝 Description

在开启了严格模式的 ts 项目中使用 <SheetComponnet/>, S2Options 的第二次分页参数 (P) 默认值是 unknown, 会报错, 重构了一下相关类型

- 新增 `SheetComponentOptions`, 用于和 `S2Options` 做区分, 让 core 层 和 react/vue 层的类型提示更准确

> s2-core

```ts
type S2Options<T = Element | string, P = Pagination>
```

> s2-react

```ts
import {AntdPaginationProps} from 'antd'

export type SheetComponentOptions = S2Options<
  ReactNode,
  Pagination & AntdPaginationProps
>;
```

> s2-vue

```ts
import {PaginationProps} from 'antd-vue'

export type SheetComponentOptions = S2Options<
  Element | string,
  Pagination & PaginationProps
>;
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
