### PR TITLE
fix(scroll): 修复点击滚动条滑道区域表格渲染空白 close #1764 #1780

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1764-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1764-spec.ts
@@ -1,0 +1,38 @@
+/**
+ * @description spec for issue #1764 #1780
+ * https://github.com/antvis/S2/issues/1764
+ * https://github.com/antvis/S2/issues/1780
+ */
+
+import { getContainer } from '../util/helpers';
+import * as mockDataConfig from '../data/data-issue-1668.json';
+import type { S2Options } from '@/index';
+import { PivotSheet } from '@/sheet-type';
+
+const s2Options: S2Options = {
+  width: 800,
+  height: 400,
+  style: {
+    // 显示滚动条
+    cellCfg: {
+      width: 200,
+    },
+  },
+};
+
+describe('ScrollBar Track Offset Tests', () => {
+  const s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
+  s2.render();
+
+  test('should not get NaN offset when scroll track clicked', () => {
+    const { hScrollBar } = s2.facet;
+
+    const updateThumbOffsetSpy = jest
+      .spyOn(hScrollBar, 'updateThumbOffset')
+      .mockImplementation(() => {});
+
+    hScrollBar.trackShape.emit('click', { x: 0, y: 0 });
+
+    expect(updateThumbOffsetSpy).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -676,4 +676,39 @@ describe('Scroll Tests', () => {
       },
     );
   });
+
+  // https://github.com/antvis/S2/issues/1784
+  test('should not throw error if scroll over the data cell area and not exist scroll bar', async () => {
+    // rowCell 显示滚动条, dataCell 无滚动条, 然后在 dataCell 区域滚动
+    s2.setOptions({
+      style: {
+        rowCfg: {
+          width: 200,
+        },
+        cellCfg: {
+          width: 30,
+        },
+      },
+    });
+
+    s2.render(false);
+
+    const errorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementationOnce(() => {});
+
+    // dataCell 区域滚动
+    const wheelEvent = new WheelEvent('wheel', {
+      deltaX: 20,
+      deltaY: 0,
+      clientX: 225,
+      clientY: 1019,
+    });
+
+    canvas.dispatchEvent(wheelEvent);
+
+    await sleep(500);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -789,13 +789,13 @@ export abstract class BaseFacet {
     const isScrollRowHeaderToRight =
       !this.hRowScrollBar ||
       this.isScrollOverThePanelArea({ offsetY, offsetX }) ||
-      this.hRowScrollBar.thumbOffset + this.hRowScrollBar.thumbLen >=
+      this.hRowScrollBar?.thumbOffset + this.hRowScrollBar?.thumbLen >=
         this.cornerBBox.width;
 
     const isScrollPanelToRight =
       (this.hRowScrollBar &&
         this.isScrollOverTheCornerArea({ offsetX, offsetY })) ||
-      this.hScrollBar.thumbOffset + this.hScrollBar.thumbLen >= viewportWidth;
+      this.hScrollBar?.thumbOffset + this.hScrollBar?.thumbLen >= viewportWidth;
 
     return deltaX >= 0 && isScrollPanelToRight && isScrollRowHeaderToRight;
   };

--- a/packages/s2-core/src/ui/scrollbar/index.ts
+++ b/packages/s2-core/src/ui/scrollbar/index.ts
@@ -1,4 +1,10 @@
-import type { IElement, IGroup, IShape, ShapeAttrs } from '@antv/g-canvas';
+import type {
+  IElement,
+  IGroup,
+  IShape,
+  ShapeAttrs,
+  Event as GEvent,
+} from '@antv/g-canvas';
 import { Group } from '@antv/g-canvas';
 import { each, get } from 'lodash';
 import { MIN_SCROLL_BAR_HEIGHT } from '../../common/constant/scroll';
@@ -147,6 +153,7 @@ export class ScrollBar extends Group {
   public updateThumbOffset = (offset: number, emitScrollChange = true) => {
     const newOffset = this.validateRange(offset);
     const isNotChanged = this.thumbOffset === newOffset && newOffset !== 0;
+
     if (isNotChanged) {
       return;
     }
@@ -360,10 +367,10 @@ export class ScrollBar extends Group {
   };
 
   // 点击滑道的事件回调,移动滑块位置
-  private onTrackClick = (event: MouseEvent) => {
+  private onTrackClick = (event: GEvent) => {
     const offset = this.isHorizontal
-      ? event.offsetX - this.position.x - this.thumbLen / 2
-      : event.offsetY - this.position.y - this.thumbLen / 2;
+      ? event.x - this.position.x - this.thumbLen / 2
+      : event.y - this.position.y - this.thumbLen / 2;
 
     const newOffset = this.validateRange(offset);
     this.updateThumbOffset(newOffset);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and closes #1784 #1780 #1764 

### 📝 Description

1. 修复 点击横/纵向滚动条的滑道时, 表格渲染空白 (透视表/明细表都有问题)
2. 修复 行头有滚动条, 数值区域无滚动条, 在数值区域滚动时报错

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Kapture 2022-09-27 at 11 20 52](https://user-images.githubusercontent.com/21015895/192424331-37bea8b0-2824-4894-b2e8-8638a8a8c177.gif) | ![Kapture 2022-09-27 at 11 19 27](https://user-images.githubusercontent.com/21015895/192424186-70011c2c-dd36-49be-aa9f-ec7e751735f9.gif) |

### 🔗 Related issue link

<!-- close #0 -->

close #1784 #1780 #1764 

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
