### PR TITLE
fix: 修复sortedDimensionValues过滤不正确而导致的排序错乱的问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/sort-by-order-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/sort-by-order-spec.ts
@@ -1,0 +1,107 @@
+import { getContainer } from 'tests/util/helpers';
+import { PivotSheet } from '@/sheet-type';
+import type { S2DataConfig, S2Options } from '@/common';
+
+const s2Options: S2Options = {
+  width: 400,
+  height: 400,
+  hierarchyType: 'grid',
+  hdAdapter: true,
+};
+
+describe('Manual Sort Tests', () => {
+  let s2: PivotSheet;
+
+  const mockDataCfg: S2DataConfig = {
+    fields: {
+      rows: ['type1', 'type2'],
+      columns: [],
+      values: ['count'],
+      valueInCols: true,
+    },
+    data: [
+      {
+        type1: '整体访问',
+        type2: '整体访问',
+        count: 20,
+      },
+      {
+        type1: '整体访问',
+        type2: '小程序访问',
+        count: 12,
+      },
+      {
+        type1: '整体访问',
+        type2: '支付宝访问',
+        count: 20,
+      },
+      {
+        type1: '小程序访问',
+        type2: '整体访问',
+        count: 5,
+      },
+      {
+        type1: '小程序访问',
+        type2: '小程序访问',
+        count: 10,
+      },
+      {
+        type1: '小程序访问',
+        type2: '支付宝访问',
+        count: 15,
+      },
+      {
+        type1: '支付宝访问',
+        type2: '整体访问',
+        count: 100,
+      },
+      {
+        type1: '支付宝访问',
+        type2: '小程序访问',
+        count: 30,
+      },
+      {
+        type1: '支付宝访问',
+        type2: '支付宝访问',
+        count: 60,
+      },
+    ],
+    sortParams: [
+      {
+        sortFieldId: 'type1',
+        sortBy: ['整体访问', '小程序访问', '支付宝访问'],
+      },
+      {
+        sortFieldId: 'type2',
+        sortBy: ['整体访问', '小程序访问', '支付宝访问'],
+      },
+    ],
+  };
+
+  beforeAll(() => {
+    const container = getContainer();
+    s2 = new PivotSheet(container, mockDataCfg, s2Options);
+    s2.render();
+  });
+
+  test('getDimensionValues should include correct values', () => {
+    const sortedType1 = s2.dataSet.getDimensionValues('type1', {});
+    expect(sortedType1).toEqual(['整体访问', '小程序访问', '支付宝访问']);
+
+    expect(
+      s2.dataSet.getDimensionValues('type2', {
+        type1: '整体访问',
+      }),
+    ).toEqual(['整体访问', '小程序访问', '支付宝访问']);
+    expect(
+      s2.dataSet.getDimensionValues('type2', {
+        type1: '小程序访问',
+      }),
+    ).toEqual(['整体访问', '小程序访问', '支付宝访问']);
+    expect(
+      s2.dataSet.getDimensionValues('type2', {
+        type1: '支付宝访问',
+      }),
+    ).toEqual(['整体访问', '小程序访问', '支付宝访问']);
+  });
+});

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -355,7 +355,7 @@ export class PivotDataSet extends BaseDataSet {
           ) {
             const dimensionValues = this.sortedDimensionValues[
               childField
-            ]?.filter((item) => item?.includes(cacheKey));
+            ]?.filter((item) => item?.startsWith(cacheKey));
             sortedMeta = getDimensionsWithoutPathPre([...dimensionValues]);
           } else {
             sortedMeta = [...meta.keys()];


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


- [x] Solve the issue and close #0

在手动排序，调用`getDimensionValues`时，对`sortedDimensionValues`采用的是`includes`而不是`startsWith`，会导致过滤的信息和预期不符合，比如想获取**小程序访问**的所有子维度用于排序：
![image](https://user-images.githubusercontent.com/17964556/201854971-d8a5a173-3618-478b-9581-0aa07a62034c.png)
最终导致排序不正确

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/17964556/201853991-99b918be-74a1-4d6b-8ab2-e5ca1c846486.png)      | ![image](https://user-images.githubusercontent.com/17964556/201854021-667760f4-2123-43e9-bcc4-e7e6093564cd.png)     |

### 🔗 Related issue link

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
