### PR TITLE
fix: 修复多指标单元格展示错误

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/text-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/text-spec.ts
@@ -221,7 +221,7 @@ describe('Text Utils Tests', () => {
       [20, 30, 40],
     ];
 
-    const boxes = getContentAreaForMultiData(box, multiData, [0.4, 0.2, 0.4]);
+    const boxes = getContentAreaForMultiData(box, multiData, [40, 0.2, 0.4]);
 
     expect(boxes).toEqual([
       [

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -6,6 +6,7 @@ import {
   isNil,
   isNumber,
   isString,
+  map,
   memoize,
   size,
   toString,
@@ -408,14 +409,18 @@ export const getContentAreaForMultiData = (
   let avgWidth: number;
   let totalWidth = 0;
 
+  const percents = map(widthPercent, (item) =>
+    Number(item) < 1 ? Number(item) : Number(item) / 100,
+  );
+
   for (let i = 0; i < size(textValues); i++) {
     curY = y + avgHeight * i;
     const rows: SimpleBBox[] = [];
     curX = x;
     totalWidth = 0;
     for (let j = 0; j < size(textValues[i]); j++) {
-      avgWidth = !isEmpty(widthPercent)
-        ? width * widthPercent[j]
+      avgWidth = !isEmpty(percents)
+        ? width * percents[j]
         : width / size(textValues[0]); // 指标个数相同，任取其一即可
 
       curX = calX(x, { left: 0, right: 0 }, totalWidth, 'left');

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -73,7 +73,7 @@ export const mockGridAnalysisOptions: SheetComponentOptions = {
       width: 400,
       height: 100,
       valuesCfg: {
-        widthPercent: [0.4, 0.2, 0.2, 0.2],
+        widthPercent: [40, 0.2, 0.2, 0.2],
       },
     },
   },


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

当为多指标哦单元格且配置了 `widthPercent` 时指标宽度计算错误，https://github.com/antvis/S2/pull/1684 时默认值均为小数，而官网早先的 demo 是百分比数值，该 pr 做了下兼容，都支持。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌  ![image](https://user-images.githubusercontent.com/10885578/190303614-80bd5ef1-607a-4c71-ac41-4d6dadda8ea8.png) | ✅   ![image](https://user-images.githubusercontent.com/10885578/190303441-c67803b7-89bf-4e43-9d09-ed9dccd50a12.png)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
