### PR TITLE
fix: 角头序号单元格meta无spreadsheet实例

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -11,7 +11,7 @@ import type { PanelScrollGroup } from '@/group/panel-scroll-group';
 import { SpreadSheet } from '@/sheet-type';
 import { PivotDataSet } from '@/data-set/pivot-data-set';
 import { PivotFacet } from '@/facet/pivot-facet';
-import { DataCell } from '@/cell';
+import { CornerCell, DataCell } from '@/cell';
 import { Store } from '@/common/store';
 import { getTheme } from '@/theme';
 import { DEFAULT_OPTIONS, DEFAULT_STYLE } from '@/common/constant/options';
@@ -271,6 +271,33 @@ describe('Pivot Mode Facet Test', () => {
       expect(panelScrollGroup.cfg.children).toHaveLength(32);
       expect(panelScrollGroup.cfg.visible).toBeTrue();
       expect(get(sampleDataCell, 'meta.data.number')).toBe(7789);
+    });
+  });
+
+  describe('should get correct result when enable seriesnumber', () => {
+    const mockDataSet = new MockPivotDataSet(s2);
+    const seriesNumberFacet = new PivotFacet({
+      spreadsheet: s2,
+      dataSet: mockDataSet,
+      ...assembleDataCfg().fields,
+      ...assembleOptions(),
+      ...DEFAULT_STYLE,
+      showSeriesNumber: true,
+    });
+    seriesNumberFacet.render();
+
+    test('render corrent corner header', () => {
+      const { cornerHeader } = seriesNumberFacet;
+
+      expect(cornerHeader instanceof CornerHeader).toBeTrue();
+      expect(cornerHeader.cfg.children).toHaveLength(3);
+      expect(cornerHeader.cfg.visible).toBeTrue();
+
+      expect(
+        cornerHeader
+          .getChildren()
+          .every((cell: CornerCell) => cell.getMeta().spreadsheet),
+      ).toBeTrue();
     });
   });
 

--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -236,15 +236,17 @@ describe('Pivot Mode Facet Test', () => {
   });
 
   describe('should get correct layer after render', () => {
-    facet.render();
-    const {
-      rowHeader,
-      cornerHeader,
-      columnHeader,
-      centerFrame,
-      backgroundGroup,
-    } = facet;
+    beforeAll(() => {
+      facet.render();
+    });
+
+    afterAll(() => {
+      facet.render();
+    });
+
     test('get header after render', () => {
+      const { rowHeader, cornerHeader, columnHeader, centerFrame } = facet;
+
       expect(rowHeader instanceof RowHeader).toBeTrue();
       expect(rowHeader.cfg.children).toHaveLength(10);
       expect(rowHeader.cfg.visible).toBeTrue();
@@ -258,6 +260,8 @@ describe('Pivot Mode Facet Test', () => {
     });
 
     test('get background after render', () => {
+      const { backgroundGroup } = facet;
+
       const rect = get(backgroundGroup, 'cfg.children[0]');
 
       expect(backgroundGroup.cfg.children).toHaveLength(1);
@@ -284,7 +288,14 @@ describe('Pivot Mode Facet Test', () => {
       ...DEFAULT_STYLE,
       showSeriesNumber: true,
     });
-    seriesNumberFacet.render();
+
+    beforeAll(() => {
+      seriesNumberFacet.render();
+    });
+
+    afterAll(() => {
+      seriesNumberFacet.destroy();
+    });
 
     test('render corrent corner header', () => {
       const { cornerHeader } = seriesNumberFacet;

--- a/packages/s2-core/src/facet/header/corner.ts
+++ b/packages/s2-core/src/facet/header/corner.ts
@@ -119,6 +119,7 @@ export class CornerHeader extends BaseHeader<CornerHeaderConfig> {
       // different type different height
       sNode.height = colsHierarchy?.sampleNodeForLastLevel?.height;
       sNode.isPivotMode = true;
+      sNode.spreadsheet = s2;
       sNode.cornerType = CornerNodeType.Series;
       cornerNodes.push(sNode);
     }


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
角头中，序号列对应的 cell.meta 没有 spreadsheet 实例变量

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
