### PR TITLE
fix: 行头过宽且不冻结时滚动条渲染错误

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2140-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2140-spec.ts
@@ -1,0 +1,35 @@
+/**
+ * 透视表不冻结行头且行头过宽时滚动条渲染错误
+ * @description spec for issue #2140
+ * https://github.com/antvis/S2/issues/2140
+ */
+
+import { getContainer } from '../util/helpers';
+import * as mockDataConfig from '../data/simple-data.json';
+import type { S2Options } from '@/index';
+import { PivotSheet } from '@/sheet-type';
+
+const s2Options: S2Options = {
+  width: 400,
+  height: 400,
+  frozenRowHeader: false,
+  style: {
+    rowCfg: {
+      widthByField: {
+        province: 300,
+        city: 300,
+      },
+    },
+  },
+};
+
+describe('Horizontal Scroll Bar Tests', () => {
+  const s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
+  s2.render();
+
+  test('should render correctly when row header wider than canvas', () => {
+    const { hScrollBar } = s2.facet;
+
+    expect(hScrollBar.trackLen).toEqual(s2.facet.getCanvasHW().width);
+  });
+});

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -642,7 +642,7 @@ export abstract class BaseFacet {
       const finalWidth =
         width +
         (this.cfg.spreadsheet.isScrollContainsRowHeader()
-          ? this.cornerBBox.width
+          ? Math.min(this.cornerBBox.width, this.getCanvasHW().width)
           : 0);
       const finalPosition = {
         x:


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2140 

### 📝 Description

行头过宽时（通过拖拽，或者 style 配置），滚动条会渲染的比整个 canvas 宽。
导致无法滚动到头，即 panel 会有部分遮挡，渲染不全。

### 🖼️ Screenshot

配置
- canvas 设置 400 宽度
- province、city 各配置 300 宽度

| Before | After |
| ------ | ----- |
|  ![CleanShot 2023-04-23 at 17 08 46](https://user-images.githubusercontent.com/6716092/233830559-7ac5215b-8667-4d94-9942-599a105e7888.gif)    |  ![CleanShot 2023-04-23 at 17 07 37](https://user-images.githubusercontent.com/6716092/233830505-75ba9945-afa6-4e01-952e-83af618a3ae5.gif)     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
