### PR TITLE
当数值存在非数字时页面白屏问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/number-calculate-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/number-calculate-spec.ts
@@ -18,6 +18,8 @@ describe('Number Calculate Test', () => {
       expect(isNotNumber(null)).toBe(true);
       expect(isNotNumber(undefined)).toBe(true);
       expect(isNotNumber('-')).toBe(true);
+      expect(isNotNumber('2022-10-28')).toBe(true);
+      expect(isNotNumber('1\n2\n3')).toBe(true);
       expect(isNotNumber(NaN)).toBe(true);
       expect(isNotNumber('')).toBe(true);
       expect(isNotNumber(Object.create(null))).toBe(true);

--- a/packages/s2-core/src/utils/number-calculate.ts
+++ b/packages/s2-core/src/utils/number-calculate.ts
@@ -8,6 +8,9 @@ export const isNotNumber = (value: unknown) => {
   if (typeof value === 'number') {
     return Number.isNaN(value);
   }
+  if (!value) {
+    return true;
+  }
   if (typeof value === 'string') {
     return Number.isNaN(Number(value));
   }

--- a/packages/s2-core/src/utils/number-calculate.ts
+++ b/packages/s2-core/src/utils/number-calculate.ts
@@ -9,7 +9,7 @@ export const isNotNumber = (value: unknown) => {
     return Number.isNaN(value);
   }
   if (typeof value === 'string') {
-    return Number.isNaN(Number.parseFloat(value));
+    return Number.isNaN(Number(value));
   }
   return true;
 };


### PR DESCRIPTION
### 👀 PR includes

当数值中存在如 '2022-10-31' 或者 '1\n2\n3\n' 这种非数字字符串时， `isNotNumber` 判断错误
<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
