### PR TITLE
fix: 修复 enableCopy 和 hideMeasureColumn 都开启为 true 时，复制报错问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -319,27 +319,29 @@ describe('Pivot Table Core Data Process', () => {
   // 2 = ['province', 'city'].length 列头宽度
   const ROW_HEADER_WIDTH = 2;
 
-  const s2 = new PivotSheet(
-    getContainer(),
-    assembleDataCfg({
+  function getDataCfg() {
+    return assembleDataCfg({
       meta: [],
       fields: {
         columns: ['type', 'sub_type'],
         rows: ['province', 'city'],
         values: ['number'],
       },
-    }),
-    assembleOptions({
+    });
+  }
+
+  function getOptions() {
+    return assembleOptions({
       hierarchyType: 'grid',
       interaction: {
         enableCopy: true,
       },
       totals: TOTALS_OPTIONS,
-    }),
-  );
-  beforeEach(() => {
-    s2.render();
-  });
+    });
+  }
+
+  const s2 = new PivotSheet(getContainer(), getDataCfg(), getOptions());
+  s2.render();
 
   it('should copy no data in grid mode', () => {
     s2.interaction.changeState({
@@ -394,14 +396,7 @@ describe('Pivot Table Core Data Process', () => {
   it('should copy row data in grid mode', () => {
     const ss = new PivotSheet(
       getContainer(),
-      assembleDataCfg({
-        meta: [],
-        fields: {
-          columns: ['type', 'sub_type'],
-          rows: ['province', 'city'],
-          values: ['number'],
-        },
-      }),
+      getDataCfg(),
       assembleOptions({
         hierarchyType: 'grid',
         interaction: {
@@ -711,22 +706,23 @@ describe('Pivot Table Core Data Process', () => {
   });
 
   it('should get correct data with hideMeasureColumn is true', () => {
-    s2.setOptions({
+    const ss = new PivotSheet(getContainer(), getDataCfg(), getOptions());
+    ss.setOptions({
       style: {
         colCfg: {
           hideMeasureColumn: true,
         },
       },
     });
-    s2.render();
-    const cells = s2.interaction
+    ss.render();
+    const cells = ss.interaction
       .getAllCells()
       .filter(({ cellType }) => cellType === CellTypes.DATA_CELL);
-    s2.interaction.changeState({
+    ss.interaction.changeState({
       cells: map(cells, getCellMeta),
       stateName: InteractionStateName.SELECTED,
     });
-    const data = getSelectedData(s2);
+    const data = getSelectedData(ss);
     expect(data).toMatchInlineSnapshot(`
       "7789	5343	13132	945	1343
       2367	632	2999	1304	1354
@@ -744,7 +740,8 @@ describe('Pivot Table Core Data Process', () => {
 
   // https://github.com/antvis/S2/issues/1955
   it('should get correct data with hideMeasureColumn、showSeriesNumber and copyWithHeader are all true', () => {
-    s2.setOptions({
+    const ss = new PivotSheet(getContainer(), getDataCfg(), getOptions());
+    ss.setOptions({
       style: {
         colCfg: {
           hideMeasureColumn: true,
@@ -756,15 +753,15 @@ describe('Pivot Table Core Data Process', () => {
       },
       showSeriesNumber: true,
     });
-    s2.render();
-    const cells = s2.interaction
+    ss.render();
+    const cells = ss.interaction
       .getAllCells()
       .filter(({ cellType }) => cellType === CellTypes.DATA_CELL);
-    s2.interaction.changeState({
+    ss.interaction.changeState({
       cells: map(cells, getCellMeta),
       stateName: InteractionStateName.SELECTED,
     });
-    const data = getSelectedData(s2);
+    const data = getSelectedData(ss);
     expect(data).toMatchInlineSnapshot(`
       "		家具	家具	家具	办公用品
       		桌子	沙发	小计	笔

--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -337,7 +337,9 @@ describe('Pivot Table Core Data Process', () => {
       totals: TOTALS_OPTIONS,
     }),
   );
-  s2.render();
+  beforeEach(() => {
+    s2.render();
+  });
 
   it('should copy no data in grid mode', () => {
     s2.interaction.changeState({
@@ -706,6 +708,78 @@ describe('Pivot Table Core Data Process', () => {
     });
     const data = getSelectedData(s2New);
     expect(data).toBe(convertString(`7789\n元`));
+  });
+
+  it('should get correct data with hideMeasureColumn is true', () => {
+    s2.setOptions({
+      style: {
+        colCfg: {
+          hideMeasureColumn: true,
+        },
+      },
+    });
+    s2.render();
+    const cells = s2.interaction
+      .getAllCells()
+      .filter(({ cellType }) => cellType === CellTypes.DATA_CELL);
+    s2.interaction.changeState({
+      cells: map(cells, getCellMeta),
+      stateName: InteractionStateName.SELECTED,
+    });
+    const data = getSelectedData(s2);
+    expect(data).toMatchInlineSnapshot(`
+      "7789	5343	13132	945	1343
+      2367	632	2999	1304	1354
+      3877	7234	11111	1145	1523
+      4342	834	5176	1432	1634
+      18375	14043	32418	4826	5854
+      1723	2451	4174	2335	4004
+      1822	2244	4066	245	3077
+      1943	2333	4276	2457	3551
+      2330	2445	4775	2458	352
+      7818	9473	17291	7495	10984
+      26193	23516	49709	12321	16838"
+    `);
+  });
+
+  // https://github.com/antvis/S2/issues/1955
+  it('should get correct data with hideMeasureColumn、showSeriesNumber and copyWithHeader are all true', () => {
+    s2.setOptions({
+      style: {
+        colCfg: {
+          hideMeasureColumn: true,
+        },
+      },
+      interaction: {
+        enableCopy: true,
+        copyWithHeader: true,
+      },
+      showSeriesNumber: true,
+    });
+    s2.render();
+    const cells = s2.interaction
+      .getAllCells()
+      .filter(({ cellType }) => cellType === CellTypes.DATA_CELL);
+    s2.interaction.changeState({
+      cells: map(cells, getCellMeta),
+      stateName: InteractionStateName.SELECTED,
+    });
+    const data = getSelectedData(s2);
+    expect(data).toMatchInlineSnapshot(`
+      "		家具	家具	家具	办公用品
+      		桌子	沙发	小计	笔
+      浙江省	杭州市	7789	5343	13132	945
+      浙江省	绍兴市	2367	632	2999	1304
+      浙江省	宁波市	3877	7234	11111	1145
+      浙江省	舟山市	4342	834	5176	1432
+      浙江省	小计	18375	14043	32418	4826
+      四川省	成都市	1723	2451	4174	2335
+      四川省	绵阳市	1822	2244	4066	245
+      四川省	南充市	1943	2333	4276	2457
+      四川省	乐山市	2330	2445	4775	2458
+      四川省	小计	7818	9473	17291	7495
+      总计		26193	23516	49709	12321"
+    `);
   });
 });
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [X] Solve the issue and close #1955 

🔧 Chore

- [X] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

兼容 hideMeasureColumn 方案：hideMeasureColumn 的隐藏实现是通过截取掉度量(measure)数据，但是又只截取了 Node 中的，像 pivotMeta 中的又是完整的。导致复制时，无法通过 Node 找出正确路径。
所以，被 hideMeasureColumn 隐藏的 度量(measure) 值，手动添加上。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|![Dec-08-2022 16-30-45](https://user-images.githubusercontent.com/20497176/206398070-d82e7591-982f-4cc7-8eca-f10cd38b5c4a.gif) |![复制-隐藏-正常展示](https://user-images.githubusercontent.com/20497176/206398099-ee1af72f-ae3e-47d7-baaa-f656b28b8cd8.gif)|

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
