### PR TITLE
fix: 自适应模式节点宽度计算错误

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
@@ -36,6 +36,34 @@ describe('Col width Test in grid mode', () => {
     expect(colLeafNodes[0].width).toBe(200);
   });
 
+  test('get correct width in layoutWidthType adaptive mode when enable seriesnumber', () => {
+    s2.setOptions({
+      showSeriesNumber: true,
+    });
+    s2.render();
+    const { colLeafNodes } = s2.facet.layoutResult;
+    expect(colLeafNodes[0].width).toBe(180);
+  });
+
+  test('get correct width in layoutWidthType adaptive tree mode', () => {
+    s2.setOptions({
+      hierarchyType: 'tree',
+    });
+    s2.render();
+    const { colLeafNodes } = s2.facet.layoutResult;
+    expect(colLeafNodes[0].width).toBe(340);
+  });
+
+  test('get correct width in layoutWidthType adaptive tree mode when enable seriesnumber', () => {
+    s2.setOptions({
+      hierarchyType: 'tree',
+      showSeriesNumber: true,
+    });
+    s2.render();
+    const { colLeafNodes } = s2.facet.layoutResult;
+    expect(colLeafNodes[0].width).toBe(300);
+  });
+
   test('get correct width in layoutWidthType compact mode', () => {
     s2.setOptions({
       style: {

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -641,13 +641,17 @@ export class PivotFacet extends BaseFacet {
   ): number {
     // tree row width = [config width, canvas / 2]
     const canvasW = this.getCanvasHW().width;
-    const rowHeaderWidth = Math.min(canvasW / 2, this.getTreeRowHeaderWidth());
+    const availableWidth = canvasW - this.getSeriesNumberWidth();
+    const rowHeaderWidth = Math.min(
+      availableWidth / 2,
+      this.getTreeRowHeaderWidth(),
+    );
     // calculate col width
     const colSize = Math.max(1, colLeafNodes.length);
     const { cellCfg } = this.cfg;
     return Math.max(
       getCellWidth(cellCfg, this.getColLabelLength(col, rowLeafNodes)),
-      (canvasW - rowHeaderWidth) / colSize,
+      (availableWidth - rowHeaderWidth) / colSize,
     );
   }
 
@@ -704,15 +708,16 @@ export class PivotFacet extends BaseFacet {
     const rowHeaderColSize = rows.length;
     const colHeaderColSize = colLeafNodes.length;
     const canvasW = this.getCanvasHW().width;
+    const availableWidth = canvasW - this.getSeriesNumberWidth();
+
     const size = Math.max(1, rowHeaderColSize + colHeaderColSize);
     if (!rowHeaderWidth) {
-      // canvasW / (rowHeader's col size + colHeader's col size) = [celCfg.width, canvasW]
-      return Math.max(getCellWidth(cellCfg), canvasW / size);
+      return Math.max(getCellWidth(cellCfg), availableWidth / size);
     }
-    // (canvasW - rowHeaderW) / (colHeader's col size) = [celCfg.width, canvasW]
+
     return Math.max(
       getCellWidth(cellCfg),
-      (canvasW - rowHeaderWidth) / colHeaderColSize,
+      (availableWidth - rowHeaderWidth) / colHeaderColSize,
     );
   }
 


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #1821 

🔧 Chore

- [x] Test case

### 📝 Description
自适应模式下，未考虑开启 `序号列` 的情况，始终使用了 canvas 总宽度作为总可用宽度计算。
实际应该使用 `canvas 宽度` 减去 `序号列宽度`，余下的空间用于所有节点均分。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|   ![CleanShot 2022-10-20 at 18 17 22](https://user-images.githubusercontent.com/6716092/196922648-83d1b593-b7e4-4e94-a345-bc4f22b31bc8.gif)      |   <img width="1008" alt="CleanShot 2022-10-20 at 18 17 55@2x" src="https://user-images.githubusercontent.com/6716092/196922794-649b269d-e0ae-467b-ba40-6422b4985c84.png"> |
