### PR TITLE
feat: add Odd rows font color, 奇数行字体颜色支持

### DIFF
--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -223,11 +223,16 @@ export class DataCell extends BaseCell<ViewMeta> {
     const textStyle = isTotals
       ? this.theme.dataCell.bolderText
       : this.theme.dataCell.text;
-
+    const { oddFill } = this.getStyle().text;
+    let textFill = this.getDefaultTextFill(textStyle);
+    if (oddFill && this.meta.rowIndex % 2 === 0) {
+      // 隔行文字颜色
+      textFill = oddFill;
+    }
     // 优先级：默认字体颜色（已经根据背景反色后的） < 用户配置字体颜色
     const fill = this.getTextConditionFill({
       ...textStyle,
-      fill: this.getDefaultTextFill(textStyle),
+      fill: textFill,
     });
 
     return { ...textStyle, fill };

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -110,6 +110,8 @@ export interface TextTheme extends TextAlignCfg {
   linkTextFill?: string;
   /* 字体透明度 */
   opacity?: number;
+  /* 奇数行字体颜色 */
+  oddFill?: string;
 }
 
 export interface CellTheme {

--- a/s2-site/docs/api/general/S2Theme.en.md
+++ b/s2-site/docs/api/general/S2Theme.en.md
@@ -149,6 +149,7 @@ Function Description: Text Theme
 | fill         | font color                                                    | `string`                      | -                                                                                  |          |
 | linkTextFill | link text color                                               | `string`                      | -                                                                                  |          |
 | opacity      | font transparency                                             | `number`                      | 1                                                                                  |          |
+| oddFill    | Odd rows font color                                               | `string`                  | -
 
 #### Cell Theme
 

--- a/s2-site/docs/api/general/S2Theme.zh.md
+++ b/s2-site/docs/api/general/S2Theme.zh.md
@@ -151,6 +151,7 @@ s2.setTheme({
 | fill         | 字体颜色                                                                       | `string`                      | -                                                                                                 |      |
 | linkTextFill | 链接文本颜色                                                                   | `string`                      | -                                                                                                 |      |
 | opacity      | 字体透明度                                                                     | `number`                      | 1                                                                                                 |      |
+| oddFill    | 奇数行字体颜色                                                                     | `string`                   | -
 
 #### CellTheme
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
主要改动 s2-core/src/cell/data-cell.ts 文件中getTextStyle() 方法 ；TextTheme 接口新增   /* 奇数行字体颜色 */ oddFill?: string;
工作中需要动态调整奇数行的字体样式，但是目前仅支持奇数行背景颜色调整；
增加功能后，可通过setTheme() 调整数值单元格奇数行文本主题。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| 
![image](https://user-images.githubusercontent.com/47958829/230527781-88fd02ef-c31d-4f36-bd2a-31dcda7914cf.png)
      | 
![image](https://user-images.githubusercontent.com/47958829/230527857-75daf9cb-fdc1-4b33-b8fe-66ebbcaeb3e1.png)
   |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [x] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
