### PR TITLE
fix: 明细表linkField失效

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -1,11 +1,14 @@
 import { getContainer, getMockData, sleep } from 'tests/util/helpers';
+import { get } from 'lodash';
 import {
   TableSheet,
   type S2Options,
   type S2DataConfig,
   ResizeType,
   ColCell,
+  TableDataCell,
 } from '@/index';
+import type { PanelScrollGroup } from '@/group/panel-scroll-group';
 
 const data = getMockData(
   '../../../s2-react/__tests__/data/tableau-supermarket.csv',
@@ -208,5 +211,28 @@ describe('TableSheet normal spec', () => {
       .belongsCell as ColCell;
 
     expect(lastColumnCell.getMeta().width).toBe(199);
+  });
+
+  test('should render link shape', () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, {
+      ...options,
+      frozenRowCount: 0,
+      frozenColCount: 0,
+      frozenTrailingColCount: 0,
+      frozenTrailingRowCount: 0,
+    });
+    s2.render();
+
+    const orderIdDataCell = (
+      s2.facet.panelGroup.findAllByName(
+        'panelScrollGroup',
+      )[0] as PanelScrollGroup
+    )
+      .getChildren()
+      .find((item: TableDataCell) => item.getMeta().valueField === 'order_id');
+
+    expect(get(orderIdDataCell, 'linkFieldShape')).toBeDefined();
+
+    s2.destroy();
   });
 });

--- a/packages/s2-core/src/utils/interaction/link-field.ts
+++ b/packages/s2-core/src/utils/interaction/link-field.ts
@@ -7,5 +7,8 @@ export const checkIsLinkField = (
 ): boolean => {
   return typeof linkFields === 'function'
     ? linkFields(meta)
-    : linkFields.some((field) => field === meta.key || field === meta.id);
+    : linkFields.some(
+        (field) =>
+          field === meta.key || field === meta.id || field === meta.valueField,
+      );
 };


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
#1992 误引入的问题，导致明细表的 linkField 判断失效
![image](https://user-images.githubusercontent.com/6716092/208637138-2c608025-3a97-4ebe-be2f-a08ca6b25657.png)


### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
