### PR TITLE
feat(strategysheet): 支持自定义衍生指标

### DIFF
--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/__snapshots__/index-spec.tsx.snap
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/__snapshots__/index-spec.tsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StrategySheet Tooltip Tests should render custom derived value 1`] = `
+Array [
+  <span
+    class="derived-value-group derived-value-trend-up"
+  >
+    <span
+      class="derived-value-trend-icon"
+    />
+    customDerivedValue
+  </span>,
+  <span
+    class="derived-value-group derived-value-trend-up"
+  >
+    <span
+      class="derived-value-trend-icon"
+    />
+    customDerivedValue
+  </span>,
+  <span
+    class="derived-value-group derived-value-trend-up"
+  >
+    <span
+      class="derived-value-trend-icon"
+    />
+    customDerivedValue
+  </span>,
+]
+`;
+
 exports[`StrategySheet Tooltip Tests should render tooltip with {
   label: 'test col label',
   component: [Function: StrategySheetColTooltip] {

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/custom-tooltip/index-spec.tsx
@@ -53,6 +53,7 @@ describe('StrategySheet Tooltip Tests', () => {
     }));
 
     const container = getContainer();
+
     ReactDOM.render(
       <StrategySheetDataTooltip
         cell={mockCellInfo.mockCell}
@@ -64,8 +65,16 @@ describe('StrategySheet Tooltip Tests', () => {
     expect(
       container.querySelector('.s2-strategy-sheet-tooltip-original-value'),
     ).toBeDefined();
-    expect([
-      ...container.querySelectorAll('.derived-value-original'),
-    ]).toHaveLength(3);
+  });
+
+  test('should render custom derived value', () => {
+    render(
+      <StrategySheetDataTooltip
+        cell={mockCellInfo.mockCell}
+        renderDerivedValue={() => 'customDerivedValue'}
+      />,
+    );
+    expect(screen.getAllByText('customDerivedValue')).toHaveLength(3);
+    expect(screen.getAllByText('customDerivedValue')).toMatchSnapshot();
   });
 });

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/custom-data-tooltip.tsx
@@ -5,10 +5,9 @@ import {
   type MultiData,
   type SimpleDataItem,
   type ViewMeta,
-  transformRatioToPercent,
 } from '@antv/s2';
 import cls from 'classnames';
-import { first, get, includes, isEmpty, isFunction, isNil } from 'lodash';
+import { first, get, isEmpty, isFunction, isNil } from 'lodash';
 import React from 'react';
 import { getStrategySheetTooltipClsName as tooltipCls } from '@antv/s2-shared';
 import { getLeafColNode, getRowName, getRowDescription } from '../utils';
@@ -20,6 +19,7 @@ export const StrategySheetDataTooltip: React.FC<CustomTooltipProps> = ({
   cell,
   label,
   showOriginalValue: showOriginalValueFromTooltip,
+  renderDerivedValue,
 }) => {
   const meta = cell.getMeta() as ViewMeta;
   const metaFieldValue = meta?.fieldValue as MultiData<SimpleDataItem[][]>;
@@ -67,18 +67,13 @@ export const StrategySheetDataTooltip: React.FC<CustomTooltipProps> = ({
         <>
           <div className={tooltipCls('divider')} />
           <ul className={tooltipCls('derived-values')}>
-            {derivedValues.map((derivedValue, i) => {
+            {derivedValues.map((derivedValue: SimpleDataItem, i) => {
               const isNormal = isNil(derivedValue) || derivedValue === '';
               const isUp = isUpDataValue(derivedValue as string);
               const isDown = !isNormal && !isUp;
-              const originalDerivedValue = derivedOriginalValues[i];
-              const isRatioLike = includes(derivedValue as string, '%');
-              const displayOriginalDerivedValue = isRatioLike
-                ? transformRatioToPercent(originalDerivedValue as string, {
-                    min: 1,
-                    max: 1,
-                  })
-                : originalDerivedValue;
+              const originalDerivedValue = derivedOriginalValues[
+                i
+              ] as SimpleDataItem;
 
               return (
                 <li className="derived-value-item" key={i}>
@@ -94,12 +89,13 @@ export const StrategySheetDataTooltip: React.FC<CustomTooltipProps> = ({
                     {!isNormal && (
                       <span className="derived-value-trend-icon"></span>
                     )}
-                    <span className="derived-value-content">
-                      {derivedValue ?? emptyPlaceholder}
-                    </span>
-                    {showOriginalValue && (
-                      <span className="derived-value-original">
-                        ({displayOriginalDerivedValue ?? emptyPlaceholder})
+                    {renderDerivedValue?.(
+                      derivedValue,
+                      originalDerivedValue,
+                      cell,
+                    ) ?? (
+                      <span className="derived-value-content">
+                        {derivedValue ?? emptyPlaceholder}
                       </span>
                     )}
                   </span>

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/index.less
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/index.less
@@ -94,10 +94,6 @@
             border-bottom-color: #2aa491;
           }
         }
-
-        .derived-value-original {
-          margin-left: 4px;
-        }
       }
     }
   }

--- a/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/interface.ts
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/custom-tooltip/interface.ts
@@ -1,3 +1,4 @@
+import type { SimpleDataItem } from '@antv/s2';
 import type { Node, S2CellType, TooltipShowOptions, ViewMeta } from '@antv/s2';
 
 export interface CustomTooltipProps {
@@ -10,4 +11,9 @@ export interface CustomTooltipProps {
         defaultLabel: React.ReactNode,
       ) => React.ReactNode);
   showOriginalValue?: boolean;
+  renderDerivedValue?: (
+    currentValue: SimpleDataItem,
+    originalValue: SimpleDataItem,
+    cell: S2CellType<Node | ViewMeta>,
+  ) => React.ReactNode;
 }

--- a/s2-site/docs/manual/basic/analysis/strategy.zh.md
+++ b/s2-site/docs/manual/basic/analysis/strategy.zh.md
@@ -115,7 +115,7 @@ object **必选**,_default：null_
 | cell           | 当前单元格 | `S2CellType`   |  ✓   |
 | defaultTooltipShowOptions | 默认 tooltip 展示配置 | `TooltipShowOptions<ReactNode>`  |  |      |
 | label        | 标题    | `ReactNode | (cell: S2CellType, defaultLabel: ReactNode) => React.ReactNode` |    |      |
-| showOriginalValue      | 是否显示原始值      | `boolean` | `false`   |      |
+| showOriginalValue      | 是否显示原始数值 （如有）      | `boolean` | `false`   |      |
 
 ```ts
 import { StrategySheetRowTooltip, StrategySheetColTooltip, StrategySheetDataTooltip } from '@antv/s2-react'
@@ -133,7 +133,7 @@ const s2Options = {
 
 默认使用行头节点名字作为 Tooltip 标题，可通过 `label` 自定义内容的方式
 
-```ts
+```tsx
 // 字符串
 <StrategySheetDataTooltip cell={cell} label={"自定义标题"}/>
 
@@ -147,8 +147,25 @@ const s2Options = {
 
 开启 `showOriginalValue` 后，会读取当前 Tooltip 对应的 `originalValues` 数据（如有）, 将原始数据一同展示，即 `展示值（原始值）`
 
-```ts
+```tsx
 <StrategySheetDataTooltip cell={cell} showOriginalValue />
 ```
 
-<img src="https://gw.alipayobjects.com/zos/antfincdn/%242tkorO2F/27504d9d-0d92-4fc4-9296-44eaf55ef613.png" width="600"  alt="preview" />
+<img src="https://gw.alipayobjects.com/zos/antfincdn/xe57%261A5E/9e0ae256-7823-498c-8d88-740ff30bff5a.png" width="600"  alt="preview" />
+
+### 渲染同环比额外节点
+
+可以通过 `renderDerivedValue` 在自定义同环比数值，比如替换成原始值
+
+* `currentValue`: 当前值
+* `originalValue`: 原始值
+* `cell`: 当前 Tooltip 对应的单元格信息
+
+```tsx
+<StrategySheetDataTooltip
+  cell={cell}
+  renderDerivedValue={(currentValue, originalValue, cell) => <span>({originalValue})</span> }
+/>
+```
+
+<img src="https://gw.alipayobjects.com/zos/antfincdn/jOYhdqOr6/a43696e1-3cdb-49b7-9906-4053c3f7e65b.png" width="600"  alt="preview" />


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

优化 https://github.com/antvis/S2/pull/1750 的方案, `<StrategySheetDataTooltip/>` 支持自定义衍生指标, 更灵活

![image](https://user-images.githubusercontent.com/21015895/190644297-518b6697-8d76-430f-82c2-74177fd91027.png)


```ts
   <StrategySheetDataTooltip
      cell={cell}
      renderDerivedValue={(currentValue, originalValue) => (
        <span>
          {currentValue} ({originalValue})
        </span>
      )}
    />
```

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
