### PR TITLE
fix(theme): 获取标准色时增加容错和兜底

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/color-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/color-spec.ts
@@ -1,5 +1,5 @@
 import { getPalette } from '@/utils';
-import { generatePalette } from '@/utils/color';
+import { generatePalette, generateStandardColors } from '@/utils/color';
 
 const expectThemeColor = '#F1535F';
 const expectThemePalette = [
@@ -20,7 +20,7 @@ const expectThemePalette = [
   '#000000',
 ];
 
-describe('color test', () => {
+describe('Theme Color Tests', () => {
   test('should generate palette', () => {
     const colorfulPalette = getPalette('colorful');
     const palette = generatePalette({
@@ -45,5 +45,37 @@ describe('color test', () => {
       brandColor: '#000000',
     });
     expect(blackTextPalette.basicColors[0]).toEqual('#FFFFFF');
+  });
+
+  test('should not throw error when receive empty palette meta', () => {
+    function renderEmptyPalette() {
+      generatePalette();
+    }
+    expect(renderEmptyPalette).not.toThrowError();
+  });
+
+  test('should not throw error when receive empty brand color', () => {
+    function renderStandardColors() {
+      generateStandardColors(undefined);
+    }
+    expect(renderStandardColors).not.toThrowError();
+  });
+
+  test('should get standard color if brand color is empty', () => {
+    const colors = [
+      '#F2F2F2',
+      '#D9D9D9',
+      '#BFBFBF',
+      '#4D4D4D',
+      '#262626',
+      '',
+      '#000000',
+      '#000000',
+      '#000000',
+      '#000000',
+      '#000000',
+    ];
+    expect(generateStandardColors(undefined)).toEqual(colors);
+    expect(generateStandardColors('')).toEqual(colors);
   });
 });

--- a/packages/s2-core/src/utils/color.ts
+++ b/packages/s2-core/src/utils/color.ts
@@ -1,5 +1,9 @@
+import { toUpper } from 'lodash';
 import tinycolor from 'tinycolor2';
 import type { Palette, PaletteMeta } from '../common/interface/theme';
+
+const WHITE_COLOR = '#FFFFFF';
+const BLACK_COLOR = '#000000';
 
 /**
  * 亮度范围 0~255
@@ -44,18 +48,23 @@ const FONT_COLOR_RELATIONS: Array<{
  * @param brandColor 主题色
  * @returns 标准色卡
  */
-export const generateStandardColors = (brandColor: string) => {
-  const standardColors = [];
+export const generateStandardColors = (brandColor: string): string[] => {
+  const standardColors: string[] = [];
 
   for (let index = 0; index < 11; index++) {
     const mixPercent = STANDARD_COLOR_MIX_PERCENT[index];
     standardColors.push(
       mixPercent === 0
-        ? brandColor.toUpperCase()
-        : tinycolor
-            .mix(brandColor, index < 5 ? '#FFFFFF' : '#000000', mixPercent)
-            .toHexString()
-            .toUpperCase(),
+        ? toUpper(brandColor)
+        : toUpper(
+            tinycolor
+              .mix(
+                brandColor,
+                index < 5 ? WHITE_COLOR : BLACK_COLOR,
+                mixPercent,
+              )
+              .toHexString(),
+          ),
     );
   }
 
@@ -64,13 +73,15 @@ export const generateStandardColors = (brandColor: string) => {
 
 /**
  * 根据 S2 内置色板及自选主题色生成新色板
- * @param palette 参考色板
+ * @param paletteMeta @PaletteMeta
  * @returns 新色板
  */
-export const generatePalette = (paletteMeta: PaletteMeta) => {
-  const basicColors = Array.from(Array(BASIC_COLOR_COUNT)).fill('#FFFFFF');
-  const { basicColorRelations } = paletteMeta;
-  const standardColors = generateStandardColors(paletteMeta.brandColor);
+export const generatePalette = (
+  paletteMeta: PaletteMeta = {} as PaletteMeta,
+): Palette => {
+  const basicColors = Array.from(Array(BASIC_COLOR_COUNT)).fill(WHITE_COLOR);
+  const { basicColorRelations = [], brandColor } = paletteMeta;
+  const standardColors = generateStandardColors(brandColor);
 
   // 使用标准色填充 basicColors
   basicColorRelations.forEach((relation) => {
@@ -83,8 +94,8 @@ export const generatePalette = (paletteMeta: PaletteMeta) => {
     basicColors[fontColorIndex] =
       tinycolor(basicColors[bgColorIndex]).getBrightness() >
       FONT_COLOR_BRIGHTNESS_THRESHOLD
-        ? '#000000'
-        : '#FFFFFF';
+        ? BLACK_COLOR
+        : WHITE_COLOR;
   });
 
   return {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

🐛 Bugfix

- [ ] Solve the issue and close #0

### 📝 Description

增加 `generateStandardColors` 的容错, 避免 `brandColor` 为空时 `toUpperCase` 报错

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
