### PR TITLE
fix(sort): 修复 tooltip 中排序菜单未记住上一次选中状态 close #1716

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -847,6 +847,7 @@ describe('PivotSheet Tests', () => {
               { key: 'none', text: groupNoneText },
             ],
             onClick: expect.anything(),
+            defaultSelectedKeys: [],
           },
         },
       );
@@ -883,6 +884,10 @@ describe('PivotSheet Tests', () => {
       },
     ]);
     expect(renderSpy).toHaveBeenCalledTimes(1);
+    expect(s2.store.get('sortMethodMap')).toEqual({
+      '1': 'asc',
+    });
+    expect(s2.getMenuDefaultSelectedKeys(nodeMeta.id)).toEqual(['asc']);
 
     s2.groupSortByMethod('desc', nodeMeta);
 
@@ -895,6 +900,10 @@ describe('PivotSheet Tests', () => {
       },
     ]);
 
+    expect(s2.store.get('sortMethodMap')).toEqual({
+      '1': 'desc',
+    });
+    expect(s2.getMenuDefaultSelectedKeys(nodeMeta.id)).toEqual(['desc']);
     expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
     expect(renderSpy).toHaveBeenCalledTimes(2);
 
@@ -921,6 +930,7 @@ describe('PivotSheet Tests', () => {
         sortMethod: 'asc',
       },
     ]);
+    expect(s2.getMenuDefaultSelectedKeys(nodeMeta.id)).toEqual(['asc']);
   });
 
   test('should destroy sheet', () => {

--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -25,6 +25,7 @@ describe('TableSheet Tests', () => {
     container = getContainer();
     s2 = new TableSheet(container, dataCfg, s2Options);
     s2.render();
+    s2.store.set('sortMethodMap', null);
   });
 
   afterAll(() => {
@@ -50,13 +51,15 @@ describe('TableSheet Tests', () => {
       );
       expect(showTooltipWithInfoSpy).toHaveBeenCalledTimes(1);
 
-      s2.onSortTooltipClick(
-        { key: 'asc' },
-        {
-          field: 'city',
-        },
-      );
+      s2.onSortTooltipClick({ key: 'asc' }, {
+        id: 'city',
+        field: 'city',
+      } as Node);
 
+      expect(s2.store.get('sortMethodMap')).toEqual({
+        city: 'asc',
+      });
+      expect(s2.getMenuDefaultSelectedKeys(nodeMeta.id)).toEqual(['asc']);
       expect(s2.dataCfg.sortParams).toEqual([
         {
           sortFieldId: 'city',
@@ -67,13 +70,18 @@ describe('TableSheet Tests', () => {
     });
 
     test('should update sort params', () => {
-      s2.onSortTooltipClick(
-        { key: 'desc' },
-        {
-          field: 'cost',
-        },
-      );
+      const node = {
+        id: 'cost',
+        field: 'cost',
+      } as Node;
 
+      s2.onSortTooltipClick({ key: 'desc' }, node);
+
+      expect(s2.store.get('sortMethodMap')).toEqual({
+        city: 'asc',
+        cost: 'desc',
+      });
+      expect(s2.getMenuDefaultSelectedKeys(node.id)).toEqual(['desc']);
       expect(s2.dataCfg.sortParams).toEqual([
         {
           sortFieldId: 'city',
@@ -85,12 +93,10 @@ describe('TableSheet Tests', () => {
         },
       ]);
 
-      s2.onSortTooltipClick(
-        { key: 'desc' },
-        {
-          field: 'city',
-        },
-      );
+      s2.onSortTooltipClick({ key: 'desc' }, {
+        id: 'city',
+        field: 'city',
+      } as Node);
 
       expect(s2.dataCfg.sortParams).toEqual([
         {
@@ -102,6 +108,11 @@ describe('TableSheet Tests', () => {
           sortMethod: 'desc',
         },
       ]);
+      expect(s2.store.get('sortMethodMap')).toEqual({
+        cost: 'desc',
+        city: 'desc',
+      });
+      expect(s2.getMenuDefaultSelectedKeys('city')).toEqual(['desc']);
 
       s2.setDataCfg({
         ...s2.dataCfg,
@@ -118,12 +129,10 @@ describe('TableSheet Tests', () => {
         ],
       });
 
-      s2.onSortTooltipClick(
-        { key: 'asc' },
-        {
-          field: 'cost',
-        },
-      );
+      s2.onSortTooltipClick({ key: 'asc' }, {
+        id: 'cost',
+        field: 'cost',
+      } as Node);
 
       expect(s2.dataCfg.sortParams).toEqual([
         {
@@ -136,6 +145,11 @@ describe('TableSheet Tests', () => {
           sortBy: ['1', '2'],
         },
       ]);
+      expect(s2.store.get('sortMethodMap')).toEqual({
+        cost: 'asc',
+        city: 'desc',
+      });
+      expect(s2.getMenuDefaultSelectedKeys('cost')).toEqual(['asc']);
     });
 
     // https://github.com/antvis/S2/issues/1421
@@ -174,6 +188,7 @@ describe('TableSheet Tests', () => {
                 { key: 'none', text: groupNoneText },
               ],
               onClick: expect.anything(),
+              defaultSelectedKeys: [],
             },
           },
         );

--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -41,7 +41,11 @@ describe('TableSheet Tests', () => {
         .spyOn(s2, 'showTooltipWithInfo')
         .mockImplementation(() => {});
 
-      const nodeMeta = new Node({ id: '1', key: '1', value: 'testValue' });
+      const nodeMeta = new Node({
+        id: '1',
+        key: '1',
+        value: 'testValue',
+      });
 
       s2.handleGroupSort(
         {
@@ -59,7 +63,7 @@ describe('TableSheet Tests', () => {
       expect(s2.store.get('sortMethodMap')).toEqual({
         city: 'asc',
       });
-      expect(s2.getMenuDefaultSelectedKeys(nodeMeta.id)).toEqual(['asc']);
+      expect(s2.getMenuDefaultSelectedKeys('city')).toEqual(['asc']);
       expect(s2.dataCfg.sortParams).toEqual([
         {
           sortFieldId: 'city',

--- a/packages/s2-core/src/common/interface/store.ts
+++ b/packages/s2-core/src/common/interface/store.ts
@@ -3,6 +3,7 @@ import type {
   InteractionOptions,
   InteractionStateInfo,
   S2CellType,
+  SortMethod,
   SortParam,
   ViewMeta,
 } from '../interface';
@@ -88,5 +89,9 @@ export interface StoreKey {
   // last click cell
   lastClickedCell: S2CellType<ViewMeta>;
   initOverscrollBehavior: InteractionOptions['overscrollBehavior'];
+
+  // 排序方式
+  sortMethodMap: Record<string, SortMethod>;
+
   [key: string]: unknown;
 }

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -18,6 +18,7 @@ export interface TooltipOperatorMenu {
 export interface TooltipOperatorOptions {
   onClick?: (...args: unknown[]) => void;
   menus?: TooltipOperatorMenu[];
+  defaultSelectedKeys?: string[];
 }
 
 export interface TooltipPosition {

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -5,7 +5,6 @@ import {
   EXTRA_FIELD,
   InterceptType,
   S2Event,
-  getTooltipOperatorTableSortMenus,
   getTooltipOperatorSortMenus,
 } from '../common/constant';
 import type {
@@ -186,11 +185,15 @@ export class PivotSheet extends SpreadSheet {
     const prevSortParams = this.dataCfg.sortParams.filter(
       (item) => item?.sortFieldId !== sortFieldId,
     );
+
+    this.updateSortMethodMap(meta.id, sortMethod, true);
+
+    const sortParams: SortParam[] = [...prevSortParams, sortParam];
     // 触发排序事件
-    this.emit(S2Event.RANGE_SORT, [...prevSortParams, sortParam]);
+    this.emit(S2Event.RANGE_SORT, sortParams);
     this.setDataCfg({
       ...this.dataCfg,
-      sortParams: [...prevSortParams, sortParam],
+      sortParams,
     });
     this.render();
   }
@@ -199,12 +202,16 @@ export class PivotSheet extends SpreadSheet {
     event.stopPropagation();
     this.interaction.addIntercepts([InterceptType.HOVER]);
 
+    const defaultSelectedKeys = this.getMenuDefaultSelectedKeys(meta?.id);
+
     const operator: TooltipOperatorOptions = {
       onClick: ({ key }) => {
-        this.groupSortByMethod(key as unknown as SortMethod, meta);
+        const sortMethod = key as unknown as SortMethod;
+        this.groupSortByMethod(sortMethod, meta);
         this.emit(S2Event.RANGE_SORTED, event);
       },
       menus: getTooltipOperatorSortMenus(),
+      defaultSelectedKeys,
     };
 
     this.showTooltipWithInfo(event, [], {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -40,6 +40,7 @@ import type {
   S2Options,
   S2RenderOptions,
   S2Theme,
+  SortMethod,
   SpreadSheetFacetCfg,
   ThemeCfg,
   TooltipContentType,
@@ -735,4 +736,26 @@ export abstract class SpreadSheet extends EE {
 
     return w;
   };
+
+  public updateSortMethodMap(
+    nodeId: string,
+    sortMethod: SortMethod,
+    replace = false,
+  ) {
+    const lastSortMethodMap = !replace && this.store.get('sortMethodMap');
+
+    this.store.set('sortMethodMap', {
+      ...lastSortMethodMap,
+      [nodeId]: sortMethod,
+    });
+  }
+
+  public getMenuDefaultSelectedKeys(nodeId: string): string[] {
+    const sortMethodMap = this.store.get('sortMethodMap');
+    if (!sortMethodMap) {
+      return [];
+    }
+    const selectedSortMethod = get(sortMethodMap, nodeId);
+    return [selectedSortMethod];
+  }
 }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -756,6 +756,6 @@ export abstract class SpreadSheet extends EE {
       return [];
     }
     const selectedSortMethod = get(sortMethodMap, nodeId);
-    return [selectedSortMethod];
+    return selectedSortMethod ? [selectedSortMethod] : [];
   }
 }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -742,8 +742,7 @@ export abstract class SpreadSheet extends EE {
     sortMethod: SortMethod,
     replace = false,
   ) {
-    const lastSortMethodMap = !replace && this.store.get('sortMethodMap');
-
+    const lastSortMethodMap = !replace ? this.store.get('sortMethodMap') : null;
     this.store.set('sortMethodMap', {
       ...lastSortMethodMap,
       [nodeId]: sortMethod,
@@ -752,9 +751,6 @@ export abstract class SpreadSheet extends EE {
 
   public getMenuDefaultSelectedKeys(nodeId: string): string[] {
     const sortMethodMap = this.store.get('sortMethodMap');
-    if (!sortMethodMap) {
-      return [];
-    }
     const selectedSortMethod = get(sortMethodMap, nodeId);
     return selectedSortMethod ? [selectedSortMethod] : [];
   }

--- a/packages/s2-react/__tests__/unit/components/tooltip/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/tooltip/index-spec.tsx
@@ -1,0 +1,36 @@
+import { getTooltipOperatorSortMenus, S2CellType } from '@antv/s2';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { TooltipComponent } from '../../../../src';
+
+describe('Tooltip Component Tests', () => {
+  // https://github.com/antvis/S2/issues/1716
+  test.each(getTooltipOperatorSortMenus())(
+    'should render sort menu and select %o menu',
+    ({ key, text }) => {
+      render(
+        <TooltipComponent
+          options={{
+            onlyMenu: true,
+            operator: {
+              menus: getTooltipOperatorSortMenus(),
+              defaultSelectedKeys: [key],
+            },
+          }}
+          cell={null as unknown as S2CellType}
+          position={{ x: 0, y: 0 }}
+        />,
+      );
+
+      expect(screen.getByText('组内升序')).toBeDefined();
+      expect(screen.getByText('组内降序')).toBeDefined();
+      expect(screen.getByText('不排序')).toBeDefined();
+
+      const selectedMenu = [
+        ...document.querySelectorAll('.ant-menu-item-selected'),
+      ];
+      expect(selectedMenu).toHaveLength(1);
+      expect(selectedMenu[0]?.textContent).toContain(text);
+    },
+  );
+});

--- a/packages/s2-react/__tests__/util/helpers.ts
+++ b/packages/s2-react/__tests__/util/helpers.ts
@@ -66,6 +66,7 @@ export const createFakeSpreadSheet = () => {
   s2.render = jest.fn();
   s2.hideTooltip = jest.fn();
   s2.showTooltipWithInfo = jest.fn();
+  s2.isTableMode = jest.fn();
 
   return s2;
 };

--- a/packages/s2-react/src/components/tooltip/components/operator.tsx
+++ b/packages/s2-react/src/components/tooltip/components/operator.tsx
@@ -13,7 +13,13 @@ interface TooltipOperatorProps extends BaseTooltipOperatorProps {
 
 export const TooltipOperator: React.FC<TooltipOperatorProps> = React.memo(
   (props) => {
-    const { menus, onlyMenu, onClick: onMenuClick, cell } = props;
+    const {
+      menus,
+      onlyMenu,
+      onClick: onMenuClick,
+      cell,
+      defaultSelectedKeys,
+    } = props;
 
     const renderTitle = (menu: TooltipOperatorMenu) => {
       return (
@@ -60,6 +66,7 @@ export const TooltipOperator: React.FC<TooltipOperatorProps> = React.memo(
           <Menu
             className={`${TOOLTIP_PREFIX_CLS}-operator-menus`}
             onClick={onMenuClick}
+            defaultSelectedKeys={defaultSelectedKeys}
           >
             {map(menus, (subMenu: TooltipOperatorMenu) => renderMenu(subMenu))}
           </Menu>
@@ -73,6 +80,7 @@ export const TooltipOperator: React.FC<TooltipOperatorProps> = React.memo(
             className={`${TOOLTIP_PREFIX_CLS}-operator-menus`}
             onClick={onMenuClick}
             key={key}
+            defaultSelectedKeys={defaultSelectedKeys}
           >
             {map(children, (subMenu: TooltipOperatorMenu) =>
               renderMenu(subMenu),

--- a/packages/s2-react/src/components/tooltip/custom-tooltip.tsx
+++ b/packages/s2-react/src/components/tooltip/custom-tooltip.tsx
@@ -24,6 +24,8 @@ export class CustomTooltip extends BaseTooltip {
       content,
     };
 
+    // 确保 tooltip 内容更新 https://github.com/antvis/S2/issues/1716
+    this.unmountComponentAtNode();
     ReactDOM.render(
       <TooltipComponent {...tooltipProps} content={content} />,
       this.container,
@@ -32,6 +34,10 @@ export class CustomTooltip extends BaseTooltip {
 
   destroy() {
     super.destroy();
+    this.unmountComponentAtNode();
+  }
+
+  private unmountComponentAtNode() {
     if (this.container) {
       ReactDOM.unmountComponentAtNode(this.container);
     }

--- a/packages/s2-react/src/components/tooltip/index.tsx
+++ b/packages/s2-react/src/components/tooltip/index.tsx
@@ -30,12 +30,7 @@ export const TooltipComponent: React.FC<TooltipRenderProps> = (props) => {
   ) => {
     return (
       operator && (
-        <TooltipOperator
-          onClick={operator.onClick}
-          menus={operator.menus}
-          onlyMenu={onlyMenu}
-          cell={cell}
-        />
+        <TooltipOperator {...operator} onlyMenu={onlyMenu} cell={cell} />
       )
     );
   };

--- a/packages/s2-shared/src/styles/tooltip/operator.less
+++ b/packages/s2-shared/src/styles/tooltip/operator.less
@@ -1,7 +1,14 @@
 @tooltip-prefix-cls: antv-s2-tooltip-operator;
+@tooltip-menu-item-text-color: rgba(0, 0, 0, 0.65);
+
+.with-menu-item-color() {
+  &:not(.ant-menu-item-active) {
+    color: @tooltip-menu-item-text-color;
+  }
+}
 
 .@{tooltip-prefix-cls} {
-  color: rgba(0, 0, 0, 0.65);
+  color: @tooltip-menu-item-text-color;
   font-size: 12px;
   line-height: 32px;
   background: #f9f9f9;
@@ -17,7 +24,7 @@
   &-menus.ant-menu-vertical.ant-menu {
     font-size: 12px;
     line-height: 32px;
-    color: rgba(0, 0, 0, 0.65);
+    color: @tooltip-menu-item-text-color;
     border: 0;
     margin: 0 -12px;
 
@@ -33,7 +40,7 @@
       height: 30px;
 
       .ant-menu-submenu-arrow {
-        color: rgba(0, 0, 0, 0.65);
+        color: @tooltip-menu-item-text-color;
       }
     }
   }
@@ -42,10 +49,11 @@
   &-menus.ant-menu-vertical {
     .ant-dropdown-menu-item,
     .ant-menu-item {
+      .with-menu-item-color();
+
       font-size: 12px;
       line-height: 32px;
       padding: 0 12px;
-      color: rgba(0, 0, 0, 0.65);
       border: 0;
       margin: 0;
     }
@@ -55,10 +63,11 @@
     .ant-menu-submenu,
     .ant-menu-submenu-vertical {
       .ant-menu-submenu-title {
+        .with-menu-item-color();
+
         padding: 0 12px;
         font-size: 12px;
         line-height: 32px;
-        color: rgba(0, 0, 0, 0.65);
         margin: 0;
 
         .ant-dropdown-menu-title-content,
@@ -72,10 +81,11 @@
   &-submenu-popup {
     .ant-dropdown-menu-item,
     .ant-menu-item {
+      .with-menu-item-color();
+
       font-size: 12px;
       line-height: 32px;
       padding: 0 12px;
-      color: rgba(0, 0, 0, 0.65);
     }
 
     .ant-menu-vertical .ant-menu-item {

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -70,6 +70,8 @@ s2.xx()
 | getInitColumnLeafNodes | 获取初次渲染的列头叶子节点 （比如：隐藏列头前） | () => [Node[]](/zh/docs/api/basic-class/node/) |
 | getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素 | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |
 | clearColumnLeafNodes | 清空存储在 store 中的初始叶子节点 | () => void |
+| updateSortMethodMap | 更新存储在 store 中的节点排序方式 map, replace 为是否覆盖上一次的值 | (nodeId: string, sortMethod: string, replace?: boolean) => void |
+| getMenuDefaultSelectedKeys | 获取 tooltip 中选中的菜单项 key 值 | `(nodeId: string) => string[]` |
 
 ### S2MountContainer
 

--- a/s2-site/docs/api/basic-class/store.zh.md
+++ b/s2-site/docs/api/basic-class/store.zh.md
@@ -24,9 +24,15 @@ s2.store.set('key', value) // 存储
 | originalDataCfg | 原始数据配置 | [S2DataConfig](/zh/docs/api/general/S2DataConfig)|
 | panelBBox | 可视区域包裹盒模型 | [BBox](/zh/docs/api/basic-class/spreadsheet/#bbox) |
 | activeResizeArea | 当前调整大小区域 group | [Group](https://g.antv.vision/zh/docs/api/group) |
-| valueRanges | ? | [ValueRanges](#ValueRanges) |
+| valueRanges | 条件格式值区间 | [ValueRanges](#valueranges) |
 | initColumnLeafNodes | 初次渲染时的列头叶子节点 | [Node[]](/zh/docs/api/basic-class/node)|
 | hiddenColumnsDetail | 隐藏的列头详情 | [HiddenColumnsInfo[]](#hiddencolumnsinfo) |
+| lastRenderedColumnFields | 上一次渲染的列头配置 | `string[]` |
+| resized | 是否手动调整过宽高 | `boolean` |
+| visibleActionIcons | hover 显示的 icon 缓存 | `GuiIcon[]` |
+| lastClickedCell | 上一次点击的单元格 | `S2CellType<ViewMeta>` |
+| initOverscrollBehavior | 初始滚动链状态 | `'auto' | 'none' | 'contain'` |
+| sortMethodMap | 排序方式 | `Record<string, SortMethod>` |
 | [key: string] | 其他任意字段 | `unknown` |
 
 ## HiddenColumnsInfo
@@ -49,4 +55,15 @@ interface PartDrillDownInfo {
   // 下钻字段
   drillField: string;
 }
+```
+
+## ValueRanges
+
+```ts
+export interface ValueRange {
+  minValue?: number;
+  maxValue?: number;
+}
+
+export type ValueRanges = Record<string, ValueRange>;
 ```

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -88,6 +88,7 @@ object **可选**,_default：null_ 功能描述： tooltip 操作栏配置
 | ------- | -------------------------------------------- | :---: | ------ | ------------------------------------------------------------------------------------------ |
 | menus   | [TooltipOperatorMenu[]](#tooltipoperatormenu)  |     |        | 操作项列表  |
 | onClick | `({ item, key, keyPath, domEvent }) => void` |      |        | 点击事件，透传 `antd` `Menu` 组件的 [onClick](https://ant.design/components/menu-cn/#Menu) |
+| defaultSelectedKeys   | `string[]`  |     |        | 初始选中的菜单项 key 数组，透传 `antd` `Menu` 组件的 [defaultSelectedKeys](https://ant.design/components/menu-cn/#Menu)  |
 
 ##### TooltipOperatorMenu
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #1716 

### 📝 Description

### 背景

目前的排序菜单是一次性操作, 不会**记住上一次选中状态** 即: 用 UI 得到当前这一次操作的 sortMethod 做排序

且 CustomTooltip 没有正确的更新 dom, 透视表和明细表, 以及业务层都有这个问题 即: 单元格1 选中了 [降序], 单元格2 还是高亮的 [降序], 因为 ui 没有更新

### 解法

1. 增加 `defaultSelectedKeys` 透传给 antd menu 组件用于高亮
2. CustomTooltip 每次 render 前 `unmountComponentAtNode` 一次确保 UI 被更新
3. 增加一个 map 存储排序状态, 用于回填
4. 修复样式被覆盖, 导致排序菜单没有高亮颜色的问题

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-09-09 at 11 45 51](https://user-images.githubusercontent.com/21015895/189331460-88f0b475-f3c5-4bef-b18e-5f9b29a26ee5.gif) | ![Kapture 2022-09-09 at 11 42 24](https://user-images.githubusercontent.com/21015895/189267278-b813f9c5-37dc-43f0-a324-c72d6d24e30d.gif)
| ![Kapture 2022-09-09 at 11 46 59](https://user-images.githubusercontent.com/21015895/189267675-0e386947-a7fb-4a5c-83b1-08fa0e084472.gif)| ![Kapture 2022-09-09 at 11 44 05](https://user-images.githubusercontent.com/21015895/189267419-96d08ccd-68af-4b3e-b59b-74f94ec3b784.gif)|

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
