### PR TITLE
refactor: 移除 g5.0 todo 项

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/row-link-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/row-link-spec.ts
@@ -89,11 +89,9 @@ describe('Row Text Link Tests', () => {
     s2.emit(S2Event.ROW_CELL_CLICK, {
       stopPropagation: noop,
       target: {
-        attr() {
-          return {
-            isLinkFieldText: true,
-            cellData: rowNode,
-          };
+        appendInfo: {
+          isLinkFieldText: true,
+          cellData: rowNode,
         },
       },
     } as any);
@@ -117,11 +115,9 @@ describe('Row Text Link Tests', () => {
     s2.emit(S2Event.ROW_CELL_CLICK, {
       stopPropagation: noop,
       target: {
-        attr() {
-          return {
-            isLinkFieldText: true,
-            cellData: rowNode,
-          };
+        appendInfo: {
+          isLinkFieldText: true,
+          cellData: rowNode,
         },
       },
     } as any);
@@ -146,11 +142,9 @@ describe('Row Text Link Tests', () => {
     s2.emit(S2Event.ROW_CELL_CLICK, {
       stopPropagation: noop,
       target: {
-        attr() {
-          return {
-            isLinkFieldText: true,
-            cellData: rowNode,
-          };
+        appendInfo: {
+          isLinkFieldText: true,
+          cellData: rowNode,
         },
       },
     } as any);

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -215,7 +215,7 @@ describe('TableSheet normal spec', () => {
     const resizeLength = 100;
 
     document.dispatchEvent(
-      new MouseEvent('mousemove', {
+      new PointerEvent('pointermove', {
         clientX: x + width + resizeLength,
         clientY: top + 25,
         bubbles: true,

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -21,7 +21,6 @@ import { PivotDataSet } from '@/data-set';
 import type { PivotFacet } from '@/facet';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
 import { renderText } from '@/utils/g-renders';
-import type { CustomText } from '@/engine/CustomText';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
@@ -143,7 +142,7 @@ describe('Data Cell Tests', () => {
       const dataCell = new DataCell(meta, s2);
       const textShape = renderText(dataCell, [], { x: 0, y: 0, text: 'test' });
 
-      dataCell.addTextShape(textShape as CustomText);
+      dataCell.addTextShape(textShape);
 
       expect(dataCell.getTextShapes()).toHaveLength(2);
     });

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -21,6 +21,7 @@ import { PivotDataSet } from '@/data-set';
 import type { PivotFacet } from '@/facet';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
 import { renderText } from '@/utils/g-renders';
+import type { CustomText } from '@/engine/CustomText';
 
 const MockPivotSheet = PivotSheet as unknown as jest.Mock<PivotSheet>;
 const MockPivotDataSet = PivotDataSet as unknown as jest.Mock<PivotDataSet>;
@@ -142,7 +143,7 @@ describe('Data Cell Tests', () => {
       const dataCell = new DataCell(meta, s2);
       const textShape = renderText(dataCell, [], { x: 0, y: 0, text: 'test' });
 
-      dataCell.addTextShape(textShape);
+      dataCell.addTextShape(textShape as CustomText);
 
       expect(dataCell.getTextShapes()).toHaveLength(2);
     });

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -4,6 +4,7 @@ import {
   type RectStyleProps,
   type ParsedRectStyleProps,
   Path,
+  FederatedPointerEvent,
 } from '@antv/g';
 import { get, pick } from 'lodash';
 import { createMockCellInfo } from '../../util/helpers';
@@ -57,11 +58,11 @@ describe('Interaction Row Column Resize Tests', () => {
 
   const emitResizeEvent = (
     type: S2Event,
-    event: Partial<MouseEvent>,
+    event: Partial<FederatedPointerEvent | PointerEvent>,
     resizeInfo?: ResizeInfo,
   ) => {
     rowColumnResizeInstance.spreadsheet.emit(type, {
-      originalEvent: event,
+      ...event,
       preventDefault() {},
       target: new CustomRect(
         {},

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -1,4 +1,11 @@
-import type { DisplayObject, Line, PointLike, Polygon, Rect } from '@antv/g';
+import type {
+  DisplayObject,
+  Line,
+  PointLike,
+  Polygon,
+  Rect,
+  Text,
+} from '@antv/g';
 import { Group } from '@antv/g';
 import {
   each,
@@ -471,12 +478,12 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     return this.textShapes || [this.textShape];
   }
 
-  public addTextShape(textShape: CustomText) {
+  public addTextShape(textShape: CustomText | Text) {
     if (!textShape) {
       return;
     }
 
-    this.textShapes.push(textShape);
+    this.textShapes.push(textShape as CustomText);
   }
 
   public getConditionIconShape(): GuiIcon {

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -1,4 +1,4 @@
-import type { DisplayObject, PointLike } from '@antv/g';
+import type { DisplayObject, Line, PointLike, Polygon, Rect } from '@antv/g';
 import { Group } from '@antv/g';
 import {
   each,
@@ -54,7 +54,6 @@ import { getEllipsisText, getEmptyPlaceholder } from '../utils/text';
 import type { GuiIcon } from '../common/icons/gui-icon';
 import type { CustomText } from '../engine/CustomText';
 
-// TODO: 迁移 shape 具体类型，如 textShape 应该是 Text 而不是 displayObject
 export abstract class BaseCell<T extends SimpleBBox> extends Group {
   // cell's data meta info
   protected meta: T;
@@ -66,7 +65,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
   protected theme: S2Theme;
 
   // background control shape
-  protected backgroundShape: DisplayObject;
+  protected backgroundShape: Rect | Polygon;
 
   // text control shape
   protected textShape: CustomText;
@@ -74,7 +73,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
   protected textShapes: CustomText[] = [];
 
   // link text underline shape
-  protected linkFieldShape: DisplayObject;
+  protected linkFieldShape: Line;
 
   // actualText
   protected actualText: string;
@@ -84,7 +83,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
 
   protected conditions: Conditions;
 
-  protected conditionIntervalShape: DisplayObject | undefined;
+  protected conditionIntervalShape: Rect | undefined;
 
   protected conditionIconShape: GuiIcon;
 

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -52,6 +52,7 @@ import {
 import { isMobile } from '../utils/is-mobile';
 import { getEllipsisText, getEmptyPlaceholder } from '../utils/text';
 import type { GuiIcon } from '../common/icons/gui-icon';
+import type { CustomText } from '../engine/CustomText';
 
 // TODO: 迁移 shape 具体类型，如 textShape 应该是 Text 而不是 displayObject
 export abstract class BaseCell<T extends SimpleBBox> extends Group {
@@ -68,9 +69,9 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
   protected backgroundShape: DisplayObject;
 
   // text control shape
-  protected textShape: DisplayObject;
+  protected textShape: CustomText;
 
-  protected textShapes: DisplayObject[] = [];
+  protected textShapes: CustomText[] = [];
 
   // link text underline shape
   protected linkFieldShape: DisplayObject;
@@ -331,7 +332,7 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       y: position.y,
       text: ellipsisText,
       ...textStyle,
-    });
+    }) as CustomText;
     this.textShapes.push(this.textShape);
   }
 
@@ -374,16 +375,13 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       );
     }
 
-    // TODO: 迁移 appendInfo
-    this.textShape.attr({
-      fill: linkFillColor,
-      cursor: 'pointer',
-      appendInfo: {
-        // 标记为行头(明细表行头其实就是Data Cell)文本，方便做链接跳转直接识别
-        isLinkFieldText: true,
-        cellData: this.meta,
-      },
-    });
+    this.textShape.style.fill = linkFillColor;
+    this.textShape.style.cursor = 'pointer';
+    this.textShape.appendInfo = {
+      // 标记为行头(明细表行头其实就是Data Cell)文本，方便做链接跳转直接识别
+      isLinkFieldText: true,
+      cellData: this.meta,
+    };
   }
 
   // 根据当前state来更新cell的样式
@@ -466,15 +464,15 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
     updateShapeAttr(this.linkFieldShape, SHAPE_STYLE_MAP.opacity, 1);
   }
 
-  public getTextShape(): DisplayObject {
+  public getTextShape(): CustomText {
     return this.textShape;
   }
 
-  public getTextShapes(): DisplayObject[] {
+  public getTextShapes(): CustomText[] {
     return this.textShapes || [this.textShape];
   }
 
-  public addTextShape(textShape: DisplayObject) {
+  public addTextShape(textShape: CustomText) {
     if (!textShape) {
       return;
     }

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -22,6 +22,7 @@ import { isIPhoneX } from '../utils/is-mobile';
 import { getEllipsisText, getEmptyPlaceholder } from '../utils/text';
 import type { CornerHeaderConfig } from '../facet/header/interface';
 import { CustomRect } from '../engine';
+import type { CustomText } from '../engine/CustomText';
 import { shouldAddResizeArea } from './../utils/interaction/resize';
 import { HeaderCell } from './header-cell';
 
@@ -123,7 +124,7 @@ export class CornerCell extends HeaderCell {
         y: textY,
         text: firstLine,
         ...textStyle,
-      }),
+      }) as CustomText,
     );
 
     // second line
@@ -134,7 +135,7 @@ export class CornerCell extends HeaderCell {
           y: y + height * 0.75,
           text: secondLine,
           ...textStyle,
-        }),
+        }) as CustomText,
       );
     }
 
@@ -288,7 +289,7 @@ export class CornerCell extends HeaderCell {
   }
 
   protected getIconPosition(): PointLike {
-    const textX = this.textShapes?.[0]?.getAttribute('x');
+    const textX = +this.textShapes[0]?.getAttribute('x')! ?? 0;
     const { textBaseline, textAlign } = this.getTextStyle();
     const { size, margin } = this.getStyle()!.icon!;
 
@@ -299,7 +300,7 @@ export class CornerCell extends HeaderCell {
         [matches('right'), constant(0)],
         [stubTrue, constant(this.actualTextWidth)],
       ])(textAlign) +
-      margin?.left;
+      margin?.left!;
 
     const iconY = getVerticalPosition(
       this.getBBoxByType(CellClipBox.CONTENT_BOX),

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -22,7 +22,6 @@ import { isIPhoneX } from '../utils/is-mobile';
 import { getEllipsisText, getEmptyPlaceholder } from '../utils/text';
 import type { CornerHeaderConfig } from '../facet/header/interface';
 import { CustomRect } from '../engine';
-import type { CustomText } from '../engine/CustomText';
 import { shouldAddResizeArea } from './../utils/interaction/resize';
 import { HeaderCell } from './header-cell';
 
@@ -124,7 +123,7 @@ export class CornerCell extends HeaderCell {
         y: textY,
         text: firstLine,
         ...textStyle,
-      }) as CustomText,
+      }),
     );
 
     // second line
@@ -135,7 +134,7 @@ export class CornerCell extends HeaderCell {
           y: y + height * 0.75,
           text: secondLine,
           ...textStyle,
-        }) as CustomText,
+        }),
       );
     }
 

--- a/packages/s2-core/src/cell/merged-cell.ts
+++ b/packages/s2-core/src/cell/merged-cell.ts
@@ -51,11 +51,6 @@ export class MergedCell extends DataCell {
       points: allPoints,
       stroke: cellTheme!.horizontalBorderColor,
       fill: cellTheme!.backgroundColor,
-
-      /*
-       * TODO: 这个应该不需要吧，g5.0 没有lineHeight
-       * lineHeight: cellTheme.horizontalBorderWidth,
-       */
     });
   }
 

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -85,7 +85,6 @@ export class RowCell extends HeaderCell {
       return;
     }
 
-    // TODO: 是否正常返回样式
     const treeIcon = (
       this.meta.parent?.belongsCell as HeaderCell
     ).getTreeIcon();

--- a/packages/s2-core/src/common/interface/emitter.ts
+++ b/packages/s2-core/src/common/interface/emitter.ts
@@ -21,6 +21,7 @@ import type { ResizeInfo } from './resize';
 type CanvasEventHandler = (event: CanvasEvent) => void;
 type KeyboardEventHandler = (event: KeyboardEvent) => void;
 type MouseEventHandler = (event: MouseEvent) => void;
+type PointerEventHandler = (event: PointerEvent) => void;
 type EventHandler = (event: Event) => void;
 type ResizeHandler = (data: {
   info: ResizeInfo;
@@ -42,7 +43,7 @@ export interface EmitterType {
   [S2Event.GLOBAL_MOUSE_MOVE]: MouseEventHandler;
   [S2Event.LAYOUT_RESIZE_MOUSE_DOWN]: CanvasEventHandler;
   [S2Event.LAYOUT_RESIZE_MOUSE_UP]: CanvasEventHandler;
-  [S2Event.LAYOUT_RESIZE_MOUSE_MOVE]: CanvasEventHandler;
+  [S2Event.LAYOUT_RESIZE_MOUSE_MOVE]: PointerEventHandler;
   [S2Event.GLOBAL_CONTEXT_MENU]: CanvasEventHandler;
   [S2Event.GLOBAL_CLICK]: CanvasEventHandler;
   [S2Event.GLOBAL_DOUBLE_CLICK]: CanvasEventHandler;

--- a/packages/s2-core/src/engine/CustomText.ts
+++ b/packages/s2-core/src/engine/CustomText.ts
@@ -1,0 +1,15 @@
+import { Text, type DisplayObjectConfig, type TextStyleProps } from '@antv/g';
+
+/**
+ * 自定义 text 图形
+ * - 有 appendInfo 属性
+ */
+export class CustomText<T = Record<string, any>> extends Text {
+  public declare appendInfo: T;
+
+  constructor(options: DisplayObjectConfig<TextStyleProps>, appendInfo: T) {
+    super(options);
+
+    this.appendInfo = appendInfo;
+  }
+}

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -272,10 +272,9 @@ export abstract class BaseFacet {
   }
 
   hideScrollBar = () => {
-    // TODO: 替换为新方法
-    this.hRowScrollBar?.hide();
-    this.hScrollBar?.hide();
-    this.vScrollBar?.hide();
+    this.hRowScrollBar?.setAttribute('visibility', 'hidden');
+    this.hScrollBar?.setAttribute('visibility', 'hidden');
+    this.vScrollBar?.setAttribute('visibility', 'hidden');
   };
 
   delayHideScrollBar = debounce(this.hideScrollBar, 1000);
@@ -287,12 +286,12 @@ export abstract class BaseFacet {
   };
 
   showVerticalScrollBar = () => {
-    this.vScrollBar?.show();
+    this.vScrollBar?.setAttribute('visibility', 'visible');
   };
 
   showHorizontalScrollBar = () => {
-    this.hRowScrollBar?.show();
-    this.hScrollBar?.show();
+    this.hRowScrollBar?.setAttribute('visibility', 'visible');
+    this.hScrollBar?.setAttribute('visibility', 'visible');
   };
 
   onContainerWheel = () => {

--- a/packages/s2-core/src/facet/header/base.ts
+++ b/packages/s2-core/src/facet/header/base.ts
@@ -11,7 +11,6 @@ export abstract class BaseHeader<T extends BaseHeaderConfig> extends Group {
   protected headerConfig: T;
 
   protected constructor(cfg: T) {
-    // TODO: 修改为不传递 cfg 到 group
     super();
     this.headerConfig = cfg;
   }

--- a/packages/s2-core/src/facet/header/frame.ts
+++ b/packages/s2-core/src/facet/header/frame.ts
@@ -8,7 +8,6 @@ export class Frame extends Group {
   declare cfg: FrameConfig;
 
   constructor(cfg: FrameConfig) {
-    // TODO: cfg 不再挂到 group 上
     super();
     this.cfg = cfg;
     this.render();

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -897,11 +897,6 @@ export class TableFacet extends BaseFacet {
         );
       }
     }
-
-    /*
-     * TODO: g5.0 没有这个排序方法，好像也没啥用
-     * this.foregroundGroup.sort();
-     */
   };
 
   protected renderFrozenPanelCornerGroup = () => {

--- a/packages/s2-core/src/facet/utils.ts
+++ b/packages/s2-core/src/facet/utils.ts
@@ -122,7 +122,6 @@ export const translateGroup = (
   scrollY: number,
 ) => {
   if (group) {
-    // TODO: 可能是本地 getLocalPosition
     const [preX, preY] = group.getPosition();
 
     group.translate(scrollX - preX, scrollY - preY);

--- a/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/data-cell-click.ts
@@ -30,7 +30,6 @@ export class DataCellClick extends BaseEvent implements BaseEventImplement {
     this.bindDataCellClick();
   }
 
-  // TODO: 抽公共逻辑
   private countClick() {
     window.clearTimeout(this.clickTimer);
     this.clickTimer = window.setTimeout(() => {

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -3,7 +3,6 @@ import {
   type FederatedPointerEvent as CanvasEvent,
   type Group,
   DisplayObject,
-  type FederatedEvent,
 } from '@antv/g';
 import { get, each, isEmpty, isNil } from 'lodash';
 import { CustomImage } from '../engine';
@@ -243,7 +242,6 @@ export class EventController {
   }
 
   private isResizeArea(event: CanvasEvent) {
-    // TODO: resize 是否能取到属性
     const appendInfo = getAppendInfo(event.target as DisplayObject);
 
     return appendInfo?.isResizeArea;
@@ -289,26 +287,27 @@ export class EventController {
       this.spreadsheet.emit(S2Event.LAYOUT_RESIZE_MOUSE_DOWN, event);
 
       // 仅捕获在 Canvas 之外触发的事件 https://github.com/antvis/S2/issues/1592
-      const resizeMouseMoveCapture = (mouseEvent: MouseEvent) => {
+      const resizeMouseMoveCapture = (pointerEvent: PointerEvent) => {
         if (!this.spreadsheet.getCanvasElement()) {
           return false;
         }
 
-        if (this.spreadsheet.getCanvasElement() !== mouseEvent.target) {
-          // TODO: resize 逻辑，可以不用覆盖 event 的方式传递？后三行都要改
-          event.client.x = mouseEvent.clientX;
-          event.client.y = mouseEvent.clientY;
-          event.originalEvent =
-            mouseEvent as unknown as FederatedEvent<MouseEvent>;
-          this.spreadsheet.emit(S2Event.LAYOUT_RESIZE_MOUSE_MOVE, event);
+        if (this.spreadsheet.getCanvasElement() !== pointerEvent.target) {
+          this.spreadsheet.emit(S2Event.LAYOUT_RESIZE_MOUSE_MOVE, pointerEvent);
         }
       };
 
-      window.addEventListener('mousemove', resizeMouseMoveCapture);
       window.addEventListener(
-        'mouseup',
+        OriginEventType.POINTER_MOVE,
+        resizeMouseMoveCapture,
+      );
+      window.addEventListener(
+        OriginEventType.POINTER_UP,
         () => {
-          window.removeEventListener('mousemove', resizeMouseMoveCapture);
+          window.removeEventListener(
+            OriginEventType.POINTER_MOVE,
+            resizeMouseMoveCapture,
+          );
         },
         { once: true },
       );
@@ -342,7 +341,10 @@ export class EventController {
   private onCanvasMousemove = (event: CanvasEvent) => {
     if (this.isResizeArea(event)) {
       this.activeResizeArea(event);
-      this.spreadsheet.emit(S2Event.LAYOUT_RESIZE_MOUSE_MOVE, event);
+      this.spreadsheet.emit(
+        S2Event.LAYOUT_RESIZE_MOUSE_MOVE,
+        event.nativeEvent as PointerEvent,
+      );
 
       return;
     }
@@ -533,7 +535,6 @@ export class EventController {
   };
 
   private onCanvasMouseout = (event: CanvasEvent) => {
-    // TODO: if 第二个条件是判断有 event?.shape，g5没有这个属性了
     if (!this.isAutoResetSheetStyle || event?.target instanceof DisplayObject) {
       return;
     }

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -224,7 +224,6 @@ export class RootInteraction {
   public getAllRowHeaderCells(): RowCell[] {
     const children = this.spreadsheet.facet?.foregroundGroup?.children || [];
     const rowHeader = children.find((group) => group instanceof RowHeader);
-    // TODO: 不用从 cfg 取 children 了吧
     const headerChildren = rowHeader?.children || [];
 
     return getAllChildCells(headerChildren as RowCell[], RowCell).filter(

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -545,7 +545,6 @@ export abstract class SpreadSheet extends EE {
   public getCell<T extends S2CellType = S2CellType>(
     target: CellEventTarget,
   ): T | null {
-    // TODO: 5.0 用 composedPath 来替换本方法
     let parent = target;
 
     // 一直索引到g顶层的canvas来检查是否在指定的cell中

--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -355,11 +355,6 @@ export const drawBullet = (value: BulletValue, cell: S2CellType) => {
     width: bulletWidth,
     height: progressBar.height,
     fill: backgroundColor,
-
-    /*
-     * TODO: 这个应该不需要的吧，g5.0
-     * textBaseline: dataCellStyle.text.textBaseline,
-     */
   });
 
   // 2. 进度条

--- a/packages/s2-core/src/utils/g-renders.ts
+++ b/packages/s2-core/src/utils/g-renders.ts
@@ -21,7 +21,7 @@ import {
 import { forEach, isArray, isEmpty, isFunction } from 'lodash';
 import { GuiIcon, type GuiIconCfg } from '../common/icons/gui-icon';
 
-export function renderRect(group: Group, style: RectStyleProps): DisplayObject {
+export function renderRect(group: Group, style: RectStyleProps): Rect {
   return group?.appendChild(
     new Rect({
       style,
@@ -29,17 +29,14 @@ export function renderRect(group: Group, style: RectStyleProps): DisplayObject {
   );
 }
 
-export function renderPolygon(
-  group: Group,
-  style: PolygonStyleProps,
-): DisplayObject {
+export function renderPolygon(group: Group, style: PolygonStyleProps): Polygon {
   return group?.appendChild(new Polygon({ style }));
 }
 
 export function renderPolyline(
   group: Group,
   style: PolylineStyleProps,
-): DisplayObject {
+): Polyline {
   return group?.appendChild(
     new Polyline({
       style,
@@ -47,10 +44,7 @@ export function renderPolyline(
   );
 }
 
-export function renderCircle(
-  group: Group,
-  style: CircleStyleProps,
-): DisplayObject {
+export function renderCircle(group: Group, style: CircleStyleProps): Circle {
   return group?.appendChild(
     new Circle({
       style,
@@ -92,7 +86,7 @@ export function renderLine(
   group: Group,
   coordinate: { x1: number; y1: number; x2: number; y2: number },
   lineStyle: Omit<LineStyleProps, 'x1' | 'x2' | 'y1' | 'y2'>,
-): DisplayObject {
+): Line {
   return group?.appendChild(
     new Line({
       style: {

--- a/packages/s2-core/src/utils/g-renders.ts
+++ b/packages/s2-core/src/utils/g-renders.ts
@@ -62,7 +62,7 @@ export function renderText(
   group: Group,
   shapes: DisplayObject[],
   attrs: TextStyleProps,
-): DisplayObject {
+): Text {
   if (!isEmpty(shapes) && group) {
     forEach(shapes, (shape: DisplayObject) => {
       if (group.contains(shape)) {

--- a/packages/s2-core/src/utils/interaction/common.ts
+++ b/packages/s2-core/src/utils/interaction/common.ts
@@ -1,18 +1,12 @@
 import type { DisplayObject } from '@antv/g';
-import { CustomRect } from '../../engine';
 import type { CellAppendInfo } from '../../common';
 
 export const getAppendInfo = <T extends Record<string, any> = CellAppendInfo>(
   eventTarget: DisplayObject,
 ) => {
-  if (!eventTarget) {
+  if (!eventTarget || !('appendInfo' in eventTarget)) {
     return {} as T;
   }
 
-  if (eventTarget instanceof CustomRect) {
-    return eventTarget.appendInfo as T;
-  }
-
-  // TODO: g5.0 没有 attrs 了，另外需要适配 textShape 下划线的那个，resize 应该都用 CustomRect 解决了
-  return (eventTarget?.attr?.('appendInfo') || {}) as T;
+  return eventTarget.appendInfo as T;
 };

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -30,7 +30,6 @@ import {
 } from '../common/interface';
 import type { Padding, TextTheme } from '../common/interface/theme';
 import { renderIcon, renderText } from '../utils/g-renders';
-import type { CustomText } from '../engine/CustomText';
 import { renderMiniChart } from './g-mini-charts';
 import { getMaxTextWidth, getTextAndFollowingIconPosition } from './cell/cell';
 
@@ -462,7 +461,7 @@ export const drawObjectText = (
       ...labelStyle,
     });
 
-    cell.addTextShape(textShape as CustomText);
+    cell.addTextShape(textShape);
   }
 
   // 绘制指标
@@ -531,7 +530,7 @@ export const drawObjectText = (
         ...curStyle,
       });
 
-      cell.addTextShape(textShape as CustomText);
+      cell.addTextShape(textShape);
 
       // 绘制条件格式的 icon
       if (iconCondition && useCondition) {

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -30,6 +30,7 @@ import {
 } from '../common/interface';
 import type { Padding, TextTheme } from '../common/interface/theme';
 import { renderIcon, renderText } from '../utils/g-renders';
+import type { CustomText } from '../engine/CustomText';
 import { renderMiniChart } from './g-mini-charts';
 import { getMaxTextWidth, getTextAndFollowingIconPosition } from './cell/cell';
 
@@ -461,7 +462,7 @@ export const drawObjectText = (
       ...labelStyle,
     });
 
-    cell.addTextShape(textShape);
+    cell.addTextShape(textShape as CustomText);
   }
 
   // 绘制指标
@@ -530,7 +531,7 @@ export const drawObjectText = (
         ...curStyle,
       });
 
-      cell.addTextShape(textShape);
+      cell.addTextShape(textShape as CustomText);
 
       // 绘制条件格式的 icon
       if (iconCondition && useCondition) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🎨 Enhance

- [x] Refactoring

### 📝 Description

主要解决迁移 g5.0 后的 todo 项目
- 清除过时的 todo
- 固定 `base-cell` 图形的类型
- 对含有 appendInfo 的 text 迁移到自定义类 `CustomText`（类似 CustomRect，不再使用 `.attr()` 语法）
- 整理 resize 事件，统一使用 PointerEvent
