### PR TITLE
fix: 子弹图左侧文字未对齐

### DIFF
--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -284,7 +284,7 @@ export interface RangeColors {
 export interface BulletTheme {
   /* 进度条 */
   progressBar: {
-    /* 子弹图宽度相对整体单元格的占比，小数， default：0.7 */
+    /* 子弹图宽度相对单元格 content 占比，小数 */
     widthPercent: number;
     height: number;
     /* 内高度 */

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -381,7 +381,7 @@ export const getTheme = (
         // ------------- bullet graph -----------------
         bullet: {
           progressBar: {
-            widthPercent: 0.75,
+            widthPercent: 0.6,
             height: 10,
             innerHeight: 6,
           },

--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -244,24 +244,22 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
   // 所以子弹图需要为数值预留宽度
   // 对于负数, 进度条计算按照 0 处理, 但是展示还是要显示原来的百分比
   const measurePercent = transformRatioToPercent(measure, 2);
-  const measurePercentWidth = Math.ceil(
-    spreadsheet.measureTextWidth(measurePercent, dataCellStyle),
-  );
-
   const widthPercent =
     progressBar?.widthPercent > 1
       ? progressBar?.widthPercent / 100
       : progressBar?.widthPercent;
 
-  const bulletWidth = widthPercent * width - measurePercentWidth;
-  const measureWidth = width - bulletWidth;
-
   const padding = dataCellStyle.cell.padding;
+  const contentWidth = width - padding.left - padding.right;
+
+  // 子弹图先占位(bulletWidth)，剩下空间给文字(measureWidth)
+  const bulletWidth = widthPercent * contentWidth;
+  const measureWidth = contentWidth - bulletWidth;
 
   // TODO 先支持默认右对齐
   // 绘制子弹图
   // 1. 背景
-  const positionX = x + width - padding.right - padding.left - bulletWidth;
+  const positionX = x + width - padding.right - bulletWidth;
   const positionY = y + height / 2 - progressBar.height / 2;
 
   renderRect(cell, {
@@ -323,7 +321,7 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     getEllipsisText({
       measureTextWidth: spreadsheet.measureTextWidth,
       text: measurePercent,
-      maxWidth: measureWidth,
+      maxWidth: measureWidth - padding.right,
       fontParam: dataCellStyle.text,
     }),
     dataCellStyle.text,


### PR DESCRIPTION
### 👀 PR includes

🎨 Enhance

- [x] Change the UI

### 📝 Description
之前计算子弹图宽度时（使用 widthPercent 自定义占比），包含了 `文字`，`进度条` 宽度
而每行文字宽度不一，会导致进度条长度也不一致

现在改为 widthPercent 仅代表 `进度条` 宽度，文字使用 `总宽度` - `进度条` 的剩余空间

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-09-15 at 19 51 47](https://user-images.githubusercontent.com/6716092/190396734-6176a1db-a51a-4317-a08d-5127768b8b02.png)    |   ![CleanShot 2022-09-15 at 19 51 11](https://user-images.githubusercontent.com/6716092/190396552-c02669f0-b7eb-4516-afe2-12b85a1b3378.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
