### PR TITLE
fix(facet): 调整 layoutCoordinate 执行顺序

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -154,6 +154,24 @@ describe('TableSheet normal spec', () => {
     s2.destroy();
   });
 
+  test('should support custom layoutCoordinate calls', () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, {
+      ...options,
+      frozenColCount: 0,
+      frozenTrailingColCount: 0,
+    });
+
+    s2.setOptions({
+      layoutCoordinate: (s2, rowNode, colNode) => {
+        colNode.width = 50;
+      },
+    });
+    s2.render();
+    expect(s2.facet.layoutResult.colsHierarchy.width).toBe(850);
+
+    s2.destroy();
+  });
+
   test('should be able to resize last column', async () => {
     const s2 = new TableSheet(getContainer(), dataCfg, options);
     s2.render();

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -322,6 +322,7 @@ export class TableFacet extends BaseFacet {
           currentNode,
           adaptiveColWitdth,
         );
+        layoutCoordinate(this.cfg, null, currentNode);
         colsHierarchy.width += currentNode.width;
         preLeafNode = currentNode;
       }
@@ -335,7 +336,6 @@ export class TableFacet extends BaseFacet {
         currentNode,
         colsHierarchy.height,
       );
-      layoutCoordinate(this.cfg, null, currentNode);
     }
     const topLevelNodes = allNodes.filter((node) => isTopLevelNode(node));
     const { frozenTrailingColCount } = getValidFrozenOptions(


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

layoutCoordinate这个layout hook函数需要在 
```
colsHierarchy.width += currentNode.width;
```
之前执行。

如果之后执行的话，就会导致node的width和实际layout的width不对等。。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|   ![image](https://user-images.githubusercontent.com/16497201/204224783-c1e159d2-5805-41df-b1fd-6f6456473b1e.png) | ![image](https://user-images.githubusercontent.com/16497201/204224696-cb218907-aa09-4542-8d32-54a78c0a6d20.png)   |

### 🔗 Related issue link

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
