### PR TITLE
fix: 明细表紧凑模式宽度计算错误

### DIFF
--- a/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/layout/col-node-width-spec.ts
@@ -1,6 +1,7 @@
 import * as mockDataConfig from 'tests/data/simple-data.json';
+import * as mockTableDataConfig from 'tests/data/simple-table-data.json';
 import { getContainer } from 'tests/util/helpers';
-import { PivotSheet } from '@/sheet-type';
+import { PivotSheet, TableSheet } from '@/sheet-type';
 import type { S2Options } from '@/common';
 
 const s2options: S2Options = {
@@ -8,97 +9,133 @@ const s2options: S2Options = {
   height: 600,
 };
 
-describe('Col width Test in grid mode', () => {
-  let s2: PivotSheet;
-  beforeEach(() => {
-    s2 = new PivotSheet(
-      getContainer(),
-      {
-        ...mockDataConfig,
-        data: [
+describe('Col width Test', () => {
+  describe('Grid Mode', () => {
+    let s2: PivotSheet;
+    beforeEach(() => {
+      s2 = new PivotSheet(
+        getContainer(),
+        {
+          ...mockDataConfig,
+          data: [
+            {
+              province: '浙江',
+              city: '义乌',
+              type: '笔',
+              // long text
+              price: 123456789,
+              cost: 2,
+            },
+          ],
+        },
+        s2options,
+      );
+      s2.render();
+    });
+
+    test('get correct width in layoutWidthType adaptive mode', () => {
+      const { colLeafNodes } = s2.facet.layoutResult;
+      expect(colLeafNodes[0].width).toBe(200);
+    });
+
+    test('get correct width in layoutWidthType adaptive mode when enable seriesnumber', () => {
+      s2.setOptions({
+        showSeriesNumber: true,
+      });
+      s2.render();
+      const { colLeafNodes } = s2.facet.layoutResult;
+      expect(colLeafNodes[0].width).toBe(180);
+    });
+
+    test('get correct width in layoutWidthType adaptive tree mode', () => {
+      s2.setOptions({
+        hierarchyType: 'tree',
+      });
+      s2.render();
+      const { colLeafNodes } = s2.facet.layoutResult;
+      expect(Math.round(colLeafNodes[0].width)).toBe(339);
+    });
+
+    test('get correct width in layoutWidthType adaptive tree mode when enable seriesnumber', () => {
+      s2.setOptions({
+        hierarchyType: 'tree',
+        showSeriesNumber: true,
+      });
+      s2.render();
+      const { colLeafNodes } = s2.facet.layoutResult;
+      expect(Math.round(colLeafNodes[0].width)).toBe(299);
+    });
+
+    test('get correct width in layoutWidthType compact mode', () => {
+      s2.setOptions({
+        style: {
+          layoutWidthType: 'compact',
+        },
+      });
+      s2.render();
+
+      // 无 formatter
+      const { colLeafNodes } = s2.facet.layoutResult;
+      expect(Math.round(colLeafNodes[0].width)).toBe(86);
+    });
+
+    test('get correct width in layoutWidthType compact mode when apply fomatter', () => {
+      s2.setDataCfg({
+        fields: undefined,
+        data: undefined,
+        meta: [
           {
-            province: '浙江',
-            city: '义乌',
-            type: '笔',
-            // long text
-            price: 123456789,
-            cost: 2,
+            field: 'price',
+            formatter: (v: number) => {
+              return `${(v / 1000000).toFixed(0)}百万`;
+            },
           },
         ],
-      },
-      s2options,
-    );
-    s2.render();
-  });
-
-  test('get correct width in layoutWidthType adaptive mode', () => {
-    const { colLeafNodes } = s2.facet.layoutResult;
-    expect(colLeafNodes[0].width).toBe(200);
-  });
-
-  test('get correct width in layoutWidthType adaptive mode when enable seriesnumber', () => {
-    s2.setOptions({
-      showSeriesNumber: true,
-    });
-    s2.render();
-    const { colLeafNodes } = s2.facet.layoutResult;
-    expect(colLeafNodes[0].width).toBe(180);
-  });
-
-  test('get correct width in layoutWidthType adaptive tree mode', () => {
-    s2.setOptions({
-      hierarchyType: 'tree',
-    });
-    s2.render();
-    const { colLeafNodes } = s2.facet.layoutResult;
-    expect(Math.round(colLeafNodes[0].width)).toBe(339);
-  });
-
-  test('get correct width in layoutWidthType adaptive tree mode when enable seriesnumber', () => {
-    s2.setOptions({
-      hierarchyType: 'tree',
-      showSeriesNumber: true,
-    });
-    s2.render();
-    const { colLeafNodes } = s2.facet.layoutResult;
-    expect(Math.round(colLeafNodes[0].width)).toBe(299);
-  });
-
-  test('get correct width in layoutWidthType compact mode', () => {
-    s2.setOptions({
-      style: {
-        layoutWidthType: 'compact',
-      },
-    });
-    s2.render();
-
-    // 无 formatter
-    const { colLeafNodes } = s2.facet.layoutResult;
-    expect(Math.round(colLeafNodes[0].width)).toBe(86);
-  });
-
-  test('get correct width in layoutWidthType compact mode when apply fomatter', () => {
-    s2.setDataCfg({
-      fields: undefined,
-      data: undefined,
-      meta: [
-        {
-          field: 'price',
-          formatter: (v: number) => {
-            return `${(v / 1000000).toFixed(0)}百万`;
-          },
+      });
+      s2.setOptions({
+        style: {
+          layoutWidthType: 'compact',
         },
-      ],
-    });
-    s2.setOptions({
-      style: {
-        layoutWidthType: 'compact',
-      },
-    });
-    s2.render();
+      });
+      s2.render();
 
-    // 有formatter
-    const { colLeafNodes } = s2.facet.layoutResult;
-    expect(Math.round(colLeafNodes[0].width)).toBe(62);
+      // 有formatter
+      const { colLeafNodes } = s2.facet.layoutResult;
+      expect(Math.round(colLeafNodes[0].width)).toBe(62);
+    });
+  });
+
+  describe('Table Mode', () => {
+    let s2: TableSheet;
+    beforeEach(() => {
+      s2 = new TableSheet(
+        getContainer(),
+        {
+          ...mockTableDataConfig,
+          meta: [
+            {
+              field: 'cost',
+              formatter: (s) => `我是一个很长的格式化标签${s}`,
+            },
+          ],
+        },
+        s2options,
+      );
+      s2.render();
+    });
+
+    test('get correct width in layoutWidthType compact mode', () => {
+      s2.setOptions({
+        style: {
+          layoutWidthType: 'compact',
+        },
+      });
+      s2.render();
+
+      const { colLeafNodes } = s2.facet.layoutResult;
+
+      expect(Math.round(colLeafNodes[0].width)).toBe(47); // 列头标签更长
+      expect(Math.round(colLeafNodes[1].width)).toBe(168); // 表身标签更长（格式化）
+    });
   });
 });

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -66,6 +66,7 @@ jest.mock('@/data-set/table-data-set', () => {
         getDimensionValues: jest.fn(),
         getDisplayDataSet: jest.fn(() => data),
         getCellData: () => 1,
+        getFieldFormatter: jest.fn(),
       };
     }),
   };

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -407,18 +407,15 @@ export class TableFacet extends BaseFacet {
     let colWidth: number;
     if (layoutWidthType === LayoutWidthTypes.Compact) {
       const datas = dataSet.getDisplayDataSet();
-      const colLabel = col.label;
+      const formatter = dataSet.getFieldFormatter(col.field);
 
-      const allLabels =
-        datas?.map((data) => `${data[col.key]}`)?.slice(0, 50) || []; // 采样取了前50
-      allLabels.push(colLabel);
-      const maxLabel = maxBy(allLabels, (label) =>
-        spreadsheet.measureTextWidthRoughly(label),
+      // 采样前50，找出表身最长的数据
+      const maxLabel = maxBy(
+        datas
+          ?.slice(0, 50)
+          .map((data) => `${formatter?.(data[col.field]) ?? data[col.field]}`),
+        (label) => spreadsheet.measureTextWidthRoughly(label),
       );
-
-      const { bolderText: colCellTextStyle } = spreadsheet.theme.colCell;
-      const { text: dataCellTextStyle, cell: cellStyle } =
-        spreadsheet.theme.dataCell;
 
       DebuggerUtil.getInstance().logger(
         'Max Label In Col:',
@@ -426,24 +423,28 @@ export class TableFacet extends BaseFacet {
         maxLabel,
       );
 
-      // 最长的 Label 如果是列名，按列名的标准计算宽度
-      if (colLabel === maxLabel) {
-        colWidth =
-          spreadsheet.measureTextWidth(maxLabel, colCellTextStyle) +
-          getOccupiedWidthForTableCol(
-            this.spreadsheet,
-            col,
-            spreadsheet.theme.colCell,
-          );
-      } else {
-        // 额外添加一像素余量，防止 maxLabel 有多个同样长度情况下，一些 label 不能展示完全
-        const EXTRA_PIXEL = 1;
-        colWidth =
-          spreadsheet.measureTextWidth(maxLabel, dataCellTextStyle) +
-          cellStyle.padding.left +
-          cellStyle.padding.right +
-          EXTRA_PIXEL;
-      }
+      const { bolderText: colCellTextStyle } = spreadsheet.theme.colCell;
+      const { text: dataCellTextStyle, cell: cellStyle } =
+        spreadsheet.theme.dataCell;
+
+      // 额外添加一像素余量，防止 maxLabel 有多个同样长度情况下，一些 label 不能展示完全
+      const EXTRA_PIXEL = 1;
+      const maxLabelWidth =
+        spreadsheet.measureTextWidth(maxLabel, dataCellTextStyle) +
+        cellStyle.padding.left +
+        cellStyle.padding.right +
+        EXTRA_PIXEL;
+
+      // 计算表头 label+icon 占用的空间
+      const colHeaderNodeWidth =
+        spreadsheet.measureTextWidth(col.label, colCellTextStyle) +
+        getOccupiedWidthForTableCol(
+          this.spreadsheet,
+          col,
+          spreadsheet.theme.colCell,
+        );
+
+      colWidth = Math.max(colHeaderNodeWidth, maxLabelWidth);
     } else {
       colWidth = adaptiveColWidth;
     }


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
紧凑模式 `layoutWidthType=compact` 下计算列宽度时，没有使用格式化后的数据
导致计算结果与实际渲染不一致
如原始数据为 `1.23456`，但 formatter 后为 `1.2`
应使用 `1.2` 来 measureWidth



### 🖼️ Screenshot

- `成本` 列，原始数据 `1.23456789`，formatter 截取两位


| Before | After |
| ------ | ----- |
|   <img width="356" alt="CleanShot 2022-12-19 at 11 31 48@2x" src="https://user-images.githubusercontent.com/6716092/208342147-2cdd6dc5-6c64-42f4-87ae-343b8d86821a.png">      |    <img width="306" alt="CleanShot 2022-12-19 at 11 32 23@2x" src="https://user-images.githubusercontent.com/6716092/208342199-79c44313-4345-456a-9360-6253a96ba26c.png">   |

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
