### PR TITLE
fix: 修复表格 onDestroy 卸载事件无法触发

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -1118,4 +1118,13 @@ describe('PivotSheet Tests', () => {
       sheet.destroy();
     });
   });
+
+  test('should emit destroy event', () => {
+    const onDestroy = jest.fn();
+    s2.on(S2Event.LAYOUT_DESTROY, onDestroy);
+
+    s2.destroy();
+
+    expect(onDestroy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -2,7 +2,7 @@ import { getContainer } from 'tests/util/helpers';
 import type { Event as GEvent } from '@antv/g-canvas';
 import * as dataCfg from 'tests/data/simple-table-data.json';
 import { TableSheet } from '@/sheet-type';
-import { setLang, type LangType, type S2Options } from '@/common';
+import { S2Event, setLang, type LangType, type S2Options } from '@/common';
 import { Node } from '@/facet/layout/node';
 
 describe('TableSheet Tests', () => {
@@ -180,5 +180,14 @@ describe('TableSheet Tests', () => {
         sheet.destroy();
       },
     );
+  });
+
+  test('should emit destroy event', () => {
+    const onDestroy = jest.fn();
+    s2.on(S2Event.LAYOUT_DESTROY, onDestroy);
+
+    s2.destroy();
+
+    expect(onDestroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
+++ b/packages/s2-react/__tests__/unit/hooks/useSpreadSheet-spec.ts
@@ -1,5 +1,10 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { PivotSheet, type S2DataConfig, type S2Options } from '@antv/s2';
+import {
+  PivotSheet,
+  S2Event,
+  type S2DataConfig,
+  type S2Options,
+} from '@antv/s2';
 import { getContainer } from 'tests/util/helpers';
 import * as mockDataConfig from 'tests/data/simple-data.json';
 import { cloneDeep } from 'lodash';
@@ -87,5 +92,34 @@ describe('useSpreadSheet tests', () => {
     // });
 
     // expect(s2.store.get('initColumnLeafNodes')).toEqual([]);
+  });
+
+  test('should destroy sheet after unmount component', () => {
+    const onDestroyFromProps = jest.fn();
+    const onDestroyFromS2Event = jest.fn();
+
+    const { result, unmount } = renderHook(() =>
+      useSpreadSheet({
+        ...getConfig(),
+        sheetType: 'pivot',
+        onDestroy: onDestroyFromProps,
+      }),
+    );
+
+    const s2 = result.current.s2Ref.current;
+
+    s2.on(S2Event.LAYOUT_DESTROY, onDestroyFromS2Event);
+
+    const destroySpy = jest
+      .spyOn(s2, 'destroy')
+      .mockImplementationOnce(() => {});
+
+    act(() => {
+      unmount();
+    });
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    expect(onDestroyFromProps).toHaveBeenCalledTimes(1);
+    expect(onDestroyFromS2Event).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -968,7 +968,9 @@ function MainLayout() {
               onDataCellTrendIconClick={logHandler('onDataCellTrendIconClick')}
               onAfterRender={logHandler('onAfterRender')}
               onRangeSort={logHandler('onRangeSort')}
-              onDestroy={logHandler('onDestroy')}
+              onDestroy={logHandler('onDestroy', () => {
+                clearInterval(scrollTimer.current);
+              })}
               onColCellClick={onColCellClick}
               onRowCellClick={logHandler('onRowCellClick')}
               onCornerCellClick={(cellInfo) => {

--- a/packages/s2-react/src/hooks/useEvents.ts
+++ b/packages/s2-react/src/hooks/useEvents.ts
@@ -30,14 +30,18 @@ export const useS2Event = (
   eventName: S2Event,
   handler: (args: unknown) => void,
   s2: SpreadSheet,
+  emitBeforeOff = false,
 ) => {
   React.useEffect(() => {
-    const handlerFn: EmitterType[S2Event] = (args) => {
+    const handlerFn: EmitterType[S2Event] = (args: unknown[]) => {
       handler?.(args);
     };
     s2?.on(eventName, handlerFn);
 
     return () => {
+      if (emitBeforeOff) {
+        s2?.emit(eventName);
+      }
       s2?.off(eventName, handlerFn);
     };
   }, [s2, handler, eventName]);
@@ -160,10 +164,9 @@ export function useEvents(props: SheetComponentsProps, s2: SpreadSheet) {
   );
   useS2Event(S2Event.LAYOUT_COLS_EXPANDED, props.onLayoutColsExpanded, s2);
   useS2Event(S2Event.LAYOUT_COLS_HIDDEN, props.onLayoutColsHidden, s2);
-
   useS2Event(S2Event.LAYOUT_BEFORE_RENDER, props.onBeforeRender, s2);
   useS2Event(S2Event.LAYOUT_AFTER_RENDER, props.onAfterRender, s2);
-  useS2Event(S2Event.LAYOUT_DESTROY, props.onDestroy, s2);
+  useS2Event(S2Event.LAYOUT_DESTROY, props.onDestroy, s2, true);
 
   // ============== Resize ====================
   useS2Event(S2Event.LAYOUT_RESIZE, props.onLayoutResize, s2);

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -69,7 +69,7 @@ export function useSpreadSheet(props: SheetComponentsProps) {
   React.useEffect(() => {
     buildSpreadSheet();
     return () => {
-      s2Ref.current.destroy();
+      s2Ref.current.destroy?.();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

修复 core 层 `s2.on(S2Event.LAYOUT_DESTROY)` 和 React 组件层 SheetComponent 的  `onDestroy` 都无法触发

背景:

组件 unmount 的时候会销毁表格 

https://github.com/antvis/S2/blob/3962178aae99c512315d9234e3e3d8bb9538ea36/packages/s2-react/src/hooks/useSpreadSheet.ts#L69-L75

然后会**同时销毁已注册**的事件

![image](https://user-images.githubusercontent.com/21015895/188462331-c6b32cf7-ac0b-4f85-8813-042e17a300cc.png)

这就会导致 emit destroy 事件的时候, emitter 已经没有相应事件了, destroy 恰好比较特殊

https://github.com/antvis/S2/blob/3962178aae99c512315d9234e3e3d8bb9538ea36/packages/s2-core/src/sheet-type/spread-sheet.ts#L398-L401

解法:

在 off destroy 事件之前, 提前触发一次


### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/188462833-427fdb57-e758-444c-b075-784d2b90cc06.png) | ![image](https://user-images.githubusercontent.com/21015895/188463052-600c048e-f35d-4503-8ae0-626c77125724.png) |

### 🔗 Related issue link

<!-- close #0 -->

ref #1728 

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
