### PR TITLE
fix: 无法触发keyup时候不会卡在多选模式

### DIFF
--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -20,7 +20,10 @@ import {
   hideColumnsByThunkGroup,
   isEqualDisplaySiblingNodeId,
 } from '../../../utils/hide-columns';
-import { isMultiSelectionKey } from '../../../utils/interaction/select-event';
+import {
+  isMultiSelectionKey,
+  shouldMouseEventTriggerMultiSelection,
+} from '../../../utils/interaction/select-event';
 import {
   getTooltipOptions,
   getTooltipVisibleOperator,
@@ -28,31 +31,16 @@ import {
 } from '../../../utils/tooltip';
 
 export class RowColumnClick extends BaseEvent implements BaseEventImplement {
-  private isMultiSelection = false;
-
   public bindEvents() {
-    this.bindKeyboardDown();
     this.bindKeyboardUp();
     this.bindColCellClick();
     this.bindRowCellClick();
     this.bindTableColExpand();
   }
 
-  private bindKeyboardDown() {
-    this.spreadsheet.on(
-      S2Event.GLOBAL_KEYBOARD_DOWN,
-      (event: KeyboardEvent) => {
-        if (isMultiSelectionKey(event)) {
-          this.isMultiSelection = true;
-        }
-      },
-    );
-  }
-
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
       if (isMultiSelectionKey(event)) {
-        this.isMultiSelection = false;
         this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
       }
     });
@@ -82,7 +70,12 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
 
     const { multiSelection: enableMultiSelection } = options.interaction;
     // 关闭了多选就算按下了 Ctrl/Commend, 行/列也按单选处理
-    const isMultiSelection = !!(enableMultiSelection && this.isMultiSelection);
+    const isMultiSelection = !!(
+      enableMultiSelection &&
+      shouldMouseEventTriggerMultiSelection(
+        event.originalEvent as unknown as MouseEvent,
+      )
+    );
 
     const success = interaction.selectHeaderCell({
       cell,

--- a/packages/s2-core/src/interaction/data-cell-multi-selection.ts
+++ b/packages/s2-core/src/interaction/data-cell-multi-selection.ts
@@ -10,6 +10,7 @@ import type { CellMeta, S2CellType, ViewMeta } from '../common/interface';
 import {
   getCellMeta,
   isMultiSelectionKey,
+  shouldMouseEventTriggerMultiSelection,
 } from '../utils/interaction/select-event';
 import { getCellsTooltipData } from '../utils/tooltip';
 import { BaseEvent, type BaseEventImplement } from './base-interaction';
@@ -18,8 +19,6 @@ export class DataCellMultiSelection
   extends BaseEvent
   implements BaseEventImplement
 {
-  private isMultiSelection = false;
-
   public bindEvents() {
     this.bindKeyboardDown();
     this.bindDataCellClick();
@@ -27,7 +26,6 @@ export class DataCellMultiSelection
   }
 
   public reset() {
-    this.isMultiSelection = false;
     this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
   }
 
@@ -36,7 +34,6 @@ export class DataCellMultiSelection
       S2Event.GLOBAL_KEYBOARD_DOWN,
       (event: KeyboardEvent) => {
         if (isMultiSelectionKey(event)) {
-          this.isMultiSelection = true;
           this.spreadsheet.interaction.addIntercepts([InterceptType.CLICK]);
         }
       },
@@ -75,7 +72,10 @@ export class DataCellMultiSelection
       const meta = cell.getMeta();
       const { interaction } = this.spreadsheet;
 
-      if (this.isMultiSelection && meta) {
+      if (
+        shouldMouseEventTriggerMultiSelection(event as unknown as MouseEvent) &&
+        meta
+      ) {
         const selectedCells = this.getSelectedCells(cell);
 
         if (isEmpty(selectedCells)) {

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -19,6 +19,11 @@ export const isMultiSelectionKey = (e: KeyboardEvent) => {
   );
 };
 
+export const shouldMouseEventTriggerMultiSelection = (e: MouseEvent) => {
+  const { metaKey, ctrlKey } = e;
+  return metaKey || ctrlKey;
+};
+
 export const getCellMeta = (cell: S2CellType) => {
   const meta = cell.getMeta();
   const { id, colIndex, rowIndex } = meta;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix
之前使用isMultiSelection变量标注的模式中，如ctrl+s触发网页保存等场景下，isMultiSelection变量仍会保持为true，导致任何click事件都会触发为多选。

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
