### PR TITLE
fix: 带行头复制报错修复

### DIFF
--- a/packages/s2-core/src/utils/export/copy.ts
+++ b/packages/s2-core/src/utils/export/copy.ts
@@ -420,6 +420,7 @@ const processTableRowSelected = (
         .map((cName) =>
           spreadsheet.getColumnNodes().find((n) => n.field === cName),
         )
+        .filter(Boolean) // 过滤掉空值，如行头cell
         .map((node) =>
           convertString(
             getFormat(node.colIndex, spreadsheet)(entry[node.field]),


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix
带行头cell复制时 rowcell对应的colIndex为0且取不到对应formatter，需要过滤

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description



### 🖼️ Screenshot
<img width="567" alt="image" src="https://user-images.githubusercontent.com/9219215/194987562-b0b3c59a-9ca3-4881-b2a3-7927b7e4186a.png">


| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
