### PR TITLE
feat: 在 shape 中添加文本的原始值

### DIFF
--- a/packages/s2-core/src/utils/g-renders.ts
+++ b/packages/s2-core/src/utils/g-renders.ts
@@ -52,7 +52,7 @@ export function renderText(
   textStyle: TextTheme,
   extraStyle?: ShapeAttrs,
   // 因为 text 为 ellipsisText
-  originText?: string,
+  originalText?: string,
 ): IShape {
   if (!isEmpty(shapes) && group) {
     forEach(shapes, (shape: IShape) => {
@@ -66,7 +66,7 @@ export function renderText(
       x,
       y,
       text,
-      originText,
+      originalText,
       ...textStyle,
       ...extraStyle,
     },

--- a/packages/s2-core/src/utils/g-renders.ts
+++ b/packages/s2-core/src/utils/g-renders.ts
@@ -51,6 +51,8 @@ export function renderText(
   text: string,
   textStyle: TextTheme,
   extraStyle?: ShapeAttrs,
+  // 因为 text 为 ellipsisText
+  originText?: string,
 ): IShape {
   if (!isEmpty(shapes) && group) {
     forEach(shapes, (shape: IShape) => {
@@ -64,6 +66,7 @@ export function renderText(
       x,
       y,
       text,
+      originText,
       ...textStyle,
       ...extraStyle,
     },

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -567,6 +567,8 @@ export const drawObjectText = (
         position.text.y,
         ellipsisText,
         curStyle,
+        {},
+        curText?.toString(),
       );
       cell.addTextShape(textShape);
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [X] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

对于趋势分析表，当文本超过省略后，无法获取原始数据。
通过 viewMeta：{ value: "[\"数值\",\"环比环比环比环比环比环比环比环比环比环比环比环比环比\"]" }
会 存在一个问题： value: "[\"cutomizedelta\",\"cutomizeContrast ratio\",\"cutomizeComparison value\"]" 时， 都展示为 cutomize... ，所以添加了 originText 字段
| Before | After |
| ------ | ----- |
| ❌      | ✅     |
| <img width="1470" alt="image" src="https://user-images.githubusercontent.com/20497176/223372864-ae993c57-e7d9-4faa-9f95-e6d264eafee5.png">|<img width="1423" alt="image" src="https://user-images.githubusercontent.com/20497176/223372249-706b5e6b-9d4a-4a95-b3ae-09bf00ed13d2.png"> |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
