### PR TITLE
fix: 下钻后meta.childField不正确

### DIFF
--- a/packages/s2-core/src/utils/dataset/pivot-data-set.ts
+++ b/packages/s2-core/src/utils/dataset/pivot-data-set.ts
@@ -162,7 +162,7 @@ export function getDataPath(params: DataPathParams) {
       }
 
       if (meta) {
-        if (shouldCreateOrUpdate && meta.childField !== dimensions?.[i + i]) {
+        if (shouldCreateOrUpdate && meta.childField !== dimensions?.[i + 1]) {
           meta.childField = dimensions?.[i + 1];
         }
         currentMeta = meta?.children;


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
下钻新增维度时，childField 填充的判断条件 typo 导致错误

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
