### PR TITLE
fix: bold字体对应数字字重不正确

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -419,7 +419,7 @@ describe('Scroll Tests', () => {
 
     s2.changeSheetSize(1000, 150); // 纵向滚动条
     s2.render(false);
-    expect(s2.facet.vScrollBar.getCanvasBBox().x).toBe(185);
+    expect(s2.facet.vScrollBar.getCanvasBBox().x).toBe(190);
 
     s2.setOptions({
       interaction: {

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-tree-mode-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-tree-mode-spec.ts
@@ -26,7 +26,7 @@ describe('SpreadSheet Tree Mode Tests', () => {
       s2.render();
 
       const rowsHierarchyWidth = s2.facet.layoutResult.rowsHierarchy.width;
-      expect(rowsHierarchyWidth).toEqual(120);
+      expect(Math.round(rowsHierarchyWidth)).toEqual(123);
 
       // 行头维度均更改为较长的 name
       const newDataCfg: S2DataConfig = {

--- a/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/theme-spec.ts
@@ -356,7 +356,7 @@ describe('SpreadSheet Theme Tests', () => {
 
         expectTextAlign({
           textAlign,
-          fontWight: 500,
+          fontWight: 700,
           customNodes: isRowCell ? rowTotalNodes : colTotalNodes,
         });
       },

--- a/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
@@ -51,7 +51,7 @@ describe('Col width Test in grid mode', () => {
     });
     s2.render();
     const { colLeafNodes } = s2.facet.layoutResult;
-    expect(colLeafNodes[0].width).toBe(340);
+    expect(Math.round(colLeafNodes[0].width)).toBe(339);
   });
 
   test('get correct width in layoutWidthType adaptive tree mode when enable seriesnumber', () => {
@@ -61,7 +61,7 @@ describe('Col width Test in grid mode', () => {
     });
     s2.render();
     const { colLeafNodes } = s2.facet.layoutResult;
-    expect(colLeafNodes[0].width).toBe(300);
+    expect(Math.round(colLeafNodes[0].width)).toBe(299);
   });
 
   test('get correct width in layoutWidthType compact mode', () => {
@@ -74,7 +74,7 @@ describe('Col width Test in grid mode', () => {
 
     // 无 formatter
     const { colLeafNodes } = s2.facet.layoutResult;
-    expect(Math.round(colLeafNodes[0].width)).toBe(83);
+    expect(Math.round(colLeafNodes[0].width)).toBe(86);
   });
 
   test('get correct width in layoutWidthType compact mode when apply fomatter', () => {
@@ -99,6 +99,6 @@ describe('Col width Test in grid mode', () => {
 
     // 有formatter
     const { colLeafNodes } = s2.facet.layoutResult;
-    expect(Math.round(colLeafNodes[0].width)).toBe(61);
+    expect(Math.round(colLeafNodes[0].width)).toBe(62);
   });
 });

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -25,7 +25,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 500,
+        fontWeight: isWindows() ? 'bold' : 700,
         fill: basicColors[0],
         opacity: 1,
         textAlign: isTable ? 'center' : 'left',
@@ -34,7 +34,7 @@ export const getTheme = (
       text: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 500,
+        fontWeight: isWindows() ? 'bold' : 700,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'right',
@@ -93,7 +93,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 500,
+        fontWeight: isWindows() ? 'bold' : 700,
         fill: basicColors[14],
         linkTextFill: basicColors[6],
         opacity: 1,
@@ -189,7 +189,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 500,
+        fontWeight: isWindows() ? 'bold' : 700,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'center',
@@ -275,7 +275,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 500,
+        fontWeight: isWindows() ? 'bold' : 700,
         fill: basicColors[13],
         opacity: 1,
         textAlign: 'right',

--- a/packages/s2-core/src/theme/index.ts
+++ b/packages/s2-core/src/theme/index.ts
@@ -18,6 +18,7 @@ export const getTheme = (
   } = themeCfg?.palette || getPalette(themeCfg?.name);
 
   const isTable = themeCfg?.spreadsheet?.isTableMode();
+  const boldTextDefaultFontWeight = isWindows() ? 'bold' : 700;
 
   return {
     // ------------- Headers -------------------
@@ -25,7 +26,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 700,
+        fontWeight: boldTextDefaultFontWeight,
         fill: basicColors[0],
         opacity: 1,
         textAlign: isTable ? 'center' : 'left',
@@ -34,7 +35,7 @@ export const getTheme = (
       text: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 700,
+        fontWeight: boldTextDefaultFontWeight,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'right',
@@ -93,7 +94,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 700,
+        fontWeight: boldTextDefaultFontWeight,
         fill: basicColors[14],
         linkTextFill: basicColors[6],
         opacity: 1,
@@ -189,7 +190,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 700,
+        fontWeight: boldTextDefaultFontWeight,
         fill: basicColors[0],
         opacity: 1,
         textAlign: 'center',
@@ -275,7 +276,7 @@ export const getTheme = (
       bolderText: {
         fontFamily: FONT_FAMILY,
         fontSize: 12,
-        fontWeight: isWindows() ? 'bold' : 700,
+        fontWeight: boldTextDefaultFontWeight,
         fill: basicColors[13],
         opacity: 1,
         textAlign: 'right',


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
据 [font-weight 定义](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) ，`bold` 应对应 `700` 数字字重。
之前的 500 在 MacOS Chrome 下有粗体效果，但在 Safari 下没有。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|    ![CleanShot 2022-10-21 at 14 58 34@2x](https://user-images.githubusercontent.com/6716092/197132767-ce39e13f-2835-4324-b672-3bb53a9a5d27.png)    |   ![CleanShot 2022-10-21 at 14 56 09@2x](https://user-images.githubusercontent.com/6716092/197132385-3303e97c-0417-4fea-8c03-3f3793f2b922.png)     |
|  ![CleanShot 2022-10-21 at 14 58 10@2x](https://user-images.githubusercontent.com/6716092/197132708-b20d26fd-bc90-4ca2-ad84-ae6cc4d7c100.png) |  ![CleanShot 2022-10-21 at 14 56 49@2x](https://user-images.githubusercontent.com/6716092/197132468-a4062b90-adc9-47c6-8cfc-2245d31cba29.png) |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
