### PR TITLE
fix: bullet占位符绘制错误

### DIFF
--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -292,7 +292,7 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
       cell,
       [],
       x + width - dataCellStyle.cell.padding.right,
-      height / 2,
+      y + height / 2,
       getEmptyPlaceholder(cell, spreadsheet.options.placeholder),
       dataCellStyle.text,
     );


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

垂直方向绘制起点始终是 0， 导致绘制错误，实际应取 cell.y

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-12-26 at 14 55 43@2x](https://user-images.githubusercontent.com/6716092/209514683-4c357c5f-b1a5-4d62-a8d8-2c0decf56d6b.png)      |    ![CleanShot 2022-12-26 at 14 56 17@2x](https://user-images.githubusercontent.com/6716092/209514738-7aad5016-876f-46b6-b1a9-de8342e7c443.png)    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
