### PR TITLE
fix: 紧凑模式下节点宽度计算错误

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
@@ -1,0 +1,76 @@
+import * as mockDataConfig from 'tests/data/simple-data.json';
+import { getContainer } from 'tests/util/helpers';
+import { PivotSheet } from '@/sheet-type';
+import type { S2Options } from '@/common';
+
+const s2options: S2Options = {
+  width: 800,
+  height: 600,
+};
+
+describe('Col width Test in grid mode', () => {
+  let s2: PivotSheet;
+  beforeEach(() => {
+    s2 = new PivotSheet(
+      getContainer(),
+      {
+        ...mockDataConfig,
+        data: [
+          {
+            province: '浙江',
+            city: '义乌',
+            type: '笔',
+            // long text
+            price: 123456789,
+            cost: 2,
+          },
+        ],
+      },
+      s2options,
+    );
+    s2.render();
+  });
+
+  test('get correct width in layoutWidthType adaptive mode', () => {
+    const { colLeafNodes } = s2.facet.layoutResult;
+    expect(colLeafNodes[0].width).toBe(200);
+  });
+
+  test('get correct width in layoutWidthType compact mode', () => {
+    s2.setOptions({
+      style: {
+        layoutWidthType: 'compact',
+      },
+    });
+    s2.render();
+
+    // 无 formatter
+    const { colLeafNodes } = s2.facet.layoutResult;
+    expect(Math.round(colLeafNodes[0].width)).toBe(83);
+  });
+
+  test('get correct width in layoutWidthType compact mode when apply fomatter', () => {
+    s2.setDataCfg({
+      fields: undefined,
+      data: undefined,
+      meta: [
+        {
+          field: 'price',
+          formatter: (v: number) => {
+            return `${(v / 1000000).toFixed(0)}百万`;
+          },
+        },
+      ],
+    });
+    s2.setOptions({
+      style: {
+        layoutWidthType: 'compact',
+      },
+    });
+    s2.render();
+
+    // 有formatter
+    const { colLeafNodes } = s2.facet.layoutResult;
+    expect(Math.round(colLeafNodes[0].width)).toBe(61);
+  });
+});

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -300,10 +300,12 @@ export class PivotFacet extends BaseFacet {
 
           if (cellData) {
             // 总小计格子不一定有数据
-            const cellLabel = `${handleDataItem(
-              cellData,
-              filterDisplayDataItem,
-            )}`;
+            const valueData = handleDataItem(cellData, filterDisplayDataItem);
+            const formattedValue =
+              this.spreadsheet.dataSet.getFieldFormatter(
+                cellData[EXTRA_FIELD],
+              )?.(valueData) ?? valueData;
+            const cellLabel = `${formattedValue}`;
             const cellLabelWidth =
               this.spreadsheet.measureTextWidthRoughly(cellLabel);
 


### PR DESCRIPTION
### 👀 PR includes
🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
紧凑模式下，计算列头根节点时，未考虑 formatter 情况，导致宽度计算错误
如数据为：`123456789`，meta.formatter 后为 `123百万`
但估算时，还是使用的 `123456789`，而非后者，导致单元格宽度过宽

### 🖼️ Screenshot

> 下图中，原始值 ratio 为 `3.321312312312`，formatter 为保留两位小数


| Before | After |
| ------ | ----- |
|    ![CleanShot 2022-10-19 at 18 07 23@2x](https://user-images.githubusercontent.com/6716092/196662395-a4446afb-8512-4439-8bea-ab34078cccda.png)    |   ![CleanShot 2022-10-19 at 18 05 28@2x](https://user-images.githubusercontent.com/6716092/196662026-39542bb6-0fca-4f61-9bfd-7418927a5750.png)     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
