### PR TITLE
feat: 在生成 id 时，对 undefined, null 做区分

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/layout/generate-id.spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/layout/generate-id.spec.ts
@@ -1,0 +1,55 @@
+import { generateId, resolveId } from '@/utils';
+
+describe('generate id test', () => {
+  test('should generate correct id for normal string variables', () => {
+    expect(generateId('root', 'child')).toEqual('root[&]child');
+
+    expect(generateId('parent', 'child', 'grandChild')).toEqual(
+      'parent[&]child[&]grandChild',
+    );
+  });
+
+  test('should distinguish null and `null` in id', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(generateId('root', 'child', null, 'null')).toEqual(
+      'root[&]child[&]$$null$$[&]null',
+    );
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(generateId('root', 'child', undefined, 'undefined')).toEqual(
+      'root[&]child[&]$$undefined$$[&]undefined',
+    );
+  });
+});
+
+describe('resolve id test', () => {
+  test('should get correct id for normal string variables', () => {
+    expect(resolveId('root[&]child')).toEqual(['child']);
+
+    expect(resolveId('parent[&]child[&]grandChild')).toEqual([
+      'parent',
+      'child',
+      'grandChild',
+    ]);
+  });
+
+  test('should get correct id to distinguish null and `null` in id', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(resolveId('root[&]child[&]$$null$$[&]null')).toEqual([
+      'child',
+      null,
+      'null',
+    ]);
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    expect(resolveId('root[&]child[&]$$undefined$$[&]undefined')).toEqual([
+      'child',
+      undefined,
+      'undefined',
+    ]);
+  });
+});

--- a/packages/s2-core/src/common/constant/basic.ts
+++ b/packages/s2-core/src/common/constant/basic.ts
@@ -8,6 +8,9 @@ export const SERIES_NUMBER_FIELD = '$$series_number$$';
 export const TOTAL_VALUE = '$$total$$';
 export const MULTI_VALUE = '$$multi$$';
 
+export const NULL_SYMBOL_ID = '$$null$$';
+export const UNDEFINED_SYMBOL_ID = '$$undefined$$';
+
 export const BACK_GROUND_GROUP_CONTAINER_Z_INDEX = 0;
 
 // foregroundGroup 上的 children 层叠顺序

--- a/packages/s2-core/src/utils/layout/generate-id.ts
+++ b/packages/s2-core/src/utils/layout/generate-id.ts
@@ -1,10 +1,43 @@
-import { ID_SEPARATOR } from '../../common/constant';
+import { isNull, isUndefined } from 'lodash';
+import {
+  ID_SEPARATOR,
+  NULL_SYMBOL_ID,
+  ROOT_ID,
+  UNDEFINED_SYMBOL_ID,
+} from '../../common/constant';
 /**
  * Row and column header node id generator.
  * @param parentId
  * @param value
  */
 
-export const generateId = (parentId: string, value: string): string => {
-  return `${parentId}${ID_SEPARATOR}${value}`;
+export const generateId = (...ids: string[]): string => {
+  return ids
+    .map((value) => {
+      if (isUndefined(value)) {
+        return UNDEFINED_SYMBOL_ID;
+      }
+      if (isNull(value)) {
+        return NULL_SYMBOL_ID;
+      }
+      return String(value);
+    })
+    .join(ID_SEPARATOR);
+};
+
+export const resolveId = (id = '') => {
+  return id.split(ID_SEPARATOR).reduce((result, current) => {
+    if (current === ROOT_ID) {
+      return result;
+    }
+
+    if (current === NULL_SYMBOL_ID) {
+      result.push(null);
+    } else if (current === UNDEFINED_SYMBOL_ID) {
+      result.push(undefined);
+    } else {
+      result.push(current);
+    }
+    return result;
+  }, []);
 };

--- a/packages/s2-core/src/utils/layout/index.ts
+++ b/packages/s2-core/src/utils/layout/index.ts
@@ -1,2 +1,2 @@
-export { generateId } from './generate-id';
+export { generateId, resolveId } from './generate-id';
 export * from './frozen';


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] 针对布局重构的第4点：内部对null, undefined类型做区分


🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
在生成 id 时，对`undefined`, `null`做区分，并抛出`resolveId`方法，方便外部产品对id进行解析，可以处理内部平台产品中趋势图id对`null`和`'null'`混淆的问题
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
