### PR TITLE
feat: 树状结构下, 行小计数据显示配置规则

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -4,6 +4,7 @@ import type { Formatter, ViewMeta } from '@/common';
 import { PivotDataSet } from '@/data-set';
 import { SpreadSheet, PivotSheet } from '@/sheet-type';
 import { DataCell } from '@/cell';
+import type { PivotFacet } from '@/facet';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
@@ -28,7 +29,14 @@ describe('data cell formatter test', () => {
 
     s2 = new MockPivotSheet(container);
     const dataSet: PivotDataSet = new MockPivotDataSet(s2);
+
     s2.dataSet = dataSet;
+
+    s2.facet = {
+      layoutResult: {
+        rowLeafNodes: [],
+      },
+    } as PivotFacet;
   });
 
   test('should pass complete data into formatter', () => {

--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -62,6 +62,9 @@ jest.mock('@/sheet-type', () => {
         isHierarchyTreeType: jest.fn(),
         facet: {
           getFreezeCornerDiffWidth: jest.fn(),
+          layoutResult: {
+            rowLeafNodes: [],
+          },
         },
         getCanvasElement: () => container.get('el'),
         hideTooltip: jest.fn(),

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -222,9 +222,8 @@ export class DataCell extends BaseCell<ViewMeta> {
   }
 
   protected shouldHideRowSubtotalData() {
-    const { row = {} } = this.spreadsheet.options.totals;
+    const { row = {} } = this.spreadsheet.options.totals ?? {};
     const { rowIndex } = this.meta;
-
     const node = this.spreadsheet.facet.layoutResult.rowLeafNodes[rowIndex];
     const isRowSubTotal = !node?.isGrandTotals && node?.isTotals;
     // 在树状结构时，如果单元格本身是行小计，但是行小计配置又未开启时

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -198,6 +198,11 @@ export class DataCell extends BaseCell<ViewMeta> {
 
     // get text condition's fill result
     let fill = textStyle.fill;
+
+    if (this.shouldHideRowSubtotalData()) {
+      return { ...textStyle, fill };
+    }
+
     const textCondition = this.findFieldCondition(this.conditions?.text);
     if (textCondition?.mapping) {
       fill = this.mappingValue(textCondition)?.fill || textStyle.fill;
@@ -267,6 +272,9 @@ export class DataCell extends BaseCell<ViewMeta> {
   }
 
   protected drawConditionIconShapes() {
+    if (this.shouldHideRowSubtotalData()) {
+      return;
+    }
     const iconCondition: IconCondition = this.findFieldCondition(
       this.conditions?.icon,
     );
@@ -291,6 +299,9 @@ export class DataCell extends BaseCell<ViewMeta> {
    * @protected
    */
   protected drawConditionIntervalShape() {
+    if (this.shouldHideRowSubtotalData()) {
+      return;
+    }
     this.conditionIntervalShape = drawInterval(this);
   }
 
@@ -304,6 +315,10 @@ export class DataCell extends BaseCell<ViewMeta> {
       // 隔行颜色的配置
       // 偶数行展示灰色背景，因为index是从0开始的
       backgroundColor = crossBackgroundColor;
+    }
+
+    if (this.shouldHideRowSubtotalData()) {
+      return { backgroundColor, backgroundColorOpacity };
     }
 
     // get background condition fill color


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
之前，在树状结构下，行头天然存在小计的格子，如果此时用户刚好传入了小计的数据，不过此时`totals.row.showSubtotals`是否开启，都会将其展示出来。
现在让行小计的格子数据展示也符合小计配置规则。
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/192933184-6bd590a1-d6f2-4b93-8f72-7e3f461c33f3.png)      | ![image](https://user-images.githubusercontent.com/17964556/192933159-459b95f3-1429-4308-ba41-1e1e738a66c9.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
