### PR TITLE
feat(strategysheet): 趋势分析表 tooltip 支持显示原始值

### DIFF
--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/__snapshots__/index-spec.tsx.snap
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/__snapshots__/index-spec.tsx.snap
@@ -29,6 +29,21 @@ exports[`StrategySheet Tooltip Tests should render tooltip with {
 `;
 
 exports[`StrategySheet Tooltip Tests should render tooltip with {
+  label: 'test data label',
+  component: [Function: StrategySheetDataTooltip] {
+    [length]: 1,
+    [name]: 'StrategySheetDataTooltip',
+    defaultProps: { showOriginalValue: true }
+  }
+} 1`] = `
+<span
+  class="header-label"
+>
+  test data label
+</span>
+`;
+
+exports[`StrategySheet Tooltip Tests should render tooltip with {
   label: 'test row label',
   component: [Function: StrategySheetRowTooltip] {
     [length]: 1,

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/index-spec.tsx
@@ -28,4 +28,36 @@ describe('StrategySheet Tooltip Tests', () => {
     expect(screen.getByText(label)).toBeDefined();
     expect(screen.getByText(label)).toMatchSnapshot();
   });
+
+  test('should hidden original value', () => {
+    const originalValues = [1.1, 2.2, 3.3];
+
+    jest.spyOn(mockCellInfo.mockCell, 'getMeta').mockImplementation(() => ({
+      fieldValue: {
+        values: ['1', '2', '3'],
+        originalValues,
+      },
+      spreadsheet: {
+        options: {
+          style: {},
+        },
+        getRowNodes: jest.fn(),
+        getColumnNodes: jest.fn(),
+        dataSet: {
+          getFieldDescription: jest.fn(),
+          getFieldName: jest.fn(),
+        },
+      },
+    }));
+    render(
+      <StrategySheetDataTooltip
+        cell={mockCellInfo.mockCell}
+        showOriginalValue={false}
+      />,
+    );
+
+    originalValues.forEach((value) => {
+      expect(screen.getByText(value)).not.toBeDefined();
+    });
+  });
 });

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -42,14 +42,14 @@ export const s2Options: SheetComponentOptions = {
     },
   },
   hierarchyType: 'grid',
-  style: {
-    rowCfg: {
-      width: 200,
-    },
-    cellCfg: {
-      height: 50,
-    },
-  },
+  // style: {
+  //   rowCfg: {
+  //     width: 200,
+  //   },
+  //   cellCfg: {
+  //     height: 50,
+  //   },
+  // },
 };
 
 export const sliderOptions: SliderSingleProps = {

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/index.less
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/index.less
@@ -65,6 +65,7 @@
 
       .derived-value-group {
         color: rgba(0, 0, 0, 0.65);
+        margin-left: 10px;
 
         .derived-value-trend-icon {
           display: inline-block;
@@ -92,6 +93,10 @@
             transform: rotate(180deg);
             border-bottom-color: #2aa491;
           }
+        }
+
+        .derived-value-original {
+          margin-left: 4px;
         }
       }
     }

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/interface.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/interface.ts
@@ -9,4 +9,5 @@ export interface CustomTooltipProps {
         cell: S2CellType<Node | ViewMeta>,
         defaultLabel: React.ReactNode,
       ) => React.ReactNode);
+  showOriginalValue?: boolean;
 }

--- a/s2-site/docs/manual/basic/analysis/strategy.zh.md
+++ b/s2-site/docs/manual/basic/analysis/strategy.zh.md
@@ -59,7 +59,7 @@ import '@antv/s2-react/dist/style.min.css';
 
 ReactDOM.render(
   <SheetComponent
-    dataCfg={dataCfg}
+    dataCfg={s2DataCfg}
     options={s2Options}
     sheetType="strategy"
   />,
@@ -105,6 +105,13 @@ object **必选**,_default：null_
 
 趋势分析表的 `Tooltip`, 使用 `S2` 提供的 [自定义能力](/zh/docs/manual/basic/tooltip#%E8%87%AA%E5%AE%9A%E4%B9%89-tooltip-%E5%86%85%E5%AE%B9) 分别对 `行头 (row)`, `列头 (col)`, `数值 (data)` 进行了 [定制](https://github.com/antvis/S2/blob/f35ff01400384cd2f3d84705e9daf75fc11b0149/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx#L105), 同时可以在 `@antv/s2-react` 包中进行单独引入
 
+| 配置项名称 | 说明     | 类型   | 默认值 | 必选 |
+| :------------- | :----------------- | :--------- | :----- | :--- |
+| cell           | 当前单元格 | `S2CellType`   |  ✓   |
+| defaultTooltipShowOptions | 默认 tooltip 展示配置 | `TooltipShowOptions<ReactNode>`  |  |      |
+| label        | 标题    | `ReactNode | (cell: S2CellType, defaultLabel: ReactNode) => React.ReactNode` |    |      |
+| showOriginalValue      | 是否显示原始值      | `boolean` | `false`   |      |
+
 ```ts
 import { StrategySheetRowTooltip, StrategySheetColTooltip, StrategySheetDataTooltip } from '@antv/s2-react'
 
@@ -130,3 +137,13 @@ const s2Options = {
 ```
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/dosQkhLBp/fbe5a635-60ad-4e55-9a23-858842b977ac.png" width="600"  alt="preview" />
+
+### 显示原始数据
+
+开启 `showOriginalValue` 后，会读取当前 Tooltip 对应的 `originalValues` 数据（如有）, 将原始数据一同展示，即 `展示值（原始值）`
+
+```ts
+<StrategySheetDataTooltip cell={cell} showOriginalValue />
+```
+
+<img src="https://gw.alipayobjects.com/zos/antfincdn/%242tkorO2F/27504d9d-0d92-4fc4-9296-44eaf55ef613.png" width="600"  alt="preview" />


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

StrategySheetDataTooltip 增加 `showOriginalValue`, 支持显示数据的原始值, 默认关闭

```
<StrategySheetDataTooltip showOriginalValue/>
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/190115810-89bc3535-fea3-4b97-9879-0e596c1397e7.png) | ![image](https://user-images.githubusercontent.com/21015895/190115285-01fd0d14-9735-43a6-9b6d-b9ef5fee80f5.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
