### PR TITLE
fix(tooltip): tooltip 显示时不应该强制清空 dom

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -840,6 +840,7 @@ describe('PivotSheet Tests', () => {
         expect.anything(),
         {
           onlyMenu: true,
+          forceRender: true,
           operator: {
             menus: [
               { icon: 'groupAsc', key: 'asc', text: groupAscText },
@@ -860,7 +861,9 @@ describe('PivotSheet Tests', () => {
 
     const showTooltipWithInfoSpy = jest
       .spyOn(s2, 'showTooltipWithInfo')
-      .mockImplementation(() => {});
+      .mockImplementation((event, data, options) => ({
+        forceRender: options.forceRender,
+      }));
 
     const nodeMeta = new Node({ id: '1', key: '1', value: 'testValue' });
 
@@ -871,7 +874,7 @@ describe('PivotSheet Tests', () => {
       nodeMeta,
     );
 
-    expect(showTooltipWithInfoSpy).toHaveBeenCalledTimes(1);
+    expect(showTooltipWithInfoSpy).toHaveReturnedWith({ forceRender: true });
 
     s2.groupSortByMethod('asc', nodeMeta);
 

--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -53,7 +53,16 @@ describe('TableSheet Tests', () => {
         } as GEvent,
         nodeMeta,
       );
-      expect(showTooltipWithInfoSpy).toHaveBeenCalledTimes(1);
+
+      expect(showTooltipWithInfoSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        [],
+        {
+          operator: expect.anything(),
+          onlyMenu: true,
+          forceRender: true,
+        },
+      );
 
       s2.onSortTooltipClick({ key: 'asc' }, {
         id: 'city',
@@ -184,6 +193,7 @@ describe('TableSheet Tests', () => {
           expect.anything(),
           expect.anything(),
           {
+            forceRender: true,
             onlyMenu: true,
             operator: {
               menus: [

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -37,15 +37,18 @@ export interface SortQuery {
 }
 
 export interface TooltipOptions {
+  // 隐藏汇总
   hideSummary?: boolean;
-  // button action on the top
+  // 顶部操作项
   operator?: TooltipOperatorOptions;
   enterable?: boolean;
-  // totals or not
+  // 是否是小计
   isTotals?: boolean;
   showSingleTips?: boolean;
   onlyMenu?: boolean;
   enableFormat?: boolean;
+  // 是否强制清空 dom
+  forceRender?: boolean;
 }
 
 export interface TooltipSummaryOptions {

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -217,6 +217,8 @@ export class PivotSheet extends SpreadSheet {
     this.showTooltipWithInfo(event, [], {
       operator,
       onlyMenu: true,
+      // 确保 tooltip 内容更新 https://github.com/antvis/S2/issues/1716
+      forceRender: true,
     });
   }
 }

--- a/packages/s2-core/src/sheet-type/table-sheet.ts
+++ b/packages/s2-core/src/sheet-type/table-sheet.ts
@@ -188,6 +188,7 @@ export class TableSheet extends SpreadSheet {
     this.showTooltipWithInfo(event, [], {
       operator,
       onlyMenu: true,
+      forceRender: true,
     });
   }
 }

--- a/packages/s2-react/__tests__/spreadsheet/tooltip-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/tooltip-spec.tsx
@@ -179,7 +179,7 @@ describe('SheetComponent Tooltip Tests', () => {
 
     document
       .querySelector('.ant-dropdown-trigger')
-      .dispatchEvent(new Event('click'));
+      ?.dispatchEvent(new Event('click'));
 
     expect(errorSpy).not.toThrowError(
       'Uncaught Error: React.Children.only expected to receive a single React element child.',
@@ -187,4 +187,23 @@ describe('SheetComponent Tooltip Tests', () => {
 
     errorSpy.mockRestore();
   });
+
+  test.each([{ forceRender: true }, { forceRender: false }])(
+    'should not unmount component after show tooltip and %o',
+    async ({ forceRender }) => {
+      await sleep(1000);
+
+      const unmountComponentAtNodeSpy = jest
+        .spyOn(ReactDOM, 'unmountComponentAtNode')
+        .mockImplementationOnce(() => true);
+
+      s2.showTooltip({ position: { x: 0, y: 0 }, options: { forceRender } });
+      s2.showTooltipWithInfo({} as MouseEvent, [], { forceRender });
+      s2.hideTooltip();
+
+      expect(unmountComponentAtNodeSpy).toHaveBeenCalledTimes(
+        forceRender ? 2 : 0,
+      );
+    },
+  );
 });

--- a/packages/s2-react/src/components/tooltip/custom-tooltip.tsx
+++ b/packages/s2-react/src/components/tooltip/custom-tooltip.tsx
@@ -24,8 +24,10 @@ export class CustomTooltip extends BaseTooltip {
       content,
     };
 
-    // 确保 tooltip 内容更新 https://github.com/antvis/S2/issues/1716
-    this.unmountComponentAtNode();
+    if (showOptions.options?.forceRender) {
+      this.unmountComponentAtNode();
+    }
+
     ReactDOM.render(
       <TooltipComponent {...tooltipProps} content={content} />,
       this.container,

--- a/s2-site/docs/common/custom-tooltip.zh.md
+++ b/s2-site/docs/common/custom-tooltip.zh.md
@@ -73,12 +73,14 @@ object **必选**,_default：null_ 功能描述： tooltip 部分配置
 
 | 参数           | 类型                                              | 必选  | 默认值 | 功能描述                     |
 | -------------- | ------------------------------------------------- | :---: | ------ | ---------------------------- |
-| hideSummary    | `boolean`                                         |       |        | 是否隐藏所选项统计信息       |
+| hideSummary    | `boolean`                                         |       |     `false`    | 是否隐藏所选项统计信息       |
 | operator       | [TooltipOperatorOptions](#tooltipoperatoroptions) |       |        | 操作栏配置                   |
-| onlyMenu       | `boolean`                                         |       |        | tooltip 是否只展示操作菜单项 |
-| enterable      | `boolean`                                         |       |        | 是否可进入 tooltip 组件      |
-| isTotals       | `boolean`                                         |       |        | 是否是 总计/小计 单元格      |
-| showSingleTips | `boolean`                                         |       |        | 是否显示单元格提示信息       |
+| onlyMenu       | `boolean`                                         |       |      `false`   | tooltip 是否只展示操作菜单项 |
+| enterable      | `boolean`                                         |       |      `false`   | 是否可进入 tooltip 组件      |
+| isTotals       | `boolean`                                         |       |      `false`   | 是否是 总计/小计 单元格      |
+| showSingleTips | `boolean`                                         |       |     `false`    | 是否显示单元格提示信息       |
+| enableFormat | `boolean`                                         |       |     `false`    | 是否开启格式化       |
+| forceRender | `boolean`                                         |       |    `false`    | 是否强制清空 dom       |
 
 #### TooltipOperatorOptions
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

内部修改为分场景, 而不是始终销毁组件, 避免外部调用 `s2.showTooltip()` 时, tooltip 反复渲染

> 测试代码

```ts
 s2.showTooltip({
  position: {
    x: event.clientX,
    y: event.clientY,
  },
  content: (
    <img
      src="https://gw.alipayobjects.com/zos/antfincdn/xv%2685cV97/2022-09-15%25252022.43.09.gif"
      width={200}
    />
  ),
});
```

### 🖼️ Screenshot

> 注意观察 img 标签

| Before | After |
| ------ | ----- |
| ![Kapture 2022-10-13 at 11 11 44](https://user-images.githubusercontent.com/21015895/195490515-65d60060-d025-4862-97b1-aaf844d211fb.gif) | 
![Kapture 2022-10-13 at 11 10 57](https://user-images.githubusercontent.com/21015895/195490543-8dd6d780-3ba7-4a68-8f70-25f1e9b1c42a.gif) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
