### PR TITLE
feat: 新增 measureTextHeight 用于测量文字高度

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -1,8 +1,13 @@
 import * as mockDataConfig from 'tests/data/simple-data.json';
 import { getContainer, sleep } from 'tests/util/helpers';
-import { omit, pick } from 'lodash';
+import { pick } from 'lodash';
 import { PivotSheet, TableSheet } from '@/sheet-type';
-import { DEFAULT_OPTIONS, S2Event, type S2Options } from '@/common';
+import {
+  DEFAULT_OPTIONS,
+  S2Event,
+  type S2Options,
+  type TextTheme,
+} from '@/common';
 
 const s2Options: S2Options = {
   width: 200,
@@ -422,6 +427,31 @@ describe('SpreadSheet Tests', () => {
         hierarchyType: s2Options.hierarchyType,
         width: 300,
         hdAdapter: false,
+      });
+    });
+
+    describe('Measure Text Tests', () => {
+      const text = '测试';
+      const font: TextTheme = {
+        textAlign: 'center',
+        fontSize: 12,
+      };
+      const s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
+      s2.render();
+
+      test('should measure text', () => {
+        expect(s2.measureText(text, null)).toBeNull();
+        expect(s2.measureText(text, font)).toBeInstanceOf(TextMetrics);
+      });
+
+      test('should measure text width', () => {
+        expect(s2.measureTextWidth(text, null)).toEqual(0);
+        expect(s2.measureTextWidth(text, font)).not.toBeLessThanOrEqual(0);
+      });
+
+      test('should measure text height', () => {
+        expect(s2.measureTextHeight(text, null)).toEqual(0);
+        expect(s2.measureTextHeight(text, font)).not.toBeLessThanOrEqual(0);
       });
     });
   });

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -690,15 +690,15 @@ export abstract class SpreadSheet extends EE {
   }
 
   /**
-   * 计算文本在画布中的宽度
+   * 获取文本在画布中的测量信息
    * @param text 待计算的文本
    * @param font 文本 css 样式
-   * @returns 文本宽度
+   * @returns 文本测量信息 TextMetrics
    */
-  public measureTextWidth = memoize(
-    (text: number | string = '', font: unknown): number => {
+  public measureText = memoize(
+    (text: number | string = '', font: unknown): TextMetrics => {
       if (!font) {
-        return 0;
+        return null;
       }
 
       const ctx = this.getCanvasElement()?.getContext('2d');
@@ -715,10 +715,43 @@ export abstract class SpreadSheet extends EE {
         .join(' ')
         .trim();
 
-      return ctx.measureText(String(text)).width;
+      return ctx.measureText(String(text));
     },
     (text: any, font) => [text, ...values(font)].join(''),
   );
+
+  /**
+   * 计算文本在画布中的宽度
+   * @param text 待计算的文本
+   * @param font 文本 css 样式
+   * @returns 文本宽度
+   */
+  public measureTextWidth = (
+    text: number | string = '',
+    font: unknown,
+  ): number => {
+    const textMetrics = this.measureText(text, font);
+    return textMetrics?.width || 0;
+  };
+
+  /**
+   * 计算文本在画布中的宽度 https://developer.mozilla.org/zh-CN/docs/Web/API/TextMetrics
+   * @param text 待计算的文本
+   * @param font 文本 css 样式
+   * @returns 文本高度
+   */
+  public measureTextHeight = (
+    text: number | string = '',
+    font: unknown,
+  ): number => {
+    const textMetrics = this.measureText(text, font);
+    if (!textMetrics) {
+      return 0;
+    }
+    return (
+      textMetrics.actualBoundingBoxAscent + textMetrics.actualBoundingBoxDescent
+    );
+  };
 
   /**
    * 粗略计算文本在画布中的宽度

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -71,7 +71,10 @@ s2.xx()
 | getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素                                                                                            | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |    |
 | clearColumnLeafNodes | 清空存储在 store 中的初始叶子节点                                                                                                   | () => void |    |
 | updateSortMethodMap | 更新存储在 store 中的节点排序方式 map, replace 为是否覆盖上一次的值                                                                           | (nodeId: string, sortMethod: string, replace?: boolean) => void |    |
-| getMenuDefaultSelectedKeys | 获取 tooltip 中选中的菜单项 key 值                                                                                               | `(nodeId: string) => string[]` |    |
+| getMenuDefaultSelectedKeys | 获取 tooltip 中选中的菜单项 key 值 | `(nodeId: string) => string[]` |    |
+| measureText | 获取文本在画布中的测量信息  | (text: `string`, font: [TextTheme](/zh/docs/api/general/S2Theme#texttheme)) => [TextMetrics](https://developer.mozilla.org/zh-CN/docs/Web/API/TextMetrics) \| `null` |    |
+| measureTextWidth | 获取文本在画布中的测量宽度   | (text: `string`, font: [TextTheme](/zh/docs/api/general/S2Theme#texttheme)) => `number | null` |    |
+| measureTextHeight |  获取文本在画布中的测量高度 | (text:`string`, font: [TextTheme](/zh/docs/api/general/S2Theme#texttheme)) => `number | null` |    |
 
 ### S2MountContainer
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

### 📝 Description

https://developer.mozilla.org/zh-CN/docs/Web/API/TextMetrics

1. 实例增加 `measureTextHeight`
2. 原有 `measureTextWidth` 拆分成 `measureText` 和 `measureTextWidth` 方法
3. 补充缺失文档

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
