### PR TITLE
fix(layout): 修复存在列总计但不存在列小计时, 隐藏其兄弟节点后单元格坐标偏移 close #1993

### DIFF
--- a/packages/s2-core/src/facet/layout/node.ts
+++ b/packages/s2-core/src/facet/layout/node.ts
@@ -1,6 +1,10 @@
 import { head, isEmpty, isEqual, omit } from 'lodash';
 import { ROOT_ID } from '../../common/constant/basic';
-import type { CornerNodeType, S2CellType } from '../../common/interface';
+import type {
+  CornerNodeType,
+  HiddenColumnsInfo,
+  S2CellType,
+} from '../../common/interface';
 import type { SpreadSheet } from '../../sheet-type';
 import type { Hierarchy } from './hierarchy';
 
@@ -33,6 +37,7 @@ export interface BaseNodeConfig {
   height?: number;
   padding?: number;
   children?: Node[];
+  hiddenColumnsInfo?: HiddenColumnsInfo | null;
   // 额外的节点信息
   extra?: Record<string, any>;
 }
@@ -43,8 +48,6 @@ export interface BaseNodeConfig {
 export class Node {
   // node represent total measure
   public isTotalMeasure: boolean;
-
-  public config: BaseNodeConfig;
 
   constructor(cfg: BaseNodeConfig) {
     const {
@@ -92,19 +95,6 @@ export class Node {
     this.isLeaf = isLeaf;
     this.isGrandTotals = isGrandTotals;
     this.isSubTotals = isSubTotals;
-    this.config = {
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-      colIndex: -1,
-      children: [],
-      padding: 0,
-      id: '',
-      key: '',
-      value: '',
-      label: '',
-    };
     this.extra = extra;
   }
 
@@ -310,6 +300,10 @@ export class Node {
   public isGrandTotals?: boolean;
 
   public isSubTotals?: boolean;
+
+  public hiddenChildNodeInfo?: HiddenColumnsInfo | null;
+
+  public extra?: Record<string, any>;
 
   [key: string]: any;
 

--- a/packages/s2-core/src/utils/layout/generate-header-nodes.ts
+++ b/packages/s2-core/src/utils/layout/generate-header-nodes.ts
@@ -113,6 +113,12 @@ export const generateHeaderNodes = (params: HeaderNodesParams) => {
       hierarchy,
     );
 
+    // 如果当前是隐藏节点, 给其父节点挂载相应信息 (兄弟节点, 当前哪个子节点隐藏了), 这样在 facet 层可以直接使用, 不用每次都去遍历
+    const hiddenColumnsInfo = spreadsheet?.facet?.getHiddenColumnsInfo(node);
+    if (hiddenColumnsInfo && parentNode) {
+      parentNode.hiddenChildNodeInfo = hiddenColumnsInfo;
+    }
+
     // omit the the whole column or row of the grandTotal or subTotals
     if (
       level > hierarchy.maxLevel &&
@@ -121,15 +127,12 @@ export const generateHeaderNodes = (params: HeaderNodesParams) => {
       !parentNode.isSubTotals &&
       !node.isSubTotals
     ) {
-      const hiddenColumnNode =
-        facetCfg.spreadsheet?.facet?.getHiddenColumnsInfo(node);
-
       hierarchy.sampleNodesForAllLevels.push(node);
       hierarchy.maxLevel = level;
       // 如果当前是隐藏节点, 则采样其兄弟节点
-      hierarchy.sampleNodeForLastLevel = hiddenColumnNode
-        ? hiddenColumnNode?.displaySiblingNode?.next ||
-          hiddenColumnNode?.displaySiblingNode?.prev
+      hierarchy.sampleNodeForLastLevel = hiddenColumnsInfo
+        ? hiddenColumnsInfo?.displaySiblingNode?.next ||
+          hiddenColumnsInfo?.displaySiblingNode?.prev
         : node;
     }
 

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -98,7 +98,7 @@ export const s2Options: SheetComponentOptions = {
   hierarchyType: 'grid',
   style: {
     colCfg: {
-      hideMeasureColumn: true,
+      hideMeasureColumn: false,
     },
     rowCfg: {
       width: 200,

--- a/s2-site/docs/api/basic-class/node.zh.md
+++ b/s2-site/docs/api/basic-class/node.zh.md
@@ -38,4 +38,5 @@ node.isTotals // false
 | width | 宽度 | `number` |
 | height | 高度 | `number` |
 | padding | 间距 | `number` |
+| hiddenChildNodeInfo | 隐藏的子节点信息 | [hiddenColumnsInfo](/api/basic-class/store#hiddencolumnsinfo) |
 | children | 子节点 | [Node[]](/docs/api/basic-class/node)  |

--- a/s2-site/examples/interaction/advanced/demo/pivot-hide-columns.ts
+++ b/s2-site/examples/interaction/advanced/demo/pivot-hide-columns.ts
@@ -18,7 +18,7 @@ fetch(
       tooltip: {
         showTooltip: true,
         operation: {
-          // 开启手动隐藏, 透视表只有叶子节点才生效
+          // 开启手动隐藏, 叶子节点有效
           hiddenColumns: true,
         },
       },


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

第一版的列头隐藏是先隐藏, 再进行布局, 没办法兼容多数值的场景

第二版后面改为了先布局, 再隐藏

问题在于:

![image](https://user-images.githubusercontent.com/21015895/212010358-517cc306-6b81-44ce-9d34-b17b6883ce38.png)

布局时, 父节点是取得第一个子节点 x 坐标, 如果第一个子节点刚好隐藏了那么就会有问题, 需要将其排除

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/21015895/212009826-24d6b906-1af9-4f65-9e70-7cd7c61a01a6.png) | ![image](https://user-images.githubusercontent.com/21015895/212010013-9da0bd13-4278-455c-b1c2-ef49f835b70f.png) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
