### PR TITLE
fix: data-cell文字无法交互

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1624-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1624-spec.ts
@@ -38,7 +38,7 @@ describe('Data Cell Border Tests', () => {
 
     // @ts-ignore
     const meta = dataCell.getCellArea();
-    const borderBbox = dataCell.getChildByIndex(3).getBBox();
+    const borderBbox = dataCell.getChildByIndex(2).getBBox();
 
     expect(meta.x).toEqual(borderBbox.x - borderWidth / 2);
     expect(meta.y).toEqual(borderBbox.y - borderWidth / 2);

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -161,12 +161,12 @@ export class DataCell extends BaseCell<ViewMeta> {
   protected initCell() {
     this.drawBackgroundShape();
     this.drawInteractiveBgShape();
+    this.drawInteractiveBorderShape();
     if (!this.shouldHideRowSubtotalData()) {
       this.drawConditionIntervalShape();
       this.drawTextShape();
       this.drawConditionIconShapes();
     }
-    this.drawInteractiveBorderShape();
     if (this.meta.isFrozenCorner) {
       this.drawBorderShape();
     }


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
#1802 改动中，误改变了 data-cell 中 shape 的绘制顺序，导致 interactiveBorderShape 在 text 之后被加入到画板。
即 text 被遮挡，导致无法交互（开启 linkField 时无能点击和 hover）

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-10-14 at 14 05 16](https://user-images.githubusercontent.com/6716092/195774038-7967f023-2133-40ce-90a7-584483e5d07b.gif)  |   ![CleanShot 2022-10-14 at 14 03 58](https://user-images.githubusercontent.com/6716092/195773867-ac1b9a34-fc6f-400b-b92c-cf9f97389560.gif)    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
