### PR TITLE
feat : 给 setDataCfg 和 setOptions 添加重置字段

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -272,4 +272,65 @@ describe('SpreadSheet Tests', () => {
       expect(container.querySelectorAll('canvas')).toHaveLength(1);
     });
   });
+
+  describe('Sheet Config Change Tests', () => {
+    let container: HTMLElement;
+
+    beforeAll(() => {
+      container = getContainer();
+    });
+
+    afterAll(() => {
+      container?.remove();
+    });
+
+    test('should update total Data when user change totalData config', () => {
+      const totalData = [
+        {
+          province: '浙江',
+          type: '笔',
+          price: 3,
+          cost: 6,
+        },
+      ];
+      const s2 = new PivotSheet(
+        container,
+        { ...mockDataConfig, totalData },
+        s2Options,
+      );
+      s2.render();
+
+      expect(s2.dataSet.totalData).toEqual([
+        {
+          $$extra$$: 'price',
+          $$value$$: 3,
+          cost: 6,
+          price: 3,
+          province: '浙江',
+          type: '笔',
+        },
+        {
+          $$extra$$: 'cost',
+          $$value$$: 6,
+          cost: 6,
+          price: 3,
+          province: '浙江',
+          type: '笔',
+        },
+      ]);
+      expect(s2.dataCfg.totalData).toEqual(totalData);
+
+      // 改变 totalData 为 undefined 再次渲染
+      s2.setDataCfg({ ...mockDataConfig, totalData: undefined });
+      s2.render();
+
+      expect(s2.dataSet.totalData).toEqual([]);
+      expect(s2.dataCfg.fields).toEqual({
+        ...mockDataConfig.fields,
+        customTreeItems: [],
+      });
+      expect(s2.dataCfg.totalData).toEqual([]);
+      s2.destroy();
+    });
+  });
 });

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -1,7 +1,8 @@
 import * as mockDataConfig from 'tests/data/simple-data.json';
 import { getContainer, sleep } from 'tests/util/helpers';
+import { omit, pick } from 'lodash';
 import { PivotSheet, TableSheet } from '@/sheet-type';
-import { S2Event, type S2Options } from '@/common';
+import { DEFAULT_OPTIONS, S2Event, type S2Options } from '@/common';
 
 const s2Options: S2Options = {
   width: 200,
@@ -284,7 +285,7 @@ describe('SpreadSheet Tests', () => {
       container?.remove();
     });
 
-    test('should update total Data when user change totalData config', () => {
+    test('should update all Data Config when reset is true', () => {
       const totalData = [
         {
           province: '浙江',
@@ -321,7 +322,7 @@ describe('SpreadSheet Tests', () => {
       expect(s2.dataCfg.totalData).toEqual(totalData);
 
       // 改变 totalData 为 undefined 再次渲染
-      s2.setDataCfg({ ...mockDataConfig, totalData: undefined });
+      s2.setDataCfg({ ...mockDataConfig, totalData: undefined }, true);
       s2.render();
 
       expect(s2.dataSet.totalData).toEqual([]);
@@ -331,6 +332,97 @@ describe('SpreadSheet Tests', () => {
       });
       expect(s2.dataCfg.totalData).toEqual([]);
       s2.destroy();
+    });
+
+    test('should update all Data Config when reset is false', () => {
+      const totalData = [
+        {
+          province: '浙江',
+          type: '笔',
+          price: 3,
+          cost: 6,
+        },
+      ];
+      const s2 = new PivotSheet(
+        container,
+        { ...mockDataConfig, totalData },
+        s2Options,
+      );
+      s2.render();
+
+      const totalDataSet = [
+        {
+          $$extra$$: 'price',
+          $$value$$: 3,
+          cost: 6,
+          price: 3,
+          province: '浙江',
+          type: '笔',
+        },
+        {
+          $$extra$$: 'cost',
+          $$value$$: 6,
+          cost: 6,
+          price: 3,
+          province: '浙江',
+          type: '笔',
+        },
+      ];
+
+      // 改变 totalData 为 undefined 再次渲染
+      s2.setDataCfg({ ...mockDataConfig, totalData: undefined }, false);
+      s2.render();
+
+      expect(s2.dataSet.totalData).toEqual(totalDataSet);
+      expect(s2.dataCfg.fields).toEqual({
+        ...mockDataConfig.fields,
+        customTreeItems: [],
+      });
+      expect(s2.dataCfg.totalData).toEqual(totalData);
+      s2.destroy();
+    });
+
+    test('should update all Options when reset is true', () => {
+      const s2 = new PivotSheet(container, mockDataConfig, s2Options);
+      s2.render();
+      const emitAttrs = ['width', 'height', 'hierarchyType', 'hdAdapter'];
+      const partialOptions = pick(s2.options, emitAttrs);
+      expect(partialOptions).toEqual(s2Options);
+
+      s2.setOptions(
+        {
+          width: 300,
+          hdAdapter: false,
+        },
+        true,
+      );
+      expect(pick(s2.options, emitAttrs)).toEqual({
+        height: DEFAULT_OPTIONS.height,
+        hierarchyType: DEFAULT_OPTIONS.hierarchyType,
+        width: 300,
+        hdAdapter: false,
+      });
+    });
+
+    test('should update all Options when reset is false', () => {
+      const s2 = new PivotSheet(container, mockDataConfig, s2Options);
+      s2.render();
+      const emitAttrs = ['width', 'height', 'hierarchyType', 'hdAdapter'];
+
+      s2.setOptions(
+        {
+          width: 300,
+          hdAdapter: false,
+        },
+        false,
+      );
+
+      expect(pick(s2.options, emitAttrs)).toEqual({
+        height: s2Options.height,
+        hierarchyType: s2Options.hierarchyType,
+        width: 300,
+        hdAdapter: false,
+      });
     });
   });
 });

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -66,7 +66,6 @@ import {
   customMerge,
   getSafetyDataConfig,
   getSafetyOptions,
-  dataCfgPatch,
 } from '../utils/merge';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
 import { removeOffscreenCanvas } from '../utils/canvas';
@@ -360,18 +359,26 @@ export abstract class SpreadSheet extends EE {
    * Group sort params kept in {@see store} and
    * Priority: group sort > advanced sort
    * @param dataCfg
+   * @param reset reset: true, 直接使用用户传入的 DataCfg ，不再与上次数据进行合并
    */
-  public setDataCfg(dataCfg: S2DataConfig) {
+  public setDataCfg(dataCfg: S2DataConfig, reset?: boolean) {
     this.store.set('originalDataCfg', dataCfg);
-    const newDataCfg = dataCfgPatch(dataCfg);
-    this.dataCfg = getSafetyDataConfig(this.dataCfg, newDataCfg);
+    if (reset) {
+      this.dataCfg = getSafetyDataConfig(dataCfg);
+    } else {
+      this.dataCfg = getSafetyDataConfig(this.dataCfg, dataCfg);
+    }
     // clear value ranger after each updated data cfg
     clearValueRangeState(this);
   }
 
-  public setOptions(options: Partial<S2Options>) {
+  public setOptions(options: Partial<S2Options>, reset?: boolean) {
     this.hideTooltip();
-    this.options = customMerge(this.options, options);
+    if (reset) {
+      this.options = getSafetyOptions(options);
+    } else {
+      this.options = customMerge(this.options, options);
+    }
     this.registerIcons();
   }
 

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -66,6 +66,7 @@ import {
   customMerge,
   getSafetyDataConfig,
   getSafetyOptions,
+  dataCfgPatch,
 } from '../utils/merge';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
 import { removeOffscreenCanvas } from '../utils/canvas';
@@ -362,7 +363,8 @@ export abstract class SpreadSheet extends EE {
    */
   public setDataCfg(dataCfg: S2DataConfig) {
     this.store.set('originalDataCfg', dataCfg);
-    this.dataCfg = getSafetyDataConfig(this.dataCfg, dataCfg);
+    const newDataCfg = dataCfgPatch(dataCfg);
+    this.dataCfg = getSafetyDataConfig(this.dataCfg, newDataCfg);
     // clear value ranger after each updated data cfg
     clearValueRangeState(this);
   }

--- a/packages/s2-core/src/utils/merge.ts
+++ b/packages/s2-core/src/utils/merge.ts
@@ -33,24 +33,6 @@ const uniqueFields = (fields: Fields) => {
   };
 };
 
-/**
- * 当用户将 DataCfg 的属性设置为 undefined 时，使用默认值
- * @param dataCfg
- */
-export const dataCfgPatch = (
-  dataCfg: Partial<S2DataConfig>,
-): Partial<S2DataConfig> => {
-  const newDataCfg = {};
-  forEach(dataCfg, (value, key) => {
-    if (value === undefined) {
-      newDataCfg[key] = DEFAULT_DATA_CONFIG[key];
-    } else {
-      newDataCfg[key] = value;
-    }
-  });
-  return newDataCfg;
-};
-
 export const getSafetyDataConfig = (...dataConfig: Partial<S2DataConfig>[]) => {
   const result = customMerge(
     DEFAULT_DATA_CONFIG,

--- a/packages/s2-core/src/utils/merge.ts
+++ b/packages/s2-core/src/utils/merge.ts
@@ -1,4 +1,4 @@
-import { isArray, isEmpty, mergeWith, uniq, isEqual } from 'lodash';
+import { isArray, isEmpty, mergeWith, uniq, isEqual, forEach } from 'lodash';
 import { DEFAULT_DATA_CONFIG } from '../common/constant/dataConfig';
 import { DEFAULT_OPTIONS } from '../common/constant/options';
 import type { S2DataConfig, S2Options, Fields } from '../common/interface';
@@ -31,6 +31,24 @@ const uniqueFields = (fields: Fields) => {
     ...fields,
     ...result,
   };
+};
+
+/**
+ * 当用户将 DataCfg 的属性设置为 undefined 时，使用默认值
+ * @param dataCfg
+ */
+export const dataCfgPatch = (
+  dataCfg: Partial<S2DataConfig>,
+): Partial<S2DataConfig> => {
+  const newDataCfg = {};
+  forEach(dataCfg, (value, key) => {
+    if (value === undefined) {
+      newDataCfg[key] = DEFAULT_DATA_CONFIG[key];
+    } else {
+      newDataCfg[key] = value;
+    }
+  });
+  return newDataCfg;
 };
 
 export const getSafetyDataConfig = (...dataConfig: Partial<S2DataConfig>[]) => {

--- a/s2-site/docs/api/basic-class/base-data-set.zh.md
+++ b/s2-site/docs/api/basic-class/base-data-set.zh.md
@@ -9,25 +9,25 @@ order: 5
 s2.dataSet.xx()
 ```
 
-| 参数 | 说明 | 类型 |
-| --- | --- | --- |
-| fields | 字段信息 | () => [Fields](/zh/docs/api/general/S2DataConfig#fields) |
-| meta | 字段元信息，包含有字段名、格式化等 | () => [Meta[]](/zh/docs/api/general/S2DataConfig#meta) |
-| originData | 原始数据 | () => [DataType[]](#datatype) |
-| totalData | 汇总数据 | () => [DataType[]](#datatype)  |
-| indexesData | 多维索引数据 | () => [DataType[]](#datatype)  |
-| sortParams | 排序配置 | () => [SortParams](/zh/docs/api/general/S2DataConfig#sortparams) |
-| spreadsheet | 表格实例 | () => [SpreadSheet](/zh/docs/api/basic-class/spreadsheet) |
-| getFieldMeta | 获取字段元数据信息 | (field: string, meta?: [Meta[]](/zh/docs/api/general/S2DataConfig#meta)) => [Meta](/zh/docs/api/general/S2DataConfig#meta) |
-| getFieldName | 获取字段名 | `() => string` |
-| getFieldFormatter | 获取字段格式化函数 | `() => (v: string) => unknown` |
-| getFieldDescription | 获取字段描述 | `() => string` |
-| setDataCfg | 设置数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig), reset?: boolean) => void |
-| getDisplayDataSet | 获取当前显示的数据集 | () => [DataType[]](#datatype)  |
-| getDimensionValues | 获取维值 | (filed: string, query?: [DataType](#datatype) ) => string[] |
-| getCellData | 获取单个的单元格数据 | (params: [CellDataParams](#celldataparams)) => [DataType[]](#datatype) |
-| getMultiData | 获取批量的单元格数据 | (query: [DataType](#datatype), isTotals?: boolean, isRow?: boolean, drillDownFields?: string[]) => [DataType[]](#datatype)|
-| moreThanOneValue | 是否超过 1 个数值 | () => [ViewMeta](#viewmeta) |
+| 参数                | 说明                               | 类型                                                         | 版本                                        |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------- |
+| fields              | 字段信息                           | () => [Fields](/zh/docs/api/general/S2DataConfig#fields)     |                                             |
+| meta                | 字段元信息，包含有字段名、格式化等 | () => [Meta[]](/zh/docs/api/general/S2DataConfig#meta)       |                                             |
+| originData          | 原始数据                           | () => [DataType[]](#datatype)                                |                                             |
+| totalData           | 汇总数据                           | () => [DataType[]](#datatype)                                |                                             |
+| indexesData         | 多维索引数据                       | () => [DataType[]](#datatype)                                |                                             |
+| sortParams          | 排序配置                           | () => [SortParams](/zh/docs/api/general/S2DataConfig#sortparams) |                                             |
+| spreadsheet         | 表格实例                           | () => [SpreadSheet](/zh/docs/api/basic-class/spreadsheet)    |                                             |
+| getFieldMeta        | 获取字段元数据信息                 | (field: string, meta?: [Meta[]](/zh/docs/api/general/S2DataConfig#meta)) => [Meta](/zh/docs/api/general/S2DataConfig#meta) |                                             |
+| getFieldName        | 获取字段名                         | `() => string`                                               |                                             |
+| getFieldFormatter   | 获取字段格式化函数                 | `() => (v: string) => unknown`                               |                                             |
+| getFieldDescription | 获取字段描述                       | `() => string`                                               |                                             |
+| setDataCfg          | 设置数据配置                       | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig), reset?: boolean) => void | `reset` 参数需在 `@antv/s2-v1.34.0`版本使用 |
+| getDisplayDataSet   | 获取当前显示的数据集               | () => [DataType[]](#datatype)                                |                                             |
+| getDimensionValues  | 获取维值                           | (filed: string, query?: [DataType](#datatype) ) => string[]  |                                             |
+| getCellData         | 获取单个的单元格数据               | (params: [CellDataParams](#celldataparams)) => [DataType[]](#datatype) |                                             |
+| getMultiData        | 获取批量的单元格数据               | (query: [DataType](#datatype), isTotals?: boolean, isRow?: boolean, drillDownFields?: string[]) => [DataType[]](#datatype) |                                             |
+| moreThanOneValue    | 是否超过 1 个数值                  | () => [ViewMeta](#viewmeta)                                  |                                             |
 
 ### DataType
 

--- a/s2-site/docs/api/basic-class/base-data-set.zh.md
+++ b/s2-site/docs/api/basic-class/base-data-set.zh.md
@@ -22,7 +22,7 @@ s2.dataSet.xx()
 | getFieldName | 获取字段名 | `() => string` |
 | getFieldFormatter | 获取字段格式化函数 | `() => (v: string) => unknown` |
 | getFieldDescription | 获取字段描述 | `() => string` |
-| setDataCfg | 设置数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig)) => void |
+| setDataCfg | 设置数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig), reset?: boolean) => void |
 | getDisplayDataSet | 获取当前显示的数据集 | () => [DataType[]](#datatype)  |
 | getDimensionValues | 获取维值 | (filed: string, query?: [DataType](#datatype) ) => string[] |
 | getCellData | 获取单个的单元格数据 | (params: [CellDataParams](#celldataparams)) => [DataType[]](#datatype) |

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -49,8 +49,8 @@ s2.xx()
 | hideTooltip | 隐藏 tooltip | `() => void` |
 | destroyTooltip | 销毁 tooltip | `() => void` |
 | registerIcons | 注册 自定义 svg 图标 （根据 `options.customSVGIcons`) | `() => void` |
-| setDataCfg | 更新数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig) ) => void |
-| setOptions | 更新表格配置 | (options: [S2Options](/zh/docs/api/general/S2Options)) => void |
+| setDataCfg | 更新数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig), reset?: boolean ) => void |
+| setOptions | 更新表格配置 | (options: [S2Options](/zh/docs/api/general/S2Options), reset?: boolean) => void |
 | render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据，`reBuildDataSet` = true, 重新构建数据集，`reBuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean, { reBuildDataSet?: boolean; reBuildHiddenColumnsDetail?: boolean }) => void` |
 | destroy | 销毁表格 | `() => void` |
 | setThemeCfg | 更新主题配置 （含主题 schema, 色板，主题名） | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme/#themecfg)) => void |

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -11,67 +11,67 @@ const s2 = new PivotSheet()
 s2.xx()
 ```
 
-| 参数 | 说明 | 类型 |
-| --- | --- | --- |
-| dom | 挂载的容器节点 | `string` \| `HTMLElement` |
-| theme | 主题配置 | [S2Theme](/zh/docs/api/general/S2Theme) |
-| store | 存储的一些信息 | [Store](/zh/docs/api/basic-class/store) |
-| dataCfg | 数据配置 | [S2DataConfig](/zh/docs/api/general/S2DataConfig) |
-| options | 表格配置 | [S2Options](/zh/docs/api/general/S2Options) |
-| dataSet | 表格数据集 （字段，数据，排序） | [BaseDataSet](/zh/docs/api/basic-class/base-data-set) |
-| facet | 当前可视渲染区域 | [BaseFacet](/zh/docs/api/basic-class/base-facet) |
-| tooltip | tooltip | [BaseTooltip](/zh/docs/api/basic-class/base-tooltip) |
-| container | g-canvas 实例 | [Canvas](https://g.antv.vision/zh/docs/api/canvas) |
-| backgroundGroup | 背景颜色区域 group | [Group](https://g.antv.vision/zh/docs/api/group) |
-| foregroundGroup | 背景颜色区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| panelGroup | 可视范围单元格区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| panelScrollGroup | 可视范围单元格滚动区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| frozenRowGroup | 行头冻结区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| frozenColGroup | 列头冻结区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| frozenTrailingRowGroup | 行头底部冻结区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| frozenTrailingColGroup | 列头底部冻结区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| frozenTopGroup | 顶部冻结区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| frozenBottomGroup | 底部冻结区域 group |  [Group](https://g.antv.vision/zh/docs/api/group) |
-| interaction | 交互 |  [Interaction](/zh/docs/api/basic-class/interaction) |
-| hdAdapter | 高清适配 | [HdAdapter](https://github.com/antvis/S2/blob/master/packages/s2-core/src/ui/hd-adapter/index.ts) |
-| on | 事件订阅 | (event: [S2Event](/zh/docs/manual/advanced/interaction/basic), listener: () => void) => void |
-| emit | 事件发布 | (event: [S2Event](/zh/docs/manual/advanced/interaction/basic), ...args: any[]) => void |
-| getDataSet | 获取数据集 | (options: [S2Options](/zh/docs/api/general/S2Options)) => [BaseDataSet](/zh/docs/api/basic-class/base-data-set) |
-| isPivotMode | 是否是透视表 | `() => boolean` |
-| isHierarchyTreeType | 是否是树状结构 | `() => boolean` |
-| isScrollContainsRowHeader | 是否是包含行头的滚动 | `() => boolean` |
-| isFrozenRowHeader | 是否是冻结行头状态 | `() => boolean` |
-| isTableMode | 是否是明细表 | `() => boolean` |
-| isValueInCols | 是否是数值置于行头 | `() => boolean` |
-| clearDrillDownData | 清除下钻数据 | `(rowNodeId?: string) => void` |
-| showTooltip | 显示 tooltip | (showOptions: [TooltipShowOptions](/zh/docs/api/common/custom-tooltip)) => void |
-| showTooltipWithInfo |  显示 tooltip, 并且展示一些默认信息 | (event: `CanvasEvent | MouseEvent`, data: [TooltipData[]](/zh/docs/api/common/custom-tooltip), options?: [TooltipOptions](/zh/docs/api/common/custom-tooltip)) => void |
-| hideTooltip | 隐藏 tooltip | `() => void` |
-| destroyTooltip | 销毁 tooltip | `() => void` |
-| registerIcons | 注册 自定义 svg 图标 （根据 `options.customSVGIcons`) | `() => void` |
-| setDataCfg | 更新数据配置 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig), reset?: boolean ) => void |
-| setOptions | 更新表格配置 | (options: [S2Options](/zh/docs/api/general/S2Options), reset?: boolean) => void |
-| render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据，`reBuildDataSet` = true, 重新构建数据集，`reBuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean, { reBuildDataSet?: boolean; reBuildHiddenColumnsDetail?: boolean }) => void` |
-| destroy | 销毁表格 | `() => void` |
-| setThemeCfg | 更新主题配置 （含主题 schema, 色板，主题名） | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme/#themecfg)) => void |
-| setTheme | 更新主题 （只包含主题 scheme) | (theme: [S2Theme](/zh/docs/api/general/S2Theme/#s2theme)) => void |
-| updatePagination | 更新分页 | (pagination: [Pagination](/zh/docs/api/general/S2Options#pagination)) => void |
-| getContentHeight | 获取当前表格实际内容高度 | `() => number` |
-| changeSheetSize （别名：changeSize) | 修改表格画布大小，不用重新加载数据 | `(width?: number, height?: number) => void` |
-| getLayoutWidthType | 获取单元格宽度布局类型（LayoutWidthType: `adaptive（自适应）` \| `colAdaptive（列自适应）` \| `compact（紧凑）`） | () => `LayoutWidthType`|
-| getRowNodes | 获取行头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |
-| getRowLeafNodes | 获取行头叶子节点 | () => [Node[]](/zh/docs/api/basic-class/node/) |
-| getColumnNodes | 获取列头节点 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |
-| getColumnLeafNodes | 获取列头叶子节点 | () => [Node[]](/zh/docs/api/basic-class/node/) |
-| updateScrollOffset | 更新滚动偏移 | (config: [OffsetConfig](#offsetconfig)) => void |
-| getCell | 根据 event.target 获取当前 单元格 | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [S2CellType](/zh/docs/api/basic-class/base-cell#s2celltype) |
-| getCellType | 根据 event.target 获取当前 单元格类型 | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [CellTypes](/zh/docs/api/basic-class/base-cell#celltypes) |
-| getTotalsConfig | 获取总计小计配置 | (dimension: string) => [Total](/zh/docs/api/general/S2Options#totals) |
-| getInitColumnLeafNodes | 获取初次渲染的列头叶子节点 （比如：隐藏列头前） | () => [Node[]](/zh/docs/api/basic-class/node/) |
-| getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素 | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |
-| clearColumnLeafNodes | 清空存储在 store 中的初始叶子节点 | () => void |
-| updateSortMethodMap | 更新存储在 store 中的节点排序方式 map, replace 为是否覆盖上一次的值 | (nodeId: string, sortMethod: string, replace?: boolean) => void |
-| getMenuDefaultSelectedKeys | 获取 tooltip 中选中的菜单项 key 值 | `(nodeId: string) => string[]` |
+| 参数 | 说明                                                                                                                     | 类型 | 版本 |
+| --- |------------------------------------------------------------------------------------------------------------------------| --- |----|
+| dom | 挂载的容器节点                                                                                                                | `string` \| `HTMLElement`   |  |
+| theme | 主题配置                                                                                                                   | [S2Theme](/zh/docs/api/general/S2Theme) |    |
+| store | 存储的一些信息                                                                                                                | [Store](/zh/docs/api/basic-class/store) |    |
+| dataCfg | 数据配置                                                                                                                   | [S2DataConfig](/zh/docs/api/general/S2DataConfig) |    |
+| options | 表格配置                                                                                                                   | [S2Options](/zh/docs/api/general/S2Options) |    |
+| dataSet | 表格数据集 （字段，数据，排序）                                                                                                       | [BaseDataSet](/zh/docs/api/basic-class/base-data-set) |    |
+| facet | 当前可视渲染区域                                                                                                               | [BaseFacet](/zh/docs/api/basic-class/base-facet) |    |
+| tooltip | tooltip                                                                                                                | [BaseTooltip](/zh/docs/api/basic-class/base-tooltip) |    |
+| container | g-canvas 实例                                                                                                            | [Canvas](https://g.antv.vision/zh/docs/api/canvas) |    |
+| backgroundGroup | 背景颜色区域 group                                                                                                           | [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| foregroundGroup | 背景颜色区域 group                                                                                                           |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| panelGroup | 可视范围单元格区域 group                                                                                                        |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| panelScrollGroup | 可视范围单元格滚动区域 group                                                                                                      |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| frozenRowGroup | 行头冻结区域 group                                                                                                           |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| frozenColGroup | 列头冻结区域 group                                                                                                           |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| frozenTrailingRowGroup | 行头底部冻结区域 group                                                                                                         |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| frozenTrailingColGroup | 列头底部冻结区域 group                                                                                                         |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| frozenTopGroup | 顶部冻结区域 group                                                                                                           |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| frozenBottomGroup | 底部冻结区域 group                                                                                                           |  [Group](https://g.antv.vision/zh/docs/api/group) |    |
+| interaction | 交互                                                                                                                     |  [Interaction](/zh/docs/api/basic-class/interaction) |    |
+| hdAdapter | 高清适配                                                                                                                   | [HdAdapter](https://github.com/antvis/S2/blob/master/packages/s2-core/src/ui/hd-adapter/index.ts) |    |
+| on | 事件订阅                                                                                                                   | (event: [S2Event](/zh/docs/manual/advanced/interaction/basic), listener: () => void) => void |    |
+| emit | 事件发布                                                                                                                   | (event: [S2Event](/zh/docs/manual/advanced/interaction/basic), ...args: any[]) => void |    |
+| getDataSet | 获取数据集                                                                                                                  | (options: [S2Options](/zh/docs/api/general/S2Options)) => [BaseDataSet](/zh/docs/api/basic-class/base-data-set) |    |
+| isPivotMode | 是否是透视表                                                                                                                 | `() => boolean` |    |
+| isHierarchyTreeType | 是否是树状结构                                                                                                                | `() => boolean` |    |
+| isScrollContainsRowHeader | 是否是包含行头的滚动                                                                                                             | `() => boolean` |    |
+| isFrozenRowHeader | 是否是冻结行头状态                                                                                                              | `() => boolean` |    |
+| isTableMode | 是否是明细表                                                                                                                 | `() => boolean` |    |
+| isValueInCols | 是否是数值置于行头                                                                                                              | `() => boolean` |    |
+| clearDrillDownData | 清除下钻数据                                                                                                                 | `(rowNodeId?: string) => void` |    |
+| showTooltip | 显示 tooltip                                                                                                             | (showOptions: [TooltipShowOptions](/zh/docs/api/common/custom-tooltip)) => void |    |
+| showTooltipWithInfo | 显示 tooltip, 并且展示一些默认信息                                                                                                 | (event: `CanvasEvent |    | MouseEvent`, data: [TooltipData[]](/zh/docs/api/common/custom-tooltip), options?: [TooltipOptions](/zh/docs/api/common/custom-tooltip)) => void |
+| hideTooltip | 隐藏 tooltip                                                                                                             | `() => void` |    |
+| destroyTooltip | 销毁 tooltip                                                                                                             | `() => void` |    |
+| registerIcons | 注册 自定义 svg 图标 （根据 `options.customSVGIcons`)                                                                            | `() => void` |    |
+| setDataCfg | 更新数据配置                                                                                                                 | (dataCfg: [S2DataConfig](/zh/docs/api/general/S2DataConfig), reset?: boolean ) => void | `reset` 参数需在 `@antv/s2-v1.34.0`版本使用  |
+| setOptions | 更新表格配置                                                                                                                 | (options: [S2Options](/zh/docs/api/general/S2Options), reset?: boolean) => void |  `reset` 参数需在 `@antv/s2-v1.34.0`版本使用 |
+| render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据，`reBuildDataSet` = true, 重新构建数据集，`reBuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean, { reBuildDataSet?: boolean; reBuildHiddenColumnsDetail?: boolean }) => void` |    |
+| destroy | 销毁表格                                                                                                                   | `() => void` |    |
+| setThemeCfg | 更新主题配置 （含主题 schema, 色板，主题名）                                                                                            | (themeCfg: [ThemeCfg](/zh/docs/api/general/S2Theme/#themecfg)) => void |    |
+| setTheme | 更新主题 （只包含主题 scheme)                                                                                                    | (theme: [S2Theme](/zh/docs/api/general/S2Theme/#s2theme)) => void |    |
+| updatePagination | 更新分页                                                                                                                   | (pagination: [Pagination](/zh/docs/api/general/S2Options#pagination)) => void |    |
+| getContentHeight | 获取当前表格实际内容高度                                                                                                           | `() => number` |    |
+| changeSheetSize （别名：changeSize) | 修改表格画布大小，不用重新加载数据                                                                                                      | `(width?: number, height?: number) => void` |    |
+| getLayoutWidthType | 获取单元格宽度布局类型（LayoutWidthType: `adaptive（自适应）` \| `colAdaptive（列自适应）` \| `compact（紧凑）`） | () => `LayoutWidthType`|    |
+| getRowNodes | 获取行头节点                                                                                                                 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |    |
+| getRowLeafNodes | 获取行头叶子节点                                                                                                               | () => [Node[]](/zh/docs/api/basic-class/node/) |    |
+| getColumnNodes | 获取列头节点                                                                                                                 | (level: number) => [Node[]](/zh/docs/api/basic-class/node/) |    |
+| getColumnLeafNodes | 获取列头叶子节点                                                                                                               | () => [Node[]](/zh/docs/api/basic-class/node/) |    |
+| updateScrollOffset | 更新滚动偏移                                                                                                                 | (config: [OffsetConfig](#offsetconfig)) => void |    |
+| getCell | 根据 event.target 获取当前 单元格                                                                                               | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [S2CellType](/zh/docs/api/basic-class/base-cell#s2celltype) |    |
+| getCellType | 根据 event.target 获取当前 单元格类型                                                                                             | (target: [EventTarget](https://developer.mozilla.org/zh-CN/docs/Web/API/Event/target)) => [CellTypes](/zh/docs/api/basic-class/base-cell#celltypes) |    |
+| getTotalsConfig | 获取总计小计配置                                                                                                               | (dimension: string) => [Total](/zh/docs/api/general/S2Options#totals) |    |
+| getInitColumnLeafNodes | 获取初次渲染的列头叶子节点 （比如：隐藏列头前）                                                                                               | () => [Node[]](/zh/docs/api/basic-class/node/) |    |
+| getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素                                                                                            | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |    |
+| clearColumnLeafNodes | 清空存储在 store 中的初始叶子节点                                                                                                   | () => void |    |
+| updateSortMethodMap | 更新存储在 store 中的节点排序方式 map, replace 为是否覆盖上一次的值                                                                           | (nodeId: string, sortMethod: string, replace?: boolean) => void |    |
+| getMenuDefaultSelectedKeys | 获取 tooltip 中选中的菜单项 key 值                                                                                               | `(nodeId: string) => string[]` |    |
 
 ### S2MountContainer
 

--- a/s2-site/docs/manual/faq.zh.md
+++ b/s2-site/docs/manual/faq.zh.md
@@ -51,17 +51,31 @@ s2.render(false)
 const pivotSheet = new PivotSheet(document.getElementById('container'), dataCfg, options);
 ```
 
-更新 options: [可选项](/zh/docs/api/general/S2Options)
+更新 options: [可选项](/zh/docs/api/general/S2Options)，会与上次的数据进行合并
 
 ```ts
 pivotSheet.setOptions({ ... })
 pivotSheet.render(false) // 重新渲染，不更新数据
 ```
 
-更新 dataCfg: [可选项](/zh/docs/api/general/S2DataConfig)
+重置 options: [可选项](/zh/docs/api/general/S2Options)，直接使用传入的 option，不会与上次的数据进行合并
+
+```ts
+pivotSheet.setOptions({ ... }, true)
+pivotSheet.render(false) // 重新渲染，不更新数据
+```
+
+更新 dataCfg: [可选项](/zh/docs/api/general/S2DataConfig)，会与上次的数据进行合并
 
 ```ts
 pivotSheet.setDataCfg({ ... })
+pivotSheet.render(true) // 重新渲染，且更新数据
+```
+
+重置 dataCfg: [可选项](/zh/docs/api/general/S2DataConfig)，直接使用传入的 dataCfg，不会与上次的数据进行合并
+
+```ts
+pivotSheet.setDataCfg({ ... }, true)
 pivotSheet.render(true) // 重新渲染，且更新数据
 ```
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #1810 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
现在 setDataCfg 和  setOptions 都只有更新配置的功能，现在很多用户需要直接重置掉之前的配置，传入全新的配置。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
