### PR TITLE
chore: 添加 latest 分支生成 release commit 脚本

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build:umd": "lerna run build:umd --include-dependencies --stream",
     "bundle:size": "lerna run bundle:size --stream",
     "release": "lerna exec --ignore @antv/s2-shared --concurrency 1 -- npx --no-install semantic-release",
+    "release:bump-latest":"node ./scripts/latest-bump-version.js",
     "release:preview": "yarn release --dry-run --no-ci",
     "prepublish:manual": "yarn build",
     "publish:manual": "lerna publish",

--- a/scripts/latest-bump-version.js
+++ b/scripts/latest-bump-version.js
@@ -1,0 +1,13 @@
+const { execSync } = require('child_process');
+const { getCurrentBranch } = require('./util');
+
+const branch = getCurrentBranch();
+
+if (branch !== 'latest') {
+  console.log('❌ 只允许在 latest 分支执行该命令');
+  process.exit(1);
+}
+
+execSync("git commit --allow-empty -m 'chore(release): bump version'");
+console.log('✅ release commit 创建完成');
+process.exit(0);

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,0 +1,12 @@
+const { execSync } = require('child_process');
+
+function getCurrentBranch() {
+  return execSync('git symbolic-ref --short -q HEAD')
+    .toString()
+    .trim()
+    .toLowerCase();
+}
+
+module.exports = {
+  getCurrentBranch,
+};

--- a/scripts/validate-deps.js
+++ b/scripts/validate-deps.js
@@ -1,17 +1,10 @@
-const { execSync } = require('child_process');
 const corePkg = require('@antv/s2/package.json');
 const reactPkg = require('../packages/s2-react/package.json');
 const vuePkg = require('../packages/s2-vue/package.json');
 const sharedPkg = require('@antv/s2-shared/package.json');
+const { getCurrentBranch } = require('./util');
 
 const branchList = ['alpha', 'next', 'beta'];
-
-function getCurrentBranch() {
-  return execSync('git symbolic-ref --short -q HEAD')
-    .toString()
-    .trim()
-    .toLowerCase();
-}
 
 function bootstrap() {
   const branch = getCurrentBranch();


### PR DESCRIPTION
✨ Feature

- [x] New feature

### 📝 Description
在 latest 分支进行部署时，为了创建`chore(release)`的触发 commit，需要我们在 `package.json` 里面做版本修改，而版本号的修改最终会被工具覆盖点，其实没有意义，现在直接通过脚本创建空的 commit。

在 latest 发布步骤：
1. 合并 master
2. 执行 `yarn release:bump-latest`
3. 推送代码

> 提供分支检测，脚本只在 latest 生效，其他预览版分支照旧
<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
