### PR TITLE
fix: 修复趋势分析表多列头情况下，单元格数据为空引起的复制数据偏移问题

### DIFF
--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -212,7 +212,7 @@ const processValueInRow = (
     }
 
     // 如果本身格子的数据是 null， 但是一个格子又需要绘制多个指标时，需要使用placeholder填充
-    if (isNil(fieldValue) && placeholder.length > 0) {
+    if (isNil(fieldValue) && placeholder.length > 1) {
       tempCells.push(...placeholder);
       return tempCells;
     }

--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -5,6 +5,8 @@ import {
   get,
   isArray,
   isEmpty,
+  isFunction,
+  isNil,
   isObject,
   last,
   max,
@@ -197,6 +199,7 @@ const processValueInCol = (
 const processValueInRow = (
   viewMeta: ViewMeta,
   sheetInstance: SpreadSheet,
+  placeholder: string[],
   isFormat?: boolean,
 ) => {
   let tempCells = [];
@@ -205,6 +208,12 @@ const processValueInRow = (
     const { fieldValue, valueField, data } = viewMeta;
     if (isObject(fieldValue)) {
       tempCells = processObjectValueInRow(fieldValue, isFormat);
+      return tempCells;
+    }
+
+    // 如果本身格子的数据是 null， 但是一个格子又需要绘制多个指标时，需要使用placeholder填充
+    if (isNil(fieldValue) && placeholder.length > 0) {
+      tempCells.push(...placeholder);
       return tempCells;
     }
     // The main measure.
@@ -216,7 +225,7 @@ const processValueInRow = (
     }
   } else {
     // If the meta equals null then it will be replaced by '-'.
-    tempCells.push(sheetInstance.options.placeholder);
+    tempCells.push(...placeholder);
   }
   return tempCells.join('    ');
 };
@@ -228,6 +237,20 @@ const getHeaderLabel = (val: string) => {
     return label;
   }
   return val;
+};
+
+const getPlaceholder = (
+  viewMeta: ViewMeta,
+  leafNode: Node,
+  sheetInstance: SpreadSheet,
+) => {
+  const label = getHeaderLabel(leafNode.label);
+  const labelLength = isArray(label) ? label.length : 1;
+  const placeholder = sheetInstance.options.placeholder;
+  const placeholderStr = isFunction(placeholder)
+    ? placeholder(viewMeta)
+    : placeholder;
+  return Array(labelLength).fill(placeholderStr);
 };
 
 /**
@@ -355,9 +378,11 @@ export const copyData = (
           );
         } else {
           const viewMeta = getCellMeta(rowNode.rowIndex, colNode.colIndex);
+          const placeholder = getPlaceholder(viewMeta, colNode, sheetInstance);
           const lintItem = processValueInRow(
             viewMeta,
             sheetInstance,
+            placeholder,
             isFormatData,
           );
           if (isArray(lintItem)) {
@@ -450,7 +475,7 @@ export const copyData = (
         // 行头展开多少层，则复制多少层的内容。不进行全量复制。 eg: 树结构下，行头为 省份/城市, 折叠所有城市，则只复制省份
 
         const copiedRows = rows.slice(0, maxRowDepth);
-        // 在趋势分析表中，行头只有一个 extra的维度，但是有有个层级
+        // 在趋势分析表中，行头只有一个 extra的维度，但是有多个层级
         if (copiedRows.length < maxRowDepth) {
           copiedRows.unshift(
             ...Array(maxRowDepth - copiedRows.length).fill(''),

--- a/packages/s2-react/__tests__/data/strategy-data.ts
+++ b/packages/s2-react/__tests__/data/strategy-data.ts
@@ -196,8 +196,36 @@ const getMiniChartMockData = () => {
 };
 
 export const StrategySheetDataConfig: S2DataConfig = {
+  // 普通数值+同环比数据
   data: [
-    // 普通数值+同环比数据
+    {
+      date: '2022-09',
+      [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比', '同比']),
+    },
+    {
+      'measure-a': {
+        originalValues: [[377, '']],
+        values: [[377, '']],
+      },
+      'measure-b': {
+        originalValues: [[377, 324]],
+        values: [[377, 324]],
+      },
+      'measure-c': {
+        originalValues: [[null, 324]],
+        values: [[null, 324]],
+      },
+      'measure-d': {
+        originalValues: [[377, 324]],
+        values: [[377, 324]],
+      },
+      'measure-f': {
+        originalValues: [[377, 324]],
+        values: [[377, 324]],
+      },
+      date: '2022-10',
+      [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比']),
+    },
     {
       'measure-a': {
         originalValues: [[3877, 4324, 0.42]],
@@ -226,9 +254,10 @@ export const StrategySheetDataConfig: S2DataConfig = {
         originalValues: [[377, 324, 0.02]],
         values: [[377, 324, '0.02']],
       },
-      date: '2021',
+      date: '2022-11',
       [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比', '同比']),
     },
+
     // 净增目标完成度子弹图数据
     getKPIMockData(),
     // 趋势图数据
@@ -256,31 +285,6 @@ export const StrategySheetDataConfig: S2DataConfig = {
       },
       date: '2022',
       [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比']),
-    },
-
-    {
-      'measure-a': {
-        originalValues: [[377, '', 0.02]],
-        values: [[377, '', '0.02']],
-      },
-      'measure-b': {
-        originalValues: [[377, 324, 0.02]],
-        values: [[377, 324, '0.02']],
-      },
-      'measure-c': {
-        originalValues: [[null, 324, 0.02]],
-        values: [[null, 324, '0.02']],
-      },
-      'measure-d': {
-        originalValues: [[377, 324, 0.02]],
-        values: [[377, 324, '0.02']],
-      },
-      'measure-f': {
-        originalValues: [[377, 324, 0.02]],
-        values: [[377, 324, '0.02']],
-      },
-      date: '2022-10',
-      [EXTRA_COLUMN_FIELD]: JSON.stringify(['数值', '环比', '同比']),
     },
   ],
   meta: [

--- a/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/strategy-sheet-spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { act } from 'react-dom/test-utils';
-import { copyData, SpreadSheet } from '@antv/s2';
+import { copyData, type SpreadSheet } from '@antv/s2';
 import {
   StrategySheetDataConfig,
   StrategyOptions,
@@ -49,8 +49,8 @@ describe('Strategy Sheet Export Tests', () => {
 
   test('should export correct data for multi different cycle compare data', () => {
     // 列头部分不同粒度的列头包含不同的同环比个数
-    // 2022 包含 [数值，环比]
-    // 2022-10 包含 [数值，环比，同比]
+    // 2022-09 包含 [数值，环比，同比]
+    // 2022-10 包含 [数值，环比]
     // 它们都应和各自的列头数值一栏对齐
     const result = copyData(s2Instance, '\t');
 
@@ -59,11 +59,22 @@ describe('Strategy Sheet Export Tests', () => {
     const col2: string[] = rows[1].split('\t').slice(3);
 
     expect(col1.length).toEqual(col2.length);
-    // 2022 对齐其数值
-    const idx1 = col1.findIndex((col) => col === `"2022"`);
+    // 2022-09 对齐其数值
+    const idx1 = col1.findIndex((col) => col === `"2022-09"`);
     expect(col2[idx1]).toEqual(`"数值"`);
     // 2022-10 对齐其数值
     const idx2 = col1.findIndex((col) => col === `"2022-10"`);
     expect(col2[idx2]).toEqual(`"数值"`);
+  });
+
+  test('should export correct data for empty cell', () => {
+    // 2022-09 包含 [数值，环比，同比], 但是数值均为空
+    // 对应数据应该空三格
+    const result = copyData(s2Instance, '\t');
+
+    const rows = result.split('\n');
+    // 自定义节点A - 指标A
+    const detailRow: string[] = rows[3].split('\t').slice(0, 5);
+    expect(detailRow).toEqual([`"自定义节点A"`, `"指标A"`, '', '', '']);
   });
 });

--- a/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/index-spec.tsx
@@ -164,18 +164,18 @@ describe('<SheetComponent/> Tests', () => {
     test('should render correctly KPI bullet column measure text', () => {
       renderStrategySheet(
         {
-          width: 600,
+          width: 6000,
           height: 600,
         },
         StrategySheetDataConfig,
       );
 
-      // 当前测试数据, 第二列是子弹图
+      // 当前测试数据, 第 4 列是子弹图
       const dataCell = s2.interaction
         .getPanelGroupAllDataCells()
         .filter((cell) => {
           const meta = cell.getMeta();
-          return meta.colIndex === 1 && meta.fieldValue;
+          return meta.colIndex === 3 && meta.fieldValue;
         });
 
       const bulletMeasureTextList = dataCell.map((cell) => {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
在趋势分析表多列头的情况下，如果某一个的数据为空，之前对这一列填充了一个空占位，但实际上应该按照列头的指标数量填充，否则就会出现数据偏移：
![image](https://user-images.githubusercontent.com/17964556/189079780-5f56c7ab-5e7b-45fc-869c-cf4c89e67f7c.png)

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/189080547-57fd789c-6a04-4093-84ac-f60fbf46aedf.png)      | ![image](https://user-images.githubusercontent.com/17964556/189080246-6a8fec73-b8a3-46ae-b0a5-a73ef3ae2e41.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
