### PR TITLE
fix: 修复tooltip 点击空白无法消失的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -440,6 +440,38 @@ describe('Interaction Event Controller Tests', () => {
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
+  test('should reset if current mouse not on the canvas container', () => {
+    const containsMock = jest
+      .spyOn(HTMLElement.prototype, 'contains')
+      .mockImplementation(() => true);
+    spreadsheet.hideTooltip = jest.fn();
+    const reset = jest.fn().mockImplementation(() => {
+      spreadsheet.hideTooltip();
+    });
+    spreadsheet.tooltip.show = jest.fn();
+
+    spreadsheet.on(S2Event.GLOBAL_RESET, reset);
+    spreadsheet.tooltip.show({
+      position: {
+        x: 100,
+        y: 100,
+      },
+      content: 'test style reset',
+    });
+    spreadsheet.interaction.addIntercepts([InterceptType.HOVER]);
+    window.dispatchEvent(
+      new MouseEvent('click', {
+        clientX: 1000,
+        clientY: 1000,
+      } as MouseEventInit),
+    );
+
+    expect(containsMock).toHaveBeenCalled();
+    expect(reset).toHaveBeenCalled();
+    expect(spreadsheet.interaction.reset).toHaveBeenCalled();
+    expect(spreadsheet.hideTooltip).toHaveBeenCalled();
+  });
+
   test('should reset if current mouse outside the canvas container', () => {
     const reset = jest.fn();
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -162,7 +162,13 @@ export class EventController {
     // 所以如果是 刷选过程中 引起的 click(mousedown + mouseup) 事件, 则不需要重置
     const { interaction } = this.spreadsheet;
 
-    if (this.hasBrushSelectionIntercepts()) {
+    if (
+      interaction.hasIntercepts([
+        InterceptType.BRUSH_SELECTION,
+        InterceptType.COL_BRUSH_SELECTION,
+        InterceptType.ROW_BRUSH_SELECTION,
+      ])
+    ) {
       interaction.removeIntercepts([
         InterceptType.BRUSH_SELECTION,
         InterceptType.ROW_BRUSH_SELECTION,

--- a/packages/s2-react/__tests__/data/grid-analysis-data.ts
+++ b/packages/s2-react/__tests__/data/grid-analysis-data.ts
@@ -1,5 +1,4 @@
-import { S2DataConfig } from '@antv/s2';
-import { SheetComponentOptions } from '../../src';
+import type { S2DataConfig } from '@antv/s2';
 
 export const mockGridAnalysisDataCfg: S2DataConfig = {
   fields: {

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -1,6 +1,6 @@
 import { EXTRA_COLUMN_FIELD, isUpDataValue, type S2DataConfig } from '@antv/s2';
 import { isNil } from 'lodash';
-import { SheetComponentOptions } from '../../src';
+import type { SheetComponentOptions } from '../../src';
 
 const getKPIMockData = () => {
   return {

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -8,7 +8,7 @@ import {
   meta,
   fields,
 } from '../__tests__/data/mock-dataset.json';
-import { SheetComponentOptions } from '../src/components';
+import type { SheetComponentOptions } from '../src/components';
 
 export const tableSheetDataCfg: S2DataConfig = {
   data,

--- a/packages/s2-react/playground/resize.tsx
+++ b/packages/s2-react/playground/resize.tsx
@@ -2,7 +2,7 @@ import { customMerge, type ThemeCfg, ResizeType } from '@antv/s2';
 import { Checkbox, Switch } from 'antd';
 import { CheckboxValueType } from 'antd/lib/checkbox/Group';
 import React from 'react';
-import { SheetComponentOptions } from '../src/components';
+import type { SheetComponentOptions } from '../src/components';
 
 const RESIZE_CONFIG: Array<{
   label: string;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #0

🔧 Chore

- [X] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
- fix: 修复不按类型引入，导致 `react:playground` 启动报错
- [fix: 修复tooltip 点击空白无法消失的问题](https://github.com/antvis/S2/commit/4a604fcd825cb3308eeef76ae6e6d002453e3c35)
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|<img width="1735" alt="image" src="https://user-images.githubusercontent.com/20497176/188353335-cf291815-d470-492a-b3ec-05048003ee8f.png"> |<img width="1392" alt="image" src="https://user-images.githubusercontent.com/20497176/188353387-f6f3fb29-b8bc-49a3-a3f9-48da869be566.png">|
|![error-tooltip](https://user-images.githubusercontent.com/20497176/188353069-d7fc41d5-a96a-4ae0-b4b4-5da73999c9e1.gif)|![right-tooltip](https://user-images.githubusercontent.com/20497176/188353074-13bf548d-a178-4d5c-9e89-2a0427235013.gif)|


### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
