### PR TITLE
feat: 在背景字段标记中添加 文本智能反色

### DIFF
--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -7,6 +7,7 @@ import { PivotDataSet } from '@/data-set';
 import { SpreadSheet, PivotSheet } from '@/sheet-type';
 import { DataCell } from '@/cell';
 import type { PivotFacet } from '@/facet';
+import { DEFAULT_FONT_COLOR, REVERSE_FONT_COLOR } from '@/common';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
@@ -54,11 +55,15 @@ describe('Data Cell Tests', () => {
     test('should return correct formatted value', () => {
       const formatter: Formatter = (_, data) => `${get(data, 'value') * 10}`;
       jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
-
+      // @ts-ignore
       const dataCell = new DataCell(meta, s2);
 
-      // @ts-ignore
-      expect(dataCell.textShape.attr('text')).toEqual('120');
+      expect(dataCell.getTextShape().attr('text')).toEqual('120');
+    });
+
+    test('should get correct text fill color', () => {
+      const dataCell = new DataCell(meta, s2);
+      expect(dataCell.getTextShape().attr('fill')).toEqual(DEFAULT_FONT_COLOR);
     });
   });
   describe('Condition Tests', () => {
@@ -118,7 +123,7 @@ describe('Data Cell Tests', () => {
               field: 'cost',
               mapping() {
                 return {
-                  fill: '#F7B46F',
+                  fill: '#fffae6',
                 };
               },
             },
@@ -130,7 +135,8 @@ describe('Data Cell Tests', () => {
         .getChildByIndex(0)
         // @ts-ignore
         .getChildByIndex(2);
-      expect(get(dataCell, 'backgroundShape.attrs.fill')).toEqual('#F7B46F');
+      expect(get(dataCell, 'backgroundShape.attrs.fill')).toEqual('#fffae6');
+      expect(get(dataCell, 'textShape.attrs.fill')).toEqual(DEFAULT_FONT_COLOR);
     });
 
     test('should draw condition interval shape', () => {
@@ -168,6 +174,30 @@ describe('Data Cell Tests', () => {
       expect(get(dataCell, 'conditionIntervalShape.attrs.width')).toEqual(
         cellWidth,
       );
+    });
+
+    test('should draw right condition text font color when background color brightness is low', () => {
+      s2.setOptions({
+        conditions: {
+          background: [
+            {
+              field: 'cost',
+              mapping() {
+                return {
+                  fill: '#000000',
+                };
+              },
+            },
+          ],
+        },
+      });
+      s2.render();
+      const dataCell = s2.facet.panelGroup
+        .getChildByIndex(0)
+        // @ts-ignore
+        .getChildByIndex(2);
+      expect(get(dataCell, 'textShape.attrs.fill')).toEqual(REVERSE_FONT_COLOR);
+      expect(get(dataCell, 'backgroundShape.attrs.fill')).toEqual('#000000');
     });
   });
 });

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -176,7 +176,32 @@ describe('Data Cell Tests', () => {
       );
     });
 
-    test('should draw right condition text font color when background color brightness is low', () => {
+    test('should draw REVERSE_FONT_COLOR on text when background low brightness and intelligentReverseTextColor is true', () => {
+      s2.setOptions({
+        conditions: {
+          background: [
+            {
+              field: 'cost',
+              mapping() {
+                return {
+                  fill: '#000000',
+                  intelligentReverseTextColor: true,
+                };
+              },
+            },
+          ],
+        },
+      });
+      s2.render();
+      const dataCell = s2.facet.panelGroup
+        .getChildByIndex(0)
+        // @ts-ignore
+        .getChildByIndex(2);
+      expect(get(dataCell, 'textShape.attrs.fill')).toEqual(REVERSE_FONT_COLOR);
+      expect(get(dataCell, 'backgroundShape.attrs.fill')).toEqual('#000000');
+    });
+
+    test('should draw DEFAULT_FONT_COLOR on text when background low brightness and intelligentReverseTextColor is false', () => {
       s2.setOptions({
         conditions: {
           background: [
@@ -196,8 +221,33 @@ describe('Data Cell Tests', () => {
         .getChildByIndex(0)
         // @ts-ignore
         .getChildByIndex(2);
-      expect(get(dataCell, 'textShape.attrs.fill')).toEqual(REVERSE_FONT_COLOR);
+      expect(get(dataCell, 'textShape.attrs.fill')).toEqual(DEFAULT_FONT_COLOR);
       expect(get(dataCell, 'backgroundShape.attrs.fill')).toEqual('#000000');
+    });
+
+    test('should draw DEFAULT_FONT_COLOR on text when background high brightness is and intelligentReverseTextColor is true', () => {
+      s2.setOptions({
+        conditions: {
+          background: [
+            {
+              field: 'cost',
+              mapping() {
+                return {
+                  fill: '#ffffff',
+                  intelligentReverseTextColor: true,
+                };
+              },
+            },
+          ],
+        },
+      });
+      s2.render();
+      const dataCell = s2.facet.panelGroup
+        .getChildByIndex(0)
+        // @ts-ignore
+        .getChildByIndex(2);
+      expect(get(dataCell, 'textShape.attrs.fill')).toEqual(DEFAULT_FONT_COLOR);
+      expect(get(dataCell, 'backgroundShape.attrs.fill')).toEqual('#ffffff');
     });
   });
 });

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -7,7 +7,10 @@ import { PivotDataSet } from '@/data-set';
 import { SpreadSheet, PivotSheet } from '@/sheet-type';
 import { DataCell } from '@/cell';
 import type { PivotFacet } from '@/facet';
-import { DEFAULT_FONT_COLOR, REVERSE_FONT_COLOR } from '@/common';
+import {
+  DEFAULT_FONT_COLOR,
+  REVERSE_FONT_COLOR,
+} from '@/common/constant/condition';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -58,7 +58,6 @@ describe('Data Cell Tests', () => {
     test('should return correct formatted value', () => {
       const formatter: Formatter = (_, data) => `${get(data, 'value') * 10}`;
       jest.spyOn(s2.dataSet, 'getFieldFormatter').mockReturnValue(formatter);
-      // @ts-ignore
       const dataCell = new DataCell(meta, s2);
 
       expect(dataCell.getTextShape().attr('text')).toEqual('120');

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -25,10 +25,10 @@ import { getIconPositionCfg } from '../utils/condition/condition';
 import { renderLine, renderRect, updateShapeAttr } from '../utils/g-renders';
 import { drawInterval } from '../utils/g-mini-charts';
 import {
-  FONT_COLOR_BRIGHTNESS_THRESHOLD,
   DEFAULT_FONT_COLOR,
+  FONT_COLOR_BRIGHTNESS_THRESHOLD,
   REVERSE_FONT_COLOR,
-} from '../utils';
+} from '../common';
 
 /**
  * DataCell for panelGroup area
@@ -186,12 +186,14 @@ export class DataCell extends BaseCell<ViewMeta> {
    */
   private getDefaultTextFill(textStyle: TextTheme) {
     let textFill = textStyle.fill;
-    const { backgroundColor } = this.getBackgroundColor();
+    const { backgroundColor, intelligentReverseTextColor } =
+      this.getBackgroundColor();
     // text 默认为黑色，当背景颜色亮度过低时，修改 text 为白色
     if (
       tinycolor(backgroundColor).getBrightness() <=
         FONT_COLOR_BRIGHTNESS_THRESHOLD &&
-      textStyle.fill === DEFAULT_FONT_COLOR
+      textStyle.fill === DEFAULT_FONT_COLOR &&
+      intelligentReverseTextColor
     ) {
       textFill = REVERSE_FONT_COLOR;
     }
@@ -287,13 +289,19 @@ export class DataCell extends BaseCell<ViewMeta> {
 
     // get background condition fill color
     const bgCondition = this.findFieldCondition(this.conditions?.background);
+    let intelligentReverseTextColor = false;
     if (bgCondition && bgCondition.mapping) {
       const attrs = this.mappingValue(bgCondition);
       if (attrs) {
         backgroundColor = attrs.fill;
+        intelligentReverseTextColor = attrs.intelligentReverseTextColor;
       }
     }
-    return { backgroundColor, backgroundColorOpacity };
+    return {
+      backgroundColor,
+      backgroundColorOpacity,
+      intelligentReverseTextColor,
+    };
   }
 
   /**

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -28,7 +28,7 @@ import {
   DEFAULT_FONT_COLOR,
   FONT_COLOR_BRIGHTNESS_THRESHOLD,
   REVERSE_FONT_COLOR,
-} from '../common';
+} from '../common/constant/condition';
 
 /**
  * DataCell for panelGroup area

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -185,22 +185,6 @@ export class DataCell extends BaseCell<ViewMeta> {
    * @private
    */
   private getDefaultTextFill(textStyle: TextTheme) {
-    const { backgroundColor, intelligentReverseTextColor } =
-      this.getBackgroundColor();
-
-    if(!intelligentReverseTextColor) {
-      return textStyle.fill
-    }
-
-    // text 默认为黑色，当背景颜色亮度过低时，修改 text 为白色
-    const isMoreThanThreshold = tinycolor(backgroundColor).getBrightness() <=
-        FONT_COLOR_BRIGHTNESS_THRESHOLD
-    if (isMoreThanThreshold && textStyle.fill === DEFAULT_FONT_COLOR) {
-      return REVERSE_FONT_COLOR;
-    }
-
-    return textStyle.fill
-  }
     let textFill = textStyle.fill;
     const { backgroundColor, intelligentReverseTextColor } =
       this.getBackgroundColor();

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -188,10 +188,14 @@ export class DataCell extends BaseCell<ViewMeta> {
     let textFill = textStyle.fill;
     const { backgroundColor, intelligentReverseTextColor } =
       this.getBackgroundColor();
+
+    const isMoreThanThreshold =
+      tinycolor(backgroundColor).getBrightness() <=
+      FONT_COLOR_BRIGHTNESS_THRESHOLD;
+
     // text 默认为黑色，当背景颜色亮度过低时，修改 text 为白色
     if (
-      tinycolor(backgroundColor).getBrightness() <=
-        FONT_COLOR_BRIGHTNESS_THRESHOLD &&
+      isMoreThanThreshold &&
       textStyle.fill === DEFAULT_FONT_COLOR &&
       intelligentReverseTextColor
     ) {

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -185,6 +185,22 @@ export class DataCell extends BaseCell<ViewMeta> {
    * @private
    */
   private getDefaultTextFill(textStyle: TextTheme) {
+    const { backgroundColor, intelligentReverseTextColor } =
+      this.getBackgroundColor();
+
+    if(!intelligentReverseTextColor) {
+      return textStyle.fill
+    }
+
+    // text 默认为黑色，当背景颜色亮度过低时，修改 text 为白色
+    const isMoreThanThreshold = tinycolor(backgroundColor).getBrightness() <=
+        FONT_COLOR_BRIGHTNESS_THRESHOLD
+    if (isMoreThanThreshold && textStyle.fill === DEFAULT_FONT_COLOR) {
+      return REVERSE_FONT_COLOR;
+    }
+
+    return textStyle.fill
+  }
     let textFill = textStyle.fill;
     const { backgroundColor, intelligentReverseTextColor } =
       this.getBackgroundColor();

--- a/packages/s2-core/src/common/constant/condition.ts
+++ b/packages/s2-core/src/common/constant/condition.ts
@@ -1,2 +1,9 @@
 export const VALUE_RANGES_KEY = 'valueRanges';
 export const DEFAULT_VALUE_RANGES = {};
+/**
+ * 亮度范围 0~255
+ * @see https://github.com/bgrins/TinyColor#getbrightness
+ */
+export const FONT_COLOR_BRIGHTNESS_THRESHOLD = 220;
+export const DEFAULT_FONT_COLOR = '#000000';
+export const REVERSE_FONT_COLOR = '#FFFFFF';

--- a/packages/s2-core/src/common/interface/condition.ts
+++ b/packages/s2-core/src/common/interface/condition.ts
@@ -14,6 +14,11 @@ export interface MappingResult extends ValueRange {
   fill: string;
   // only used in interval condition
   isCompare?: boolean;
+  /**
+   * @description only used in background condition, when the background color is too light, the font color will be white
+   * @version 1.34.0
+   */
+  intelligentReverseTextColor?: boolean;
 }
 
 export type MappingFunction = (

--- a/packages/s2-core/src/utils/color.ts
+++ b/packages/s2-core/src/utils/color.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_FONT_COLOR,
   FONT_COLOR_BRIGHTNESS_THRESHOLD,
   REVERSE_FONT_COLOR,
-} from '../common';
+} from '../common/constant/condition';
 
 /** S2 标准色板 mix 规则 */
 const STANDARD_COLOR_MIX_PERCENT = [95, 85, 75, 30, 15, 0, 15, 30, 45, 60, 80];

--- a/packages/s2-core/src/utils/color.ts
+++ b/packages/s2-core/src/utils/color.ts
@@ -7,6 +7,8 @@ import {
   REVERSE_FONT_COLOR,
 } from '../common/constant/condition';
 
+const WHITE_COLOR = '#FFFFFF';
+const BLACK_COLOR = '#000000';
 
 /** S2 标准色板 mix 规则 */
 const STANDARD_COLOR_MIX_PERCENT = [95, 85, 75, 30, 15, 0, 15, 30, 45, 60, 80];
@@ -57,7 +59,7 @@ export const generateStandardColors = (brandColor: string): string[] => {
             tinycolor
               .mix(
                 brandColor,
-                index < 5 ? DEFAULT_FONT_COLOR : REVERSE_FONT_COLOR,
+                index < 5 ? WHITE_COLOR : BLACK_COLOR,
                 mixPercent,
               )
               .toHexString(),
@@ -76,7 +78,9 @@ export const generateStandardColors = (brandColor: string): string[] => {
 export const generatePalette = (
   paletteMeta: PaletteMeta = {} as PaletteMeta,
 ): Palette => {
-  const basicColors = Array.from(Array(BASIC_COLOR_COUNT)).fill(DEFAULT_FONT_COLOR);
+  const basicColors = Array.from(Array(BASIC_COLOR_COUNT)).fill(
+    REVERSE_FONT_COLOR,
+  );
   const { basicColorRelations = [], brandColor } = paletteMeta;
   const standardColors = generateStandardColors(brandColor);
 

--- a/packages/s2-core/src/utils/color.ts
+++ b/packages/s2-core/src/utils/color.ts
@@ -1,13 +1,10 @@
 import tinycolor from 'tinycolor2';
 import type { Palette, PaletteMeta } from '../common/interface/theme';
-
-/**
- * 亮度范围 0~255
- * @see https://github.com/bgrins/TinyColor#getbrightness
- */
-export const FONT_COLOR_BRIGHTNESS_THRESHOLD = 220;
-export const DEFAULT_FONT_COLOR = '#000000';
-export const REVERSE_FONT_COLOR = '#FFFFFF';
+import {
+  DEFAULT_FONT_COLOR,
+  FONT_COLOR_BRIGHTNESS_THRESHOLD,
+  REVERSE_FONT_COLOR,
+} from '../common';
 
 /** S2 标准色板 mix 规则 */
 const STANDARD_COLOR_MIX_PERCENT = [95, 85, 75, 30, 15, 0, 15, 30, 45, 60, 80];

--- a/packages/s2-core/src/utils/color.ts
+++ b/packages/s2-core/src/utils/color.ts
@@ -5,7 +5,9 @@ import type { Palette, PaletteMeta } from '../common/interface/theme';
  * 亮度范围 0~255
  * @see https://github.com/bgrins/TinyColor#getbrightness
  */
-const FONT_COLOR_BRIGHTNESS_THRESHOLD = 220;
+export const FONT_COLOR_BRIGHTNESS_THRESHOLD = 220;
+export const DEFAULT_FONT_COLOR = '#000000';
+export const REVERSE_FONT_COLOR = '#FFFFFF';
 
 /** S2 标准色板 mix 规则 */
 const STANDARD_COLOR_MIX_PERCENT = [95, 85, 75, 30, 15, 0, 15, 30, 45, 60, 80];
@@ -83,8 +85,8 @@ export const generatePalette = (paletteMeta: PaletteMeta) => {
     basicColors[fontColorIndex] =
       tinycolor(basicColors[bgColorIndex]).getBrightness() >
       FONT_COLOR_BRIGHTNESS_THRESHOLD
-        ? '#000000'
-        : '#FFFFFF';
+        ? DEFAULT_FONT_COLOR
+        : REVERSE_FONT_COLOR;
   });
 
   return {

--- a/s2-site/docs/common/conditions.zh.md
+++ b/s2-site/docs/common/conditions.zh.md
@@ -44,6 +44,9 @@ type MappingFunction = (
   isCompare?: boolean;
   minValue?: number;
   maxValue?: number;
+  
+  // 仅用于背景字段标记，可选。（当背景颜色较暗，将文本颜色设置为白色。优先级低于 文本字段标记）
+  intelligentReverseTextColor?: boolean;
 } | null | undefined // 返回值为空时，表示当前字段不显示字段标记样式
 
 ```

--- a/s2-site/docs/manual/basic/conditions.zh.md
+++ b/s2-site/docs/manual/basic/conditions.zh.md
@@ -132,7 +132,7 @@ const s2Options = {
 
 <playground path="analysis/conditions/demo/bidirectional-interval.ts" rid='bidirectional'></playground>
 
-​📊 查看更多 [字段标记示例](/zh/examples/analysis/conditions#text)。
+​📊 查看更多 [字段标记示例](/zh/examples/analysis/conditions#bidirectional-interval)。
 
 ### 渐变柱状图
 
@@ -141,4 +141,14 @@ const s2Options = {
 `price` 字段使用渐变色：
 <playground path="analysis/conditions/demo/gradient-interval.ts" rid='gradient'></playground>
 
-​📊 查看更多 [字段标记示例](/zh/examples/analysis/conditions#text)。
+​📊 查看更多 [字段标记示例](/zh/examples/analysis/conditions#gradient-interval)。
+
+### 开启文字智能反色
+
+通过显示指定 `background` 字段标记中的 `mapping` 函数返回值  `intelligentReverseTextColor` 属性值为 `true`。
+当标记背景颜色较暗时，文本颜色将变为白色。当标记背景颜色明亮时，文本颜色默认为黑色。
+优先级： `background condition` 的 `intelligentReverseTextColor` < `text condition` 的 `fill`
+
+<playground path="analysis/conditions/demo/intelligent-background.ts" rid='intelligentReverseTextColor'></playground>
+
+​📊 查看更多 [字段标记示例](/zh/examples/analysis/conditions#intelligent-background)。

--- a/s2-site/examples/analysis/conditions/demo/intelligent-background.ts
+++ b/s2-site/examples/analysis/conditions/demo/intelligent-background.ts
@@ -1,0 +1,34 @@
+import { PivotSheet } from '@antv/s2';
+
+fetch(
+  'https://gw.alipayobjects.com/os/bmw-prod/2a5dbbc8-d0a7-4d02-b7c9-34f6ca63cff6.json',
+)
+  .then((res) => res.json())
+  .then((dataCfg) => {
+    const container = document.getElementById('container');
+
+    const s2Options = {
+      width: 600,
+      height: 480,
+      interaction: {
+        hoverHighlight: false,
+      },
+      conditions: {
+        background: [
+          {
+            field: 'number',
+            mapping() {
+              return {
+                // fill 是背景字段下唯一必须的字段，用于指定文本颜色
+                fill: '#000',
+                intelligentReverseTextColor: true,
+              };
+            },
+          },
+        ],
+      },
+    };
+    const s2 = new PivotSheet(container, dataCfg, s2Options);
+
+    s2.render();
+  });

--- a/s2-site/examples/analysis/conditions/demo/meta.json
+++ b/s2-site/examples/analysis/conditions/demo/meta.json
@@ -75,6 +75,14 @@
         "en": "Bidirectional interval"
       },
       "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/oUICMHjOA/7fd723cb-fc2a-45a5-a0ab-a2840127a48a.png"
+    },
+    {
+      "filename": "intelligent-background.ts",
+      "title": {
+        "zh": "开启文字智能反色",
+        "en": "Intelligent background"
+      },
+      "screenshot": "https://gw.alipayobjects.com/zos/antfincdn/oUICMHjOA/7fd723cb-fc2a-45a5-a0ab-a2840127a48a.png"
     }
   ]
 }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [X] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [X] Test case
- [X] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
通过显示指定 `background` 字段标记中的 `mapping` 函数返回值  `intelligentReverseTextColor` 属性值为 `true`。

当标记背景颜色较暗时，文本颜色将变为白色。当标记背景颜色明亮时，文本颜色默认为黑色。

优先级： `background condition` 的 `intelligentReverseTextColor` < `text condition` 的 `fill`

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| <img width="567" alt="image" src="https://user-images.githubusercontent.com/20497176/197137662-ba48220b-35a3-441b-85c7-39f0b9abd79f.png"> |<img width="568" alt="image" src="https://user-images.githubusercontent.com/20497176/197137550-e9f0f543-23aa-42c7-968a-dda5913babff.png"> |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
