### PR TITLE
fix: 多指标行头总计节点宽度计算错误

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2164-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2164-spec.ts
@@ -1,0 +1,48 @@
+/**
+ * 行头多数值配置下，总计子节点宽度计算有误
+ * @description spec for issue #2164
+ * https://github.com/antvis/S2/issues/2164
+ */
+
+import { getContainer } from '../util/helpers';
+import * as mockDataConfig from '../data/simple-data.json';
+import type { S2Options } from '@/index';
+import { PivotSheet } from '@/sheet-type';
+
+const s2Options: S2Options = {
+  width: 400,
+  height: 400,
+  style: {
+    layoutWidthType: 'compact',
+  },
+  totals: {
+    row: {
+      showGrandTotals: true,
+      showSubTotals: true,
+      reverseLayout: true,
+    },
+  },
+};
+
+describe('Grand Total Row Node Tests', () => {
+  const s2 = new PivotSheet(
+    getContainer(),
+    {
+      ...mockDataConfig,
+      fields: {
+        ...mockDataConfig.fields,
+        valueInCols: false, // 指标放行头
+      },
+    },
+    s2Options,
+  );
+  s2.render();
+
+  test("should calc correct grand total children nodes' width", () => {
+    const { rowLeafNodes } = s2.facet.layoutResult;
+    const totalLeafNode = rowLeafNodes.find((it) => it.isTotalMeasure);
+    const normalLeafNode = rowLeafNodes.find((it) => !it.isTotalMeasure);
+
+    expect(totalLeafNode.width).toEqual(normalLeafNode.width);
+  });
+});

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -535,7 +535,7 @@ export class PivotFacet extends BaseFacet {
     if (isRowHeader) {
       // 填充行总单元格宽度
       grandTotalNode.width = hierarchy.width;
-      // 调整其叶子结点位置和宽度
+      // 调整其叶子节点位置和宽度
       forEach(grandTotalChildren, (node: Node) => {
         const maxLevelNode = hierarchy.getNodes(maxLevel)[0];
         node.x = maxLevelNode.x;

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -535,9 +535,11 @@ export class PivotFacet extends BaseFacet {
     if (isRowHeader) {
       // 填充行总单元格宽度
       grandTotalNode.width = hierarchy.width;
-      // 调整其叶子结点位置
+      // 调整其叶子结点位置和宽度
       forEach(grandTotalChildren, (node: Node) => {
-        node.x = hierarchy.getNodes(maxLevel)[0].x;
+        const maxLevelNode = hierarchy.getNodes(maxLevel)[0];
+        node.x = maxLevelNode.x;
+        node.width = maxLevelNode.width;
       });
     } else if (maxLevel > 1 || (maxLevel <= 1 && !moreThanOneValue)) {
       // 只有当列头总层级大于1级或列头为1级单指标时总计格高度才需要填充


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2164 


### 📝 Description
多个数值放行头时，总计节点没有调整节点宽度。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
|   <img width="293" alt="CleanShot 2023-04-17 at 12 15 47@2x" src="https://user-images.githubusercontent.com/6716092/232376562-de9ebf8b-aea0-45ce-8704-7096f821c0c2.png">     |  <img width="299" alt="CleanShot 2023-04-17 at 12 15 23@2x" src="https://user-images.githubusercontent.com/6716092/232376527-5450e6c8-aeb7-4178-90ba-7ec41e5e407b.png">    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
