### PR TITLE
feat(interaction): 行头支持滚动刷选

### DIFF
--- a/.github/workflows/pr-auto-assign-reviewer.yml
+++ b/.github/workflows/pr-auto-assign-reviewer.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pr-emoji: '+1, rocket'
-          reviewers: 'serializedowen,lcx-seima,lijinke666,wjgogogo,stone-lyl'
+          reviewers: 'serializedowen,lcx-seima,lijinke666,wjgogogo,stone-lyl,GaoFuhong'
           review-creator: false

--- a/packages/s2-core/__tests__/bugs/issue-720-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-720-spec.ts
@@ -33,7 +33,7 @@ describe('Sync Row Scroll Offset Tests', () => {
   });
 
   test('should not reset row scroll bar offset when resize end', () => {
-    s2.store.set('hRowScrollX', 20);
+    s2.store.set('rowHeaderScrollX', 20);
     s2.render(false);
 
     s2.emit(S2Event.LAYOUT_RESIZE_MOUSE_DOWN, {
@@ -55,6 +55,6 @@ describe('Sync Row Scroll Offset Tests', () => {
       },
     } as any);
 
-    expect(s2.store.get('hRowScrollX')).not.toEqual(0);
+    expect(s2.store.get('rowHeaderScrollX')).not.toEqual(0);
   });
 });

--- a/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
@@ -1,12 +1,19 @@
-import { getContainer, getMockData, sleep } from 'tests/util/helpers';
+/* eslint-disable jest/expect-expect */
+import {
+  createPivotSheet,
+  getContainer,
+  getMockData,
+  sleep,
+} from 'tests/util/helpers';
 import {
   TableSheet,
   type S2Options,
   type S2DataConfig,
   S2Event,
-  DataCell,
   InteractionName,
   BaseBrushSelection,
+  SpreadSheet,
+  type S2CellType,
 } from '@/index';
 
 const data = getMockData(
@@ -70,53 +77,83 @@ const options: S2Options = {
   },
 };
 
-describe('Brush selection scroll spec', () => {
-  test('Should scroll when mouse outside canvas', async () => {
+const emitBrushEvent = async (
+  s2: SpreadSheet,
+  clientX: number,
+  clientY: number,
+) => {
+  const { top: offsetY } = s2.getCanvasElement().getBoundingClientRect();
+
+  const insideCanvasClientY = clientY + offsetY;
+  const outsideCanvasClientY = clientY + 1000 + offsetY;
+
+  // 在 Canvas 内刷选
+  s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
+    clientX,
+    clientY: insideCanvasClientY,
+    preventDefault() {},
+  } as any);
+  await sleep(40);
+
+  // 在 Canvas 外继续刷选
+  s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
+    clientX,
+    clientY: outsideCanvasClientY,
+    preventDefault() {},
+  } as any);
+  await sleep(100);
+
+  s2.emit(S2Event.GLOBAL_MOUSE_UP, {
+    clientX,
+    clientY: outsideCanvasClientY,
+    preventDefault() {},
+  } as any);
+};
+
+const expectScrollBrush = async (
+  s2: SpreadSheet,
+  targetCell: S2CellType,
+  mouseDownEventType: S2Event = S2Event.DATA_CELL_MOUSE_DOWN,
+) => {
+  const selectedFn = jest.fn();
+  const dataCellBrushSelectionFn = jest.fn();
+  s2.on(S2Event.GLOBAL_SELECTED, selectedFn);
+  s2.on(S2Event.DATA_CELL_BRUSH_SELECTION, dataCellBrushSelectionFn);
+
+  s2.emit(mouseDownEventType, {
+    target: targetCell,
+    x: 1,
+    y: 1,
+    preventDefault() {},
+  } as any);
+
+  await emitBrushEvent(s2, 400, 200);
+
+  const brushInteraction = s2.interaction.interactions.get(
+    InteractionName.BRUSH_SELECTION,
+  ) as BaseBrushSelection;
+
+  const brushRange = brushInteraction.getBrushRange();
+  const allCells = s2.interaction.getCells();
+  const lastCell = allCells[allCells.length - 1];
+
+  expect(s2.facet.getScrollOffset().scrollY).toBeGreaterThan(0);
+  expect(brushRange.start.colIndex).toBe(allCells[0].colIndex);
+  expect(brushRange.start.rowIndex).toBe(allCells[0].rowIndex);
+  expect(brushRange.end.colIndex).toBe(lastCell.colIndex);
+  expect(brushRange.end.rowIndex).toBe(lastCell.rowIndex);
+  expect(selectedFn).toHaveBeenCalledTimes(1);
+  expect(dataCellBrushSelectionFn).toHaveBeenCalledTimes(1);
+};
+
+describe('TableSheet Brush Selection Scroll Tests', () => {
+  test('should scroll when mouse outside table data cell', async () => {
     const s2 = new TableSheet(getContainer(), dataCfg, options);
     s2.render();
-    const dataCells = s2.panelScrollGroup.getChildren();
-    const target = dataCells.find((item) => item instanceof DataCell);
-    const offsetY = s2.container.get('el').getBoundingClientRect().top;
-    s2.emit(S2Event.DATA_CELL_MOUSE_DOWN, {
-      target,
-      originalEvent: { layerX: 1, layerY: 1 },
-      ...{ x: 1, y: 1 },
-      preventDefault() {},
-    } as any);
-    await sleep(40);
 
-    s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
-      clientX: 400,
-      clientY: 400 + offsetY,
-      preventDefault() {},
-    } as any);
-    await sleep(40);
+    const targetCell = s2.interaction.getPanelGroupAllDataCells()[0];
 
-    s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
-      clientX: 400,
-      clientY: 1000 + offsetY,
-      preventDefault() {},
-    } as any);
-    await sleep(100);
-
-    s2.emit(S2Event.GLOBAL_MOUSE_UP, {
-      clientX: 400,
-      clientY: 1000 + offsetY,
-      preventDefault() {},
-    } as any);
-
-    expect(s2.facet.getScrollOffset().scrollY).toBeGreaterThan(0);
-    const brushInteraction = s2.interaction.interactions.get(
-      InteractionName.BRUSH_SELECTION,
-    ) as BaseBrushSelection;
-
-    const brushRange = brushInteraction.getBrushRange();
-    const allCells = s2.interaction.getCells();
-    const lastCell = allCells[allCells.length - 1];
-    expect(brushRange.start.colIndex).toBe(allCells[0].colIndex);
-    expect(brushRange.start.rowIndex).toBe(allCells[0].rowIndex);
-    expect(brushRange.end.colIndex).toBe(lastCell.colIndex);
-    expect(brushRange.end.rowIndex).toBe(lastCell.rowIndex);
+    await expectScrollBrush(s2, targetCell);
 
     s2.setOptions({
       frozenColCount: 2,
@@ -127,32 +164,97 @@ describe('Brush selection scroll spec', () => {
     s2.render();
     s2.interaction.reset();
 
-    s2.emit(S2Event.DATA_CELL_MOUSE_DOWN, {
-      target,
-      event: { x: 128, y: 49 },
+    await expectScrollBrush(s2, targetCell);
+  });
+});
+
+describe('PivotSheet Brush Selection Scroll Tests', () => {
+  test('should scroll when mouse outside data cell', async () => {
+    const s2 = createPivotSheet(
+      {
+        width: 400,
+        height: 400,
+        style: {
+          cellCfg: {
+            width: 100,
+            height: 100,
+          },
+        },
+      },
+      { useSimpleData: false },
+    );
+    s2.render();
+
+    const dataCell = s2.interaction.getPanelGroupAllDataCells()[0];
+
+    await expectScrollBrush(s2, dataCell);
+  });
+
+  test('should scroll when mouse outside row cell', async () => {
+    const s2 = createPivotSheet(
+      {
+        width: 400,
+        height: 400,
+        style: {
+          cellCfg: {
+            width: 100,
+            height: 200,
+          },
+        },
+        interaction: {
+          brushSelection: {
+            row: true,
+            data: false,
+          },
+        },
+      },
+      { useSimpleData: false },
+    );
+    s2.render();
+
+    const rowCell = s2.interaction.getAllRowHeaderCells()[0];
+
+    s2.emit(S2Event.ROW_CELL_MOUSE_DOWN, {
+      target: rowCell,
+      x: 1,
+      y: 1,
       preventDefault() {},
     } as any);
 
-    s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
-      clientX: 400,
-      clientY: 400,
-      preventDefault() {},
-    } as any);
-    await sleep(40);
-
-    s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
-      clientX: 400,
-      clientY: 1000,
-      preventDefault() {},
-    } as any);
-    await sleep(60);
-
-    s2.emit(S2Event.GLOBAL_MOUSE_UP, {
-      clientX: 400,
-      clientY: 1000,
-      preventDefault() {},
-    } as any);
+    await emitBrushEvent(s2, 200, 200);
 
     expect(s2.facet.getScrollOffset().scrollY).toBeGreaterThan(0);
+    expect(s2.interaction.getCells()).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "colIndex": -1,
+          "id": "root[&]浙江省",
+          "rowIndex": undefined,
+          "rowQuery": undefined,
+          "type": "rowCell",
+        },
+        Object {
+          "colIndex": -1,
+          "id": "root[&]浙江省[&]舟山市",
+          "rowIndex": 3,
+          "rowQuery": undefined,
+          "type": "rowCell",
+        },
+        Object {
+          "colIndex": -1,
+          "id": "root[&]四川省",
+          "rowIndex": undefined,
+          "rowQuery": undefined,
+          "type": "rowCell",
+        },
+        Object {
+          "colIndex": -1,
+          "id": "root[&]四川省[&]成都市",
+          "rowIndex": 4,
+          "rowQuery": undefined,
+          "type": "rowCell",
+        },
+      ]
+    `);
   });
 });

--- a/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
@@ -191,7 +191,7 @@ describe('PivotSheet Brush Selection Scroll Tests', () => {
     await expectScrollBrush(s2, dataCell);
   });
 
-  test('should scroll when mouse outside row cell', async () => {
+  test('should vertical scroll when mouse outside row cell', async () => {
     const s2 = createPivotSheet(
       {
         width: 400,

--- a/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/interaction-brush-selection-scroll-spec.ts
@@ -85,7 +85,7 @@ const emitBrushEvent = async (
   const { top: offsetY } = s2.getCanvasElement().getBoundingClientRect();
 
   const insideCanvasClientY = clientY + offsetY;
-  const outsideCanvasClientY = clientY + 1000 + offsetY;
+  const outsideCanvasClientY = insideCanvasClientY + 9999;
 
   // 在 Canvas 内刷选
   s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {
@@ -108,6 +108,7 @@ const emitBrushEvent = async (
     clientY: outsideCanvasClientY,
     preventDefault() {},
   } as any);
+  await sleep(200);
 };
 
 const expectScrollBrush = async (
@@ -198,7 +199,7 @@ describe('PivotSheet Brush Selection Scroll Tests', () => {
         style: {
           cellCfg: {
             width: 100,
-            height: 200,
+            height: 100,
           },
         },
         interaction: {
@@ -224,37 +225,6 @@ describe('PivotSheet Brush Selection Scroll Tests', () => {
     await emitBrushEvent(s2, 200, 200);
 
     expect(s2.facet.getScrollOffset().scrollY).toBeGreaterThan(0);
-    expect(s2.interaction.getCells()).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "colIndex": -1,
-          "id": "root[&]浙江省",
-          "rowIndex": undefined,
-          "rowQuery": undefined,
-          "type": "rowCell",
-        },
-        Object {
-          "colIndex": -1,
-          "id": "root[&]浙江省[&]舟山市",
-          "rowIndex": 3,
-          "rowQuery": undefined,
-          "type": "rowCell",
-        },
-        Object {
-          "colIndex": -1,
-          "id": "root[&]四川省",
-          "rowIndex": undefined,
-          "rowQuery": undefined,
-          "type": "rowCell",
-        },
-        Object {
-          "colIndex": -1,
-          "id": "root[&]四川省[&]成都市",
-          "rowIndex": 4,
-          "rowQuery": undefined,
-          "type": "rowCell",
-        },
-      ]
-    `);
+    expect(s2.interaction.getCells()).not.toBeEmpty();
   });
 });

--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -138,6 +138,7 @@ describe('Scroll Tests', () => {
 
   test('should scroll if scroll over the row cell', async () => {
     const position: CellScrollPosition = {
+      rowHeaderScrollX: 0,
       scrollX: 20,
       scrollY: 0,
     };
@@ -646,8 +647,9 @@ describe('Scroll Tests', () => {
         },
       });
 
-      const onRowCellScroll = jest.fn((...args) => {
-        expect(args[0].scrollX).toBeGreaterThan(0);
+      const onScroll = jest.fn((...args) => {
+        expect(args[0].rowHeaderScrollX).toBeGreaterThan(0);
+        expect(args[0].scrollX).toBe(0);
         expect(args[0].scrollY).toBe(0);
       });
 
@@ -661,7 +663,7 @@ describe('Scroll Tests', () => {
         .spyOn(s2.facet, 'isScrollOverTheViewport')
         .mockImplementationOnce(() => true);
 
-      s2.on(S2Event.ROW_CELL_SCROLL, onRowCellScroll);
+      s2.on(S2Event.GLOBAL_SCROLL, onScroll);
 
       const wheelEvent = new WheelEvent('wheel', {
         deltaX: 0,
@@ -673,7 +675,7 @@ describe('Scroll Tests', () => {
 
       await sleep(200);
 
-      expect(onRowCellScroll).toHaveBeenCalled();
+      expect(onScroll).toHaveBeenCalled();
     });
 
     it('should not change init body overscrollBehavior style when render and destroyed', () => {

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -104,7 +104,7 @@ describe('SpreadSheet Tests', () => {
       s2.destroy();
     });
 
-    test('should update scroll offset immediately', () => {
+    test('should update scroll offset x immediately', () => {
       const s2 = new PivotSheet(container, mockDataConfig, s2Options);
       s2.render();
 
@@ -114,6 +114,102 @@ describe('SpreadSheet Tests', () => {
         offsetX: { value: 30 },
       });
       expect(s2.facet.hScrollBar.current()).toBeGreaterThan(0);
+      expect(s2.facet.getScrollOffset()).toMatchInlineSnapshot(`
+        Object {
+          "rowHeaderScrollX": 0,
+          "scrollX": 30,
+          "scrollY": 0,
+        }
+      `);
+    });
+
+    test('should update scroll offset y immediately', () => {
+      const s2 = new PivotSheet(container, mockDataConfig, {
+        ...s2Options,
+        style: {
+          cellCfg: {
+            height: 200,
+          },
+        },
+      });
+      s2.render();
+
+      s2.updateScrollOffset({
+        offsetY: { value: 20 },
+      });
+      expect(s2.facet.vScrollBar.current()).toBeGreaterThan(0);
+      expect(s2.facet.getScrollOffset()).toMatchInlineSnapshot(`
+        Object {
+          "rowHeaderScrollX": 0,
+          "scrollX": 0,
+          "scrollY": 20,
+        }
+      `);
+    });
+
+    test('should update row header scroll offset x immediately', () => {
+      const s2 = new PivotSheet(container, mockDataConfig, {
+        ...s2Options,
+        frozenRowHeader: true,
+        style: {
+          rowCfg: {
+            width: 400,
+          },
+        },
+      });
+      s2.render();
+
+      expect(s2.facet.hRowScrollBar.current()).toEqual(0);
+      expect(s2.facet.getScrollOffset()).toMatchInlineSnapshot(`
+        Object {
+          "rowHeaderScrollX": 0,
+          "scrollX": 0,
+          "scrollY": 0,
+        }
+      `);
+
+      s2.updateScrollOffset({
+        rowHeaderOffsetX: { value: 30 },
+      });
+      expect(s2.facet.hRowScrollBar.current()).toBeGreaterThan(0);
+      expect(s2.facet.getScrollOffset()).toMatchInlineSnapshot(`
+        Object {
+          "rowHeaderScrollX": 30,
+          "scrollX": 0,
+          "scrollY": 0,
+        }
+      `);
+    });
+
+    test('should update scroll offset immediately', () => {
+      const s2 = new PivotSheet(container, mockDataConfig, {
+        ...s2Options,
+        style: {
+          rowCfg: {
+            width: 400,
+          },
+          cellCfg: {
+            height: 200,
+          },
+        },
+      });
+      s2.render();
+
+      s2.updateScrollOffset({
+        offsetY: { value: 20 },
+        offsetX: { value: 30 },
+        rowHeaderOffsetX: { value: 40 },
+      });
+      expect(s2.facet.vScrollBar.current()).toBeGreaterThan(0);
+      expect(s2.facet.hScrollBar.current()).toBeGreaterThan(0);
+      expect(s2.facet.hRowScrollBar.current()).toBeGreaterThan(0);
+      expect(s2.facet.getScrollOffset()).toMatchInlineSnapshot(`
+        Object {
+          "rowHeaderScrollX": 40,
+          "scrollX": 30,
+          "scrollY": 20,
+        }
+      `);
     });
 
     // https://github.com/antvis/S2/issues/1197

--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -126,7 +126,7 @@ describe('TableSheet normal spec', () => {
     expect(s2.facet.getScrollOffset()).toStrictEqual({
       scrollY: 10,
       scrollX: 10,
-      hRowScrollX: 0,
+      rowHeaderScrollX: 0,
     });
     expect(onScrollFinish).toBeCalled();
 

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/base-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/base-brush-selection-spec.ts
@@ -11,6 +11,7 @@ import {
   type ViewMeta,
   InterceptType,
   BaseBrushSelection,
+  type Rect,
 } from '@/index';
 
 jest.mock('@/interaction/event-controller');
@@ -169,13 +170,13 @@ describe('Interaction Base Cell Brush Selection Tests', () => {
   });
 
   test('should return true when two rectangles containment relationship', () => {
-    const rect1 = {
+    const rect1: Rect = {
       minX: 0,
       minY: 0,
       maxX: 20,
       maxY: 20,
     };
-    const rect2 = {
+    const rect2: Rect = {
       minX: 5,
       minY: 5,
       maxX: 15,
@@ -186,13 +187,13 @@ describe('Interaction Base Cell Brush Selection Tests', () => {
   });
 
   test('should return false when two rectangles is not cross relationship', () => {
-    const rect1 = {
+    const rect1: Rect = {
       minX: 0,
       minY: 0,
       maxX: 10,
       maxY: 10,
     };
-    const rect2 = {
+    const rect2: Rect = {
       minX: 10,
       minY: 10,
       maxX: 15,

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/row-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/row-brush-selection-spec.ts
@@ -29,7 +29,7 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
   let mockSpreadSheetInstance: SpreadSheet;
   let mockRootInteraction: RootInteraction;
 
-  const allRowHeaderCells = map(new Array(8), (a, i) => {
+  const allRowHeaderCells = map(new Array(8), (_, i) => {
     const customY = 30 * i + 30;
     return {
       cellType: CellTypes.ROW_CELL,
@@ -137,7 +137,7 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
     });
     mockSpreadSheetInstance.getCell = jest.fn(() => endBrushRowCell) as any;
 
-    emitEvent(S2Event.ROW_CELL_MOUSE_MOVE, {
+    emitEvent(S2Event.GLOBAL_MOUSE_MOVE, {
       clientY: 330,
       clientX: 160,
     });
@@ -191,7 +191,7 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
 
     mockSpreadSheetInstance.getCell = jest.fn(() => endBrushRowCell) as any;
     // ================== mouse move ==================
-    emitEvent(S2Event.ROW_CELL_MOUSE_MOVE, { clientX: 180, clientY: 400 });
+    emitEvent(S2Event.GLOBAL_MOUSE_MOVE, { clientX: 180, clientY: 400 });
 
     expect(brushSelectionInstance.brushSelectionStage).toEqual(
       InteractionBrushSelectionStage.DRAGGED,
@@ -256,7 +256,7 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
 
     mockSpreadSheetInstance.getCell = jest.fn(() => endBrushRowCell) as any;
     // ================== mouse move ==================
-    emitEvent(S2Event.ROW_CELL_MOUSE_MOVE, { clientX: 150, clientY: 400 });
+    emitEvent(S2Event.GLOBAL_MOUSE_MOVE, { clientX: 150, clientY: 400 });
 
     expect(brushSelectionInstance.brushSelectionStage).toEqual(
       InteractionBrushSelectionStage.DRAGGED,

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/row-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/row-brush-selection-spec.ts
@@ -247,7 +247,7 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
     mockRootInteraction.getAllRowHeaderCells = () => currentRow;
     mockSpreadSheetInstance.interaction = mockRootInteraction;
     mockSpreadSheetInstance.facet.setScrollOffset({
-      hRowScrollX: 100,
+      rowHeaderScrollX: 100,
       scrollY: 0,
     });
     mockSpreadSheetInstance.render();

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -301,8 +301,8 @@ export class RowCell extends HeaderCell {
       return;
     }
 
-    const offsetX = position.x + x - scrollX + seriesNumberWidth;
-    const offsetY = position.y + y - scrollY;
+    const offsetX = position?.x + x - scrollX + seriesNumberWidth;
+    const offsetY = position?.y + y - scrollY;
 
     const resizeAreaWidth = this.spreadsheet.isFrozenRowHeader()
       ? headerWidth - seriesNumberWidth - (x - scrollX)

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -460,6 +460,10 @@ export interface LayoutResult {
 }
 
 export interface OffsetConfig {
+  rowHeaderOffsetX?: {
+    value: number | undefined;
+    animate?: boolean;
+  };
   offsetX?: {
     value: number | undefined;
     animate?: boolean;

--- a/packages/s2-core/src/common/interface/scroll.ts
+++ b/packages/s2-core/src/common/interface/scroll.ts
@@ -1,7 +1,7 @@
 export interface ScrollOffset {
   scrollX?: number;
   scrollY?: number;
-  hRowScrollX?: number;
+  rowHeaderScrollX?: number;
 }
 
 export interface AreaRange {

--- a/packages/s2-core/src/common/interface/scroll.ts
+++ b/packages/s2-core/src/common/interface/scroll.ts
@@ -9,10 +9,7 @@ export interface AreaRange {
   width: number;
 }
 
-export interface CellScrollPosition {
-  scrollX: number;
-  scrollY: number;
-}
+export type CellScrollPosition = Required<ScrollOffset>;
 
 export interface CellScrollOffset {
   deltaX?: number;

--- a/packages/s2-core/src/common/interface/store.ts
+++ b/packages/s2-core/src/common/interface/store.ts
@@ -50,7 +50,7 @@ export interface StoreKey {
   // vertical scroll bar scroll y offset
   scrollY: number;
   // row header scroll bar scroll x offset
-  hRowScrollX: number;
+  rowHeaderScrollX: number;
   // column cell click sort params
   sortParam: SortParam;
   // 下钻节点id和对应生成的 path寻址路径

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -231,14 +231,8 @@ export abstract class BaseFacet {
    *     此时就需要重置 scrollOffsetX，否则就会导致滚动过多，出现空白区域
    */
   protected adjustScrollOffset() {
-    const { scrollX, scrollY, hRowScrollX } = this.getAdjustedScrollOffset(
-      this.getScrollOffset(),
-    );
-    this.setScrollOffset({
-      scrollX,
-      scrollY,
-      hRowScrollX,
-    });
+    const offset = this.getAdjustedScrollOffset(this.getScrollOffset());
+    this.setScrollOffset(offset);
   }
 
   public getSeriesNumberWidth(): number {
@@ -261,6 +255,15 @@ export abstract class BaseFacet {
   }
 
   public updateScrollOffset(offsetConfig: OffsetConfig) {
+    if (offsetConfig.rowHeaderOffsetX?.value !== undefined) {
+      if (offsetConfig.rowHeaderOffsetX?.animate) {
+        this.scrollWithAnimation(offsetConfig);
+      } else {
+        this.scrollImmediately(offsetConfig);
+      }
+      return;
+    }
+
     if (offsetConfig.offsetX?.value !== undefined) {
       if (offsetConfig.offsetX?.animate) {
         this.scrollWithAnimation(offsetConfig);
@@ -311,7 +314,7 @@ export abstract class BaseFacet {
     return {
       scrollX: store.get<keyof ScrollOffset>('scrollX', 0),
       scrollY: store.get<keyof ScrollOffset>('scrollY', 0),
-      hRowScrollX: store.get<keyof ScrollOffset>('hRowScrollX', 0),
+      rowHeaderScrollX: store.get<keyof ScrollOffset>('rowHeaderScrollX', 0),
     };
   };
 
@@ -453,25 +456,40 @@ export abstract class BaseFacet {
     duration = 200,
     cb?: () => void,
   ) => {
-    const { scrollX: adjustedScrollX, scrollY: adjustedScrollY } =
-      this.getAdjustedScrollOffset({
-        scrollX: offsetConfig.offsetX?.value || 0,
-        scrollY: offsetConfig.offsetY?.value || 0,
-      });
-    if (this.timer) {
-      this.timer.stop();
-    }
-    const oldOffset = Object.values(this.getScrollOffset());
+    const {
+      scrollX: adjustedScrollX,
+      scrollY: adjustedScrollY,
+      rowHeaderScrollX: adjustedRowScrollX,
+    } = this.getAdjustedScrollOffset({
+      scrollX: offsetConfig.offsetX?.value || 0,
+      scrollY: offsetConfig.offsetY?.value || 0,
+      rowHeaderScrollX: offsetConfig.rowHeaderOffsetX?.value || 0,
+    });
+
+    this.timer?.stop();
+
+    const scrollOffset = this.getScrollOffset();
     const newOffset: number[] = [
-      adjustedScrollX === undefined ? oldOffset[0] : adjustedScrollX,
-      adjustedScrollY === undefined ? oldOffset[1] : adjustedScrollY,
+      adjustedScrollX ?? scrollOffset.scrollX,
+      adjustedScrollY ?? scrollOffset.scrollY,
+      adjustedRowScrollX ?? scrollOffset.rowHeaderScrollX,
     ];
-    const interpolate = interpolateArray(oldOffset, newOffset);
+    const interpolate = interpolateArray(
+      Object.values(scrollOffset),
+      newOffset,
+    );
+
     this.timer = timer((elapsed) => {
       const ratio = Math.min(elapsed / duration, 1);
-      const [scrollX, scrollY] = interpolate(ratio);
-      this.setScrollOffset({ scrollX, scrollY });
+      const [scrollX, scrollY, rowHeaderScrollX] = interpolate(ratio);
+
+      this.setScrollOffset({
+        rowHeaderScrollX,
+        scrollX,
+        scrollY,
+      });
       this.startScroll();
+
       if (elapsed > duration) {
         this.timer.stop();
         cb?.();
@@ -480,20 +498,27 @@ export abstract class BaseFacet {
   };
 
   scrollImmediately = (offsetConfig: OffsetConfig = {}) => {
-    const { scrollX, scrollY } = this.getAdjustedScrollOffset({
-      scrollX: offsetConfig.offsetX?.value || 0,
-      scrollY: offsetConfig.offsetY?.value || 0,
-    });
-    this.setScrollOffset({ scrollX, scrollY });
+    const { scrollX, scrollY, rowHeaderScrollX } = this.getAdjustedScrollOffset(
+      {
+        scrollX: offsetConfig.offsetX?.value || 0,
+        scrollY: offsetConfig.offsetY?.value || 0,
+        rowHeaderScrollX: offsetConfig.rowHeaderOffsetX?.value || 0,
+      },
+    );
+    this.setScrollOffset({ scrollX, scrollY, rowHeaderScrollX });
     this.startScroll();
   };
 
   /**
    *
-   * @param skipScrollEvent 如为true则不触发S2Event.GLOBAL_SCROLL
+   * @param skipScrollEvent 不触发 S2Event.GLOBAL_SCROLL
    */
   startScroll = (skipScrollEvent = false) => {
-    const { scrollX, scrollY } = this.getScrollOffset();
+    const { rowHeaderScrollX, scrollX, scrollY } = this.getScrollOffset();
+
+    this.hRowScrollBar?.onlyUpdateThumbOffset(
+      this.getScrollBarOffset(rowHeaderScrollX, this.hRowScrollBar),
+    );
 
     this.hScrollBar?.onlyUpdateThumbOffset(
       this.getScrollBarOffset(scrollX, this.hScrollBar),
@@ -516,7 +541,7 @@ export abstract class BaseFacet {
   private getAdjustedScrollOffset = ({
     scrollX,
     scrollY,
-    hRowScrollX,
+    rowHeaderScrollX,
   }: ScrollOffset): ScrollOffset => {
     return {
       scrollX: getAdjustedScrollOffset(
@@ -529,11 +554,14 @@ export abstract class BaseFacet {
         this.getRendererHeight(),
         this.panelBBox.height,
       ),
-      hRowScrollX: getAdjustedRowScrollX(hRowScrollX, this.cornerBBox),
+      rowHeaderScrollX: getAdjustedRowScrollX(
+        rowHeaderScrollX,
+        this.cornerBBox,
+      ),
     };
   };
 
-  renderRowScrollBar = (rowScrollX: number) => {
+  renderRowScrollBar = (rowHeaderScrollX: number) => {
     if (
       !this.cfg.spreadsheet.isScrollContainsRowHeader() &&
       this.cornerBBox.width < this.cornerBBox.originalWidth
@@ -560,28 +588,31 @@ export abstract class BaseFacet {
           y: maxY,
         },
         thumbOffset:
-          (rowScrollX * (this.cornerBBox.width - thumbSize)) / maxOffset,
+          (rowHeaderScrollX * (this.cornerBBox.width - thumbSize)) / maxOffset,
         theme: this.scrollBarTheme,
         scrollTargetMaxOffset: maxOffset,
       });
 
       this.hRowScrollBar.on(ScrollType.ScrollChange, ({ offset }) => {
         const newOffset = this.getValidScrollBarOffset(offset, maxOffset);
-        const hRowScrollX = Math.floor(newOffset);
-        this.setScrollOffset({ hRowScrollX });
+        const rowHeaderScrollX = Math.floor(newOffset);
+        this.setScrollOffset({ rowHeaderScrollX });
 
-        this.rowHeader?.onRowScrollX(hRowScrollX, KEY_GROUP_ROW_RESIZE_AREA);
+        this.rowHeader?.onRowScrollX(
+          rowHeaderScrollX,
+          KEY_GROUP_ROW_RESIZE_AREA,
+        );
         this.rowIndexHeader?.onRowScrollX(
-          hRowScrollX,
+          rowHeaderScrollX,
           KEY_GROUP_ROW_INDEX_RESIZE_AREA,
         );
         this.cornerHeader.onRowScrollX(
-          hRowScrollX,
+          rowHeaderScrollX,
           KEY_GROUP_CORNER_RESIZE_AREA,
         );
 
         const scrollBarOffsetX = this.getScrollBarOffset(
-          hRowScrollX,
+          rowHeaderScrollX,
           this.hRowScrollBar,
         );
 
@@ -942,7 +973,7 @@ export abstract class BaseFacet {
       const {
         scrollX: currentScrollX,
         scrollY: currentScrollY,
-        hRowScrollX,
+        rowHeaderScrollX,
       } = this.getScrollOffset();
 
       if (optimizedDeltaX !== 0) {
@@ -950,7 +981,7 @@ export abstract class BaseFacet {
         this.updateHorizontalRowScrollOffset({
           offsetX,
           offsetY,
-          offset: optimizedDeltaX + hRowScrollX,
+          offset: optimizedDeltaX + rowHeaderScrollX,
         });
         this.updateHorizontalScrollOffset({
           offsetX,
@@ -1116,13 +1147,13 @@ export abstract class BaseFacet {
    * 3. vertical scroll bar
    */
   protected renderScrollBars() {
-    const { scrollX, scrollY, hRowScrollX } = this.getScrollOffset();
+    const { scrollX, scrollY, rowHeaderScrollX } = this.getScrollOffset();
     const { width, height } = this.panelBBox;
     const realWidth = this.layoutResult.colsHierarchy.width;
     const realHeight = this.getRealHeight();
 
     // scroll row header separate from the whole canvas
-    this.renderRowScrollBar(hRowScrollX);
+    this.renderRowScrollBar(rowHeaderScrollX);
 
     // render horizontal scroll bar(default not contains row header)
     this.renderHScrollBar(width, realWidth, scrollX);
@@ -1278,7 +1309,7 @@ export abstract class BaseFacet {
     const {
       scrollX,
       scrollY: originalScrollY,
-      hRowScrollX,
+      rowHeaderScrollX,
     } = this.getScrollOffset();
     const defaultScrollY = originalScrollY + this.getPaginationScrollY();
     const scrollY = getAdjustedScrollOffset(
@@ -1292,7 +1323,7 @@ export abstract class BaseFacet {
 
     this.realCellRender(scrollX, scrollY);
     this.updatePanelScrollGroup();
-    this.translateRelatedGroups(scrollX, scrollY, hRowScrollX);
+    this.translateRelatedGroups(scrollX, scrollY, rowHeaderScrollX);
     this.clip(scrollX, scrollY);
     if (!skipScrollEvent) {
       this.emitScrollEvent({ scrollX, scrollY });

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -616,9 +616,11 @@ export abstract class BaseFacet {
           this.hRowScrollBar,
         );
 
+        const { scrollX, scrollY } = this.getScrollOffset();
         const position: CellScrollPosition = {
-          scrollX: scrollBarOffsetX,
-          scrollY: 0,
+          scrollX,
+          scrollY,
+          rowHeaderScrollX: scrollBarOffsetX,
         };
 
         this.hRowScrollBar.updateThumbOffset(scrollBarOffsetX, false);
@@ -1326,7 +1328,7 @@ export abstract class BaseFacet {
     this.translateRelatedGroups(scrollX, scrollY, rowHeaderScrollX);
     this.clip(scrollX, scrollY);
     if (!skipScrollEvent) {
-      this.emitScrollEvent({ scrollX, scrollY });
+      this.emitScrollEvent({ scrollX, scrollY, rowHeaderScrollX });
     }
     this.onAfterScroll();
   }

--- a/packages/s2-core/src/facet/header/base.ts
+++ b/packages/s2-core/src/facet/header/base.ts
@@ -47,6 +47,10 @@ export abstract class BaseHeader<T extends BaseHeaderConfig> extends Group {
     this.headerConfig = cfg;
   }
 
+  public getConfig(): T {
+    return this.headerConfig;
+  }
+
   /**
    * 清空热区，为重绘做准备，防止热区重复渲染
    * @param type 当前重绘的header类型
@@ -85,11 +89,11 @@ export abstract class BaseHeader<T extends BaseHeaderConfig> extends Group {
 
   /**
    * Only call when hRowScrollBar scrolls
-   * @param rowScrollX  hRowScrollbar horizontal offset
+   * @param rowHeaderScrollX  hRowScrollbar horizontal offset
    * @param type
    */
-  public onRowScrollX(rowScrollX: number, type: string): void {
-    this.headerConfig.scrollX = rowScrollX;
+  public onRowScrollX(rowHeaderScrollX: number, type: string): void {
+    this.headerConfig.scrollX = rowHeaderScrollX;
     this.render(type);
   }
 

--- a/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
@@ -15,6 +15,7 @@ import type {
   BrushAutoScrollConfig,
   BrushPoint,
   BrushRange,
+  OffsetConfig,
   OnUpdateCells,
   S2CellType,
   ViewMeta,
@@ -40,8 +41,7 @@ import { BaseEvent } from '../base-interaction';
 import type { Rect } from '../../common/interface';
 
 /**
- * Panel area's brush selection interaction
- * 只有 data cell 存在滚动刷选
+ * 刷选基类, dataCell, rowCell, colCell 支持滚动刷选
  */
 export class BaseBrushSelection
   extends BaseEvent
@@ -102,7 +102,7 @@ export class BaseBrushSelection
   }
 
   // 默认是 Data cell 的绘制区
-  protected isPointInCanvas(point: { x: number; y: number }): boolean {
+  protected isPointInCanvas(point: Point): boolean {
     const { height, width } = this.spreadsheet.facet.getCanvasHW();
     const { minX, minY } = this.spreadsheet.facet.panelBBox;
 
@@ -353,7 +353,7 @@ export class BaseBrushSelection
     }
   };
 
-  private autoScroll = () => {
+  private autoScroll = (isRowHeader = false) => {
     if (
       this.brushSelectionStage === InteractionBrushSelectionStage.UN_DRAGGED ||
       !this.scrollAnimationComplete
@@ -362,7 +362,15 @@ export class BaseBrushSelection
     }
     const config = this.autoScrollConfig;
     const scrollOffset = this.spreadsheet.facet.getScrollOffset();
-    const offsetCfg = {
+    const key: keyof OffsetConfig = isRowHeader
+      ? 'rowHeaderOffsetX'
+      : 'offsetX';
+
+    const offsetCfg: OffsetConfig = {
+      rowHeaderOffsetX: {
+        value: scrollOffset.rowHeaderScrollX,
+        animate: true,
+      },
       offsetX: {
         value: scrollOffset.scrollX,
         animate: true,
@@ -374,6 +382,7 @@ export class BaseBrushSelection
     };
 
     const { x: deltaX, y: deltaY } = this.getNextScrollDelta(config);
+
     if (deltaY === 0 && deltaX === 0) {
       this.clearAutoScroll();
       return;
@@ -382,10 +391,12 @@ export class BaseBrushSelection
     if (config.y.scroll) {
       offsetCfg.offsetY.value += deltaY;
     }
+
     if (config.x.scroll) {
-      offsetCfg.offsetX.value += deltaX;
-      if (offsetCfg.offsetX.value < 0) {
-        offsetCfg.offsetX.value = 0;
+      const offset = offsetCfg[key];
+      offset.value += deltaX;
+      if (offset.value < 0) {
+        offset.value = 0;
       }
     }
 
@@ -403,40 +414,45 @@ export class BaseBrushSelection
     );
   };
 
-  protected handleScroll = throttle((x: number, y: number) => {
-    if (
-      this.brushSelectionStage === InteractionBrushSelectionStage.UN_DRAGGED
-    ) {
-      return;
-    }
+  protected handleScroll = throttle(
+    (x: number, y: number, isRowHeader = false) => {
+      if (
+        this.brushSelectionStage === InteractionBrushSelectionStage.UN_DRAGGED
+      ) {
+        return;
+      }
 
-    const {
-      x: { value: newX, needScroll: needScrollForX },
-      y: { value: newY, needScroll: needScrollForY },
-    } = this.formatBrushPointForScroll({ x, y });
+      const {
+        x: { value: newX, needScroll: needScrollForX },
+        y: { value: newY, needScroll: needScrollForY },
+      } = this.formatBrushPointForScroll({ x, y });
 
-    const config = this.autoScrollConfig;
-    if (needScrollForY) {
-      config.y.value = y;
-      config.y.scroll = true;
-    }
-    if (needScrollForX) {
-      config.x.value = x;
-      config.x.scroll = true;
-    }
+      const config = this.autoScrollConfig;
+      if (needScrollForY) {
+        config.y.value = y;
+        config.y.scroll = true;
+      }
+      if (needScrollForX) {
+        config.x.value = x;
+        config.x.scroll = true;
+      }
 
-    this.setMoveDistanceFromCanvas({ x, y }, needScrollForX, needScrollForY);
-    this.renderPrepareSelected({
-      x: newX,
-      y: newY,
-    });
+      this.setMoveDistanceFromCanvas({ x, y }, needScrollForX, needScrollForY);
+      this.renderPrepareSelected({
+        x: newX,
+        y: newY,
+      });
 
-    if (needScrollForY || needScrollForX) {
-      this.clearAutoScroll();
-      this.autoScroll();
-      this.autoScrollIntervalId = setInterval(this.autoScroll, 16);
-    }
-  }, 30);
+      if (needScrollForY || needScrollForX) {
+        this.clearAutoScroll();
+        this.autoScroll(isRowHeader);
+        this.autoScrollIntervalId = setInterval(() => {
+          this.autoScroll(isRowHeader);
+        }, 16);
+      }
+    },
+    30,
+  );
 
   protected clearAutoScroll = () => {
     if (this.autoScrollIntervalId) {
@@ -560,7 +576,7 @@ export class BaseBrushSelection
     });
   }
 
-  protected onUpdateCells: OnUpdateCells = (root, defaultOnUpdateCells) => {
+  protected onUpdateCells: OnUpdateCells = (_, defaultOnUpdateCells) => {
     return defaultOnUpdateCells();
   };
 
@@ -668,13 +684,13 @@ export class BaseBrushSelection
     }
   };
 
-  public autoBrushScroll(point: Point) {
+  public autoBrushScroll(point: Point, isRowHeader = false) {
     this.clearAutoScroll();
 
     if (!this.isPointInCanvas(point)) {
       const deltaX = point?.x - this.endBrushPoint?.x;
       const deltaY = point?.y - this.endBrushPoint?.y;
-      this.handleScroll(deltaX, deltaY);
+      this.handleScroll(deltaX, deltaY, isRowHeader);
 
       return true;
     }

--- a/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
@@ -426,7 +426,6 @@ export class BaseBrushSelection
     }
 
     this.setMoveDistanceFromCanvas({ x, y }, needScrollForX, needScrollForY);
-
     this.renderPrepareSelected({
       x: newX,
       y: newY,

--- a/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
@@ -639,8 +639,8 @@ export class BaseBrushSelection
   protected renderPrepareSelected = (point: Point) => {
     const { x, y } = point;
     const target = this.spreadsheet.container.getShape(x, y);
-
     const cell = this.spreadsheet.getCell(target);
+
     // 只有行头，列头，单元格可以刷选
     const isBrushCellType =
       cell instanceof DataCell ||
@@ -668,6 +668,20 @@ export class BaseBrushSelection
       this.updatePrepareSelectMask();
     }
   };
+
+  protected autoBrushScroll(point: Point) {
+    this.clearAutoScroll();
+
+    if (!this.isPointInCanvas(point)) {
+      const deltaX = point?.x - this.endBrushPoint?.x;
+      const deltaY = point?.y - this.endBrushPoint?.y;
+      this.handleScroll(deltaX, deltaY);
+
+      return true;
+    }
+
+    return false;
+  }
 
   // 需要查看继承他的父类是如何定义的
   protected isInBrushRange(meta: ViewMeta | Node): boolean {

--- a/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
@@ -27,10 +27,8 @@ export class ColBrushSelection extends BaseBrushSelection {
   }
 
   protected bindMouseDown() {
-    [S2Event.COL_CELL_MOUSE_DOWN].forEach((e: S2Event) => {
-      this.spreadsheet.on(e, (event: CanvasEvent) => {
-        super.mouseDown(event);
-      });
+    this.spreadsheet.on(S2Event.COL_CELL_MOUSE_DOWN, (event) => {
+      super.mouseDown(event);
     });
   }
 

--- a/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
@@ -12,9 +12,6 @@ import { getCellMeta } from '../../utils/interaction/select-event';
 import type { OnUpdateCells } from '../../common/interface';
 import { BaseBrushSelection } from './base-brush-selection';
 
-/**
- * Panel area's brush col cell selection interaction
- */
 export class ColBrushSelection extends BaseBrushSelection {
   public displayedCells: ColCell[] = [];
 

--- a/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
@@ -93,12 +93,10 @@ export class DataCellBrushSelection extends BaseBrushSelection {
 
   // 最终刷选的cell
   protected updateSelectedCells() {
-    const { interaction, options } = this.spreadsheet;
-
     const brushRange = this.getBrushRange();
     const selectedCellMetas = this.getSelectedCellMetas(brushRange);
 
-    interaction.changeState({
+    this.spreadsheet.interaction.changeState({
       cells: selectedCellMetas,
       stateName: InteractionStateName.SELECTED,
       onUpdateCells: afterSelectDataCells,
@@ -107,16 +105,10 @@ export class DataCellBrushSelection extends BaseBrushSelection {
     const scrollBrushRangeCells =
       this.getScrollBrushRangeCells(selectedCellMetas);
 
-    this.spreadsheet.emit(
+    this.emitBrushSelectionEvent(
       S2Event.DATA_CELL_BRUSH_SELECTION,
       scrollBrushRangeCells,
     );
-    this.spreadsheet.emit(S2Event.GLOBAL_SELECTED, scrollBrushRangeCells);
-
-    // 未刷选到有效格子, 允许 hover
-    if (isEmpty(this.brushRangeCells)) {
-      interaction.removeIntercepts([InterceptType.HOVER]);
-    }
   }
 
   /**
@@ -126,10 +118,7 @@ export class DataCellBrushSelection extends BaseBrushSelection {
    */
   private getScrollBrushRangeCells(selectedCellMetas: CellMeta[]) {
     return selectedCellMetas.map((meta) => {
-      const visibleCell = this.brushRangeCells.find((cell) => {
-        const visibleCellMeta = cell.getMeta();
-        return visibleCellMeta?.id === meta.id;
-      });
+      const visibleCell = this.getVisibleBrushRangeCells(meta.id);
 
       if (visibleCell) {
         return visibleCell;

--- a/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
@@ -1,6 +1,6 @@
 import { isEmpty, range } from 'lodash';
 import { DataCell } from '../../cell/data-cell';
-import { InterceptType, S2Event } from '../../common/constant';
+import { S2Event } from '../../common/constant';
 import {
   CellTypes,
   InteractionBrushSelectionStage,
@@ -10,9 +10,6 @@ import type { BrushRange, CellMeta, ViewMeta } from '../../common/interface';
 import { afterSelectDataCells } from '../../utils/interaction/select-event';
 import { BaseBrushSelection } from './base-brush-selection';
 
-/**
- * Panel area's brush data cell selection interaction
- */
 export class DataCellBrushSelection extends BaseBrushSelection {
   public displayedCells: DataCell[] = [];
 

--- a/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
@@ -1,5 +1,4 @@
-import type { Event as CanvasEvent } from '@antv/g-canvas';
-import { isBoolean, isEmpty, range } from 'lodash';
+import { isEmpty, range } from 'lodash';
 import { DataCell } from '../../cell/data-cell';
 import { InterceptType, S2Event } from '../../common/constant';
 import {
@@ -8,7 +7,6 @@ import {
   InteractionStateName,
 } from '../../common/constant/interaction';
 import type { BrushRange, CellMeta, ViewMeta } from '../../common/interface';
-import { getInteractionCellsBySelectedCells } from '../../utils';
 import { afterSelectDataCells } from '../../utils/interaction/select-event';
 import { BaseBrushSelection } from './base-brush-selection';
 
@@ -21,7 +19,7 @@ export class DataCellBrushSelection extends BaseBrushSelection {
   public brushRangeCells: DataCell[] = [];
 
   protected bindMouseDown() {
-    this.spreadsheet.on(S2Event.DATA_CELL_MOUSE_DOWN, (event: CanvasEvent) => {
+    this.spreadsheet.on(S2Event.DATA_CELL_MOUSE_DOWN, (event) => {
       super.mouseDown(event);
       this.resetScrollDelta();
     });
@@ -38,14 +36,9 @@ export class DataCellBrushSelection extends BaseBrushSelection {
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
       const pointInCanvas = this.spreadsheet.container.getPointByEvent(event);
 
-      this.clearAutoScroll();
-      if (!this.isPointInCanvas(pointInCanvas)) {
-        const deltaX = pointInCanvas?.x - this.endBrushPoint?.x;
-        const deltaY = pointInCanvas?.y - this.endBrushPoint?.y;
-        this.handleScroll(deltaX, deltaY);
+      if (this.autoBrushScroll(pointInCanvas)) {
         return;
       }
-
       this.renderPrepareSelected(pointInCanvas);
     });
   }

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -5,18 +5,11 @@ import {
   InteractionBrushSelectionStage,
   InteractionStateName,
 } from '../../common/constant/interaction';
-import type {
-  BrushRange,
-  OnUpdateCells,
-  ViewMeta,
-} from '../../common/interface';
+import type { OnUpdateCells, ViewMeta } from '../../common/interface';
 import type { Node } from '../../facet/layout/node';
 import { getCellMeta } from '../../utils/interaction/select-event';
 import { BaseBrushSelection } from './base-brush-selection';
 
-/**
- * Panel area's brush selection interaction
- */
 export class RowBrushSelection extends BaseBrushSelection {
   public displayedCells: RowCell[] = [];
 
@@ -74,7 +67,7 @@ export class RowBrushSelection extends BaseBrushSelection {
       {
         // 行头过长时，可以单独进行滚动，所以需要加上滚动的距离
         minX: start.x + hRowScrollX,
-        // 由于刷选的时候，是以列头的左上角为起点，所以需要减去角头的宽度，在滚动后需要加上滚动条的偏移量
+        // 由于刷选的时候，是以行头的左上角为起点，所以需要减去角头的宽度，在滚动后需要加上滚动条的偏移量
         minY: start.y - cornerBBox.height + scrollY,
         maxX: end.x + hRowScrollX,
         maxY: end.y - cornerBBox.height + scrollY,
@@ -90,8 +83,7 @@ export class RowBrushSelection extends BaseBrushSelection {
 
   // 最终刷选的cell
   protected updateSelectedCells() {
-    const brushRange = this.getBrushRange();
-    const selectedRowNodes = this.getSelectedRowNodes(brushRange);
+    const selectedRowNodes = this.getSelectedRowNodes();
     const scrollBrushRangeCells =
       this.getScrollBrushRangeCells(selectedRowNodes);
     const selectedCellMetas = map(scrollBrushRangeCells, getCellMeta);
@@ -118,17 +110,8 @@ export class RowBrushSelection extends BaseBrushSelection {
     return root.updateCells(root.getAllRowHeaderCells());
   };
 
-  private getSelectedRowNodes = (brushRange: BrushRange): Node[] => {
-    return this.spreadsheet.getRowNodes().filter((node) => {
-      const { start, end } = brushRange;
-
-      return (
-        node.rowIndex >= start.rowIndex &&
-        node.rowIndex <= end.rowIndex &&
-        node.colIndex >= start.colIndex &&
-        node.colIndex <= end.colIndex
-      );
-    });
+  private getSelectedRowNodes = (): Node[] => {
+    return this.spreadsheet.getRowNodes().filter(this.isInBrushRange);
   };
 
   private getScrollBrushRangeCells(nodes: Node[]) {

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -1,4 +1,3 @@
-import type { Event as CanvasEvent } from '@antv/g-canvas';
 import { isEmpty, map } from 'lodash';
 import type { RowCell } from '../../cell';
 import { InterceptType, S2Event } from '../../common/constant';
@@ -6,10 +5,9 @@ import {
   InteractionBrushSelectionStage,
   InteractionStateName,
 } from '../../common/constant/interaction';
-import type { ViewMeta } from '../../common/interface';
+import type { OnUpdateCells, ViewMeta } from '../../common/interface';
 import type { Node } from '../../facet/layout/node';
 import { getCellMeta } from '../../utils/interaction/select-event';
-import type { OnUpdateCells } from '../../common/interface';
 import { BaseBrushSelection } from './base-brush-selection';
 
 /**
@@ -21,10 +19,8 @@ export class RowBrushSelection extends BaseBrushSelection {
   public brushRangeCells: RowCell[] = [];
 
   protected bindMouseDown() {
-    [S2Event.ROW_CELL_MOUSE_DOWN].forEach((e: S2Event) => {
-      this.spreadsheet.on(e, (event: CanvasEvent) => {
-        super.mouseDown(event);
-      });
+    this.spreadsheet.on(S2Event.ROW_CELL_MOUSE_DOWN, (event) => {
+      super.mouseDown(event);
     });
   }
 
@@ -39,7 +35,7 @@ export class RowBrushSelection extends BaseBrushSelection {
   }
 
   protected bindMouseMove() {
-    this.spreadsheet.on(S2Event.ROW_CELL_MOUSE_MOVE, (event) => {
+    this.spreadsheet.on(S2Event.GLOBAL_MOUSE_MOVE, (event) => {
       if (
         this.brushSelectionStage === InteractionBrushSelectionStage.UN_DRAGGED
       ) {
@@ -47,11 +43,9 @@ export class RowBrushSelection extends BaseBrushSelection {
       }
 
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
-      const pointInCanvas = this.spreadsheet.container.getPointByEvent(
-        event.originalEvent,
-      );
+      const pointInCanvas = this.spreadsheet.container.getPointByEvent(event);
 
-      if (!this.isPointInCanvas(pointInCanvas)) {
+      if (this.autoBrushScroll(pointInCanvas)) {
         return;
       }
 

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -1,3 +1,4 @@
+import type { Point } from '@antv/g-canvas';
 import { map } from 'lodash';
 import { RowCell } from '../../cell';
 import { InterceptType, S2Event } from '../../common/constant';
@@ -17,7 +18,7 @@ export class RowBrushSelection extends BaseBrushSelection {
     });
   }
 
-  protected isPointInCanvas(point: { x: number; y: number }) {
+  protected isPointInCanvas(point: Point) {
     // 获取行头的区域范围
     const { height: maxY } = this.spreadsheet.facet.getCanvasHW();
     const { minX, height: minY, maxX } = this.spreadsheet.facet.cornerBBox;
@@ -38,7 +39,7 @@ export class RowBrushSelection extends BaseBrushSelection {
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
       const pointInCanvas = this.spreadsheet.container.getPointByEvent(event);
 
-      if (this.autoBrushScroll(pointInCanvas)) {
+      if (this.autoBrushScroll(pointInCanvas, true)) {
         return;
       }
 
@@ -53,8 +54,8 @@ export class RowBrushSelection extends BaseBrushSelection {
   protected isInBrushRange = (meta: ViewMeta | Node) => {
     // start、end 都是相对位置
     const { start, end } = this.getBrushRange();
-    const { scrollY, hRowScrollX } = this.spreadsheet.facet.getScrollOffset();
-
+    const { scrollY, rowHeaderScrollX } =
+      this.spreadsheet.facet.getScrollOffset();
     const { cornerBBox } = this.spreadsheet.facet;
     // 绝对位置，不随滚动条变化
     const { x = 0, y = 0, width = 0, height = 0 } = meta;
@@ -62,10 +63,10 @@ export class RowBrushSelection extends BaseBrushSelection {
     return this.rectanglesIntersect(
       {
         // 行头过长时，可以单独进行滚动，所以需要加上滚动的距离
-        minX: start.x + hRowScrollX,
+        minX: start.x + rowHeaderScrollX,
         // 由于刷选的时候，是以行头的左上角为起点，所以需要减去角头的宽度，在滚动后需要加上滚动条的偏移量
         minY: start.y - cornerBBox.height + scrollY,
-        maxX: end.x + hRowScrollX,
+        maxX: end.x + rowHeaderScrollX,
         maxY: end.y - cornerBBox.height + scrollY,
       },
       {
@@ -77,7 +78,7 @@ export class RowBrushSelection extends BaseBrushSelection {
     );
   };
 
-  // 最终刷选的cell
+  // 最终刷选的 cells
   protected updateSelectedCells() {
     const selectedRowNodes = this.getSelectedRowNodes();
     const scrollBrushRangeCells =

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -11,10 +11,6 @@ import { getCellMeta } from '../../utils/interaction/select-event';
 import { BaseBrushSelection } from './base-brush-selection';
 
 export class RowBrushSelection extends BaseBrushSelection {
-  public displayedCells: RowCell[] = [];
-
-  public brushRangeCells: RowCell[] = [];
-
   protected bindMouseDown() {
     this.spreadsheet.on(S2Event.ROW_CELL_MOUSE_DOWN, (event) => {
       super.mouseDown(event);

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -536,20 +536,23 @@ export abstract class SpreadSheet extends EE {
    * but offsetY(vertical scroll don't need animation)
    */
   public updateScrollOffset(offsetConfig: OffsetConfig) {
+    const config: OffsetConfig = {
+      offsetX: {
+        value: undefined,
+        animate: false,
+      },
+      offsetY: {
+        value: undefined,
+        animate: false,
+      },
+      rowHeaderOffsetX: {
+        value: undefined,
+        animate: false,
+      },
+    };
+
     this.facet.updateScrollOffset(
-      customMerge(
-        {
-          offsetX: {
-            value: undefined,
-            animate: false,
-          },
-          offsetY: {
-            value: undefined,
-            animate: false,
-          },
-        },
-        offsetConfig,
-      ) as OffsetConfig,
+      customMerge(config, offsetConfig) as OffsetConfig,
     );
   }
 

--- a/packages/s2-core/src/utils/facet.ts
+++ b/packages/s2-core/src/utils/facet.ts
@@ -63,7 +63,7 @@ export const getIndexRangeWithOffsets = (
 };
 
 export const getAdjustedRowScrollX = (
-  hRowScrollX: number,
+  rowHeaderScrollX: number,
   cornerBBox: {
     width: number;
     originalWidth: number;
@@ -71,7 +71,7 @@ export const getAdjustedRowScrollX = (
 ): number => {
   const { width, originalWidth } = cornerBBox;
 
-  const scrollX = Math.min(originalWidth - width, hRowScrollX);
+  const scrollX = Math.min(originalWidth - width, rowHeaderScrollX);
 
   if (scrollX < 0) {
     return 0;

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -27,7 +27,7 @@ export const isMultiSelectionKey = (e: KeyboardEvent) => {
 
 export const getCellMeta = (cell: S2CellType): CellMeta => {
   const meta = cell.getMeta();
-  const { id, colIndex, rowIndex, rowQuery } = meta;
+  const { id, colIndex, rowIndex, rowQuery } = meta || {};
   return {
     id,
     colIndex,

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -1,14 +1,19 @@
 import { forEach, reduce, uniqBy } from 'lodash';
 import { ColCell, RowCell, TableSeriesCell } from '../../cell';
-import { getDataCellId } from '../cell/data-cell';
 import {
   InteractionKeyboardKey,
   InteractionStateName,
   S2Event,
 } from '../../common/constant';
-import type { CellMeta, S2CellType, ViewMeta } from '../../common/interface';
-import type { SpreadSheet } from '../../sheet-type';
+import type {
+  CellMeta,
+  OnUpdateCells,
+  S2CellType,
+  ViewMeta,
+} from '../../common/interface';
 import type { Node } from '../../facet/layout/node';
+import type { SpreadSheet } from '../../sheet-type';
+import { getDataCellId } from '../cell/data-cell';
 import {
   getActiveHoverRowColCells,
   updateAllColHeaderCellState,
@@ -162,7 +167,7 @@ export const getInteractionCellsBySelectedCells = (
   return uniqBy([...selectedCells, ...headerSelectedCell], 'id');
 };
 
-export const afterSelectDataCells = (root, updateDataCells) => {
+export const afterSelectDataCells: OnUpdateCells = (root, updateDataCells) => {
   const { colHeader, rowHeader } = root.getSelectedCellHighlight();
   if (colHeader) {
     root.updateCells(root.getAllColHeaderCells());

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -47,7 +47,7 @@ export const pivotSheetDataCfg: S2DataConfig = {
 };
 
 export const s2Options: SheetComponentOptions = {
-  debug: false,
+  debug: true,
   width: 600,
   height: 400,
   showSeriesNumber: false,

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -47,7 +47,7 @@ export const pivotSheetDataCfg: S2DataConfig = {
 };
 
 export const s2Options: SheetComponentOptions = {
-  debug: true,
+  debug: false,
   width: 600,
   height: 400,
   showSeriesNumber: false,

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -602,6 +602,20 @@ function MainLayout() {
                 </Button>
                 <Button
                   size="small"
+                  onClick={() => {
+                    clearInterval(scrollTimer.current);
+                    s2Ref.current.updateScrollOffset({
+                      rowHeaderOffsetX: {
+                        value: 100,
+                        animate: true,
+                      },
+                    });
+                  }}
+                >
+                  滚动行头
+                </Button>
+                <Button
+                  size="small"
                   danger
                   onClick={() => {
                     if (

--- a/s2-site/docs/api/basic-class/base-facet.en.md
+++ b/s2-site/docs/api/basic-class/base-facet.en.md
@@ -160,6 +160,6 @@ export interface OffsetConfig {
 export interface ScrollOffset {
   scrollX?: number;
   scrollY?: number;
-  hRowScrollX?: number;
+  rowHeaderScrollX?: number;
 }
 ```

--- a/s2-site/docs/api/basic-class/base-facet.zh.md
+++ b/s2-site/docs/api/basic-class/base-facet.zh.md
@@ -146,6 +146,10 @@ export interface ViewCellHeights {
 
 ```ts
 export interface OffsetConfig {
+  rowHeaderOffsetX?: {
+    value: number | undefined;
+    animate?: boolean;
+  };
   offsetX?: {
     value: number | undefined;
     animate?: boolean;
@@ -163,6 +167,6 @@ export interface OffsetConfig {
 export interface ScrollOffset {
   scrollX?: number;
   scrollY?: number;
-  hRowScrollX?: number;
+  rowHeaderScrollX?: number;
 }
 ```

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -88,6 +88,10 @@ type S2MountContainer = string | HTMLElement;
 
 ```ts
 interface OffsetConfig {
+  rowHeaderOffsetX?: {
+    value: number | undefined;
+    animate?: boolean;
+  };
   offsetX?: {
     value: number | undefined;
     animate?: boolean;

--- a/s2-site/docs/api/basic-class/store.en.md
+++ b/s2-site/docs/api/basic-class/store.en.md
@@ -13,7 +13,7 @@ s2.store.set('key', value) // 存储
 | ------------------------ | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
 | scrollX                  | horizontal scroll offset                                            | `number`                                                         |
 | scrollX                  | vertical scroll offset                                              | `number`                                                         |
-| hRowScrollX              | vertical header scroll offset                                       | `number`                                                         |
+| rowHeaderScrollX              | vertical header scroll offset                                       | `number`                                                         |
 | sortParam                | Column header sorting configuration                                 | [SortParam](/docs/api/components/sheet-component/#sortparams) |
 | drillDownIdPathMap       | Drill down node id and corresponding generated path addressing path | `Map<string, number[][]>`                                        |
 | drillDownNode            | current drill-down node                                             | [node](/docs/api/basic-class/node)                            |

--- a/s2-site/docs/api/basic-class/store.zh.md
+++ b/s2-site/docs/api/basic-class/store.zh.md
@@ -13,8 +13,8 @@ s2.store.set('key', value) // 存储
 | 参数 | 说明                                   | 类型 |
 | --- | --- | --- |
 | scrollX | 水平滚动偏移 | `number` |
-| scrollX | 垂直滚动偏移 | `number` |
-| rowHeaderScrollX | 垂直行头滚动偏移 | `number` |
+| scrollY | 垂直滚动偏移 | `number` |
+| rowHeaderScrollX | 行头水平滚动偏移 | `number` |
 | sortParam | 列头排序配置 | [SortParam](/docs/api/components/sheet-component/#sortparams) |
 | drillDownIdPathMap | 下钻节点 id 和对应生成的 path 寻址路径 | `Map<string, number[][]>` |
 | drillDownNode | 当前下钻节点 | [Node](/docs/api/basic-class/node) |

--- a/s2-site/docs/api/basic-class/store.zh.md
+++ b/s2-site/docs/api/basic-class/store.zh.md
@@ -14,7 +14,7 @@ s2.store.set('key', value) // 存储
 | --- | --- | --- |
 | scrollX | 水平滚动偏移 | `number` |
 | scrollX | 垂直滚动偏移 | `number` |
-| hRowScrollX | 垂直行头滚动偏移 | `number` |
+| rowHeaderScrollX | 垂直行头滚动偏移 | `number` |
 | sortParam | 列头排序配置 | [SortParam](/docs/api/components/sheet-component/#sortparams) |
 | drillDownIdPathMap | 下钻节点 id 和对应生成的 path 寻址路径 | `Map<string, number[][]>` |
 | drillDownNode | 当前下钻节点 | [Node](/docs/api/basic-class/node) |

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -272,7 +272,6 @@ const s2Options = {
 };
 ```
 
-
 #### 滚动圈选
 
 <img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*pmskQL_WvMIAAAAAAAAAAAAADmJ7AQ/original" alt="preview" width="600" />
@@ -284,7 +283,6 @@ const s2Options = {
 单击行头所对应的角头，可以快捷选中当前列
 
 <img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*TNjTS7HzcgUAAAAAAAAAAAAADmJ7AQ/original" width="600" alt="preview" />
-
 
 ### 快捷键多选
 

--- a/s2-site/docs/manual/advanced/interaction/basic.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/basic.zh.md
@@ -189,7 +189,7 @@ const s2Options = {
 // 当 selectedCellHighlight 为 boolean 时
 const s2Options = {
   interaction: {
-    selectedCellHighlight: true // 默认 false， 当 selectedCellsSpotlight 为 true 时，会高亮 rowHeader 和 colHeader (兼容未拓展类型前的设计)
+    selectedCellHighlight: true // 默认 false， 当 selectedCellsSpotlight 为 true 时，会高亮 rowHeader 和 colHeader （兼容未拓展类型前的设计）
   }
 };
 
@@ -199,7 +199,7 @@ const S2Options = {
     selectedCellHighlight: {
       rowHeader: true,  // 选中单元格时，高亮行头
       colHeader: true,  // 选中单元格时，高亮列头
-      rowCells: false,  // 选中单元格时，高亮当前行 
+      rowCells: false,  // 选中单元格时，高亮当前行
       colCells: false,  // 选中单元格时，高亮当前列
     },
   },
@@ -224,7 +224,7 @@ const s2Options = {
 
 ### 圈选高亮
 
-圈选高亮又叫刷选，刷选过程中，会提示预选中的单元格，并且显示半透明的刷选蒙层，默认开启，可配置 `brushSelection` 关闭：
+圈选高亮又叫刷选，刷选过程中，会提示预选中的单元格，并且显示半透明的刷选蒙层，支持对 `数据单元格 (dataCell)`, `行头单元格 (rowCell)`, `列头单元格 (colCell)` 进行圈选，同时支持 `滚动圈选`, 可以用来做 `统计数据总和`, `单元格个数`, `复制选定数据` 等操作，默认开启 `数据单元格`，可配置 `brushSelection` 关闭：
 
 #### 数据单元格圈选
 
@@ -233,7 +233,13 @@ const s2Options = {
 ```ts
 const s2Options = {
   interaction: {
-    brushSelection: false // 默认 true
+    brushSelection: false
+    // 等同于：
+    // brushSelection:  {
+    //   row: false,
+    //   col: false,
+    //   data: false,
+    // }
   }
 };
 ```
@@ -246,7 +252,7 @@ const s2Options = {
 const s2Options = {
   interaction: {
     brushSelection:  {
-        row: true // 默认 false
+      row: true // 默认 false
     }
   }
 };
@@ -260,11 +266,17 @@ const s2Options = {
 const s2Options = {
   interaction: {
     brushSelection:  {
-        col: true // 默认 false
+      col: true // 默认 false
     }
   }
 };
 ```
+
+#### 滚动圈选
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*pmskQL_WvMIAAAAAAAAAAAAADmJ7AQ/original" alt="preview" width="600" />
+
+<img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*r8fFQ6ySwScAAAAAAAAAAAAADmJ7AQ/original" alt="preview" width="600" />
 
 ### 快捷键多选
 

--- a/s2-site/examples/interaction/advanced/demo/scroll-to-cell.ts
+++ b/s2-site/examples/interaction/advanced/demo/scroll-to-cell.ts
@@ -8,7 +8,7 @@ function addScrollRowHeaderButton(s2: SpreadSheet) {
 
   btn.addEventListener('click', () => {
     s2.updateScrollOffset({
-      rowHeaderScrollX: {
+      rowHeaderOffsetX: {
         value: 50,
         animate: true,
       },

--- a/s2-site/examples/interaction/advanced/demo/scroll-to-cell.ts
+++ b/s2-site/examples/interaction/advanced/demo/scroll-to-cell.ts
@@ -1,7 +1,23 @@
-import { PivotSheet } from '@antv/s2';
+import { PivotSheet, S2Options, SpreadSheet } from '@antv/s2';
 import insertCss from 'insert-css';
 
-function addScrollToCellButton(s2) {
+function addScrollRowHeaderButton(s2: SpreadSheet) {
+  const btn = document.createElement('button');
+  btn.className = 'ant-btn ant-btn-default';
+  btn.innerHTML = '滚动行头';
+
+  btn.addEventListener('click', () => {
+    s2.updateScrollOffset({
+      rowHeaderScrollX: {
+        value: 50,
+        animate: true,
+      },
+    });
+  });
+  document.querySelector('#container > canvas')?.before(btn);
+}
+
+function addScrollToCellButton(s2: SpreadSheet) {
   const btn = document.createElement('button');
   btn.className = 'ant-btn ant-btn-default';
   btn.innerHTML = '滚动至成都市';
@@ -19,10 +35,10 @@ function addScrollToCellButton(s2) {
       },
     });
   });
-  document.querySelector('#container > canvas').before(btn);
+  document.querySelector('#container > canvas')?.before(btn);
 }
 
-function addScrollToTopButton(s2) {
+function addScrollToTopButton(s2: SpreadSheet) {
   const btn = document.createElement('button');
   btn.className = 'ant-btn ant-btn-default';
   btn.innerHTML = '滚动至顶部';
@@ -35,7 +51,7 @@ function addScrollToTopButton(s2) {
       },
     });
   });
-  document.querySelector('#container > canvas').before(btn);
+  document.querySelector('#container > canvas')?.before(btn);
 }
 
 fetch(
@@ -45,12 +61,17 @@ fetch(
   .then((dataCfg) => {
     const container = document.getElementById('container');
 
-    const s2Options = {
+    const s2Options: S2Options = {
       width: 600,
       height: 480,
+      frozenRowHeader: true,
       style: {
+        // 让行头区域显示滚动条
+        rowCfg: {
+          width: 200,
+        },
+        // 让表格数值区域显示滚动条
         cellCfg: {
-          // 让表格显示滚动条
           height: 100,
         },
       },
@@ -61,6 +82,7 @@ fetch(
 
     addScrollToCellButton(s2);
     addScrollToTopButton(s2);
+    addScrollRowHeaderButton(s2);
   });
 
 insertCss(`


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

- 行头增加刷选时自动滚动, 支持 **水平滚动** 和 **垂直滚动**, 可以用于统计单元格个数, 复制
- 增加行头区域的滚动方法, 原本 `updateScrollOffset` 只支持数值区域的滚动 (即 `offsetX` 和 `offsetY`), 现在行头滚动需要增强其能力, `rowHeaderOffsetX`


```ts
s2.updateScrollOffset({
  rowHeaderOffsetX: {
    value: 50,
    animate: true,
  },
});
```



TODO:

- [x] 兼容复制
- [x] 单测
- [x] 文档

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![Kapture 2023-02-21 at 17 14 42](https://user-images.githubusercontent.com/21015895/220302089-f5db8cc9-5c24-4e32-a350-3f1c1b88ef68.gif) | ![Kapture 2023-02-21 at 17 12 17](https://user-images.githubusercontent.com/21015895/220300656-daf50950-358a-40c7-9748-72c8555504f0.gif) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

close #2075 

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
