### PR TITLE
fix: canvas mouseout 判断错误

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -1,13 +1,19 @@
 /* eslint-disable jest/expect-expect */
-import { Canvas, FederatedEvent, Image } from '@antv/g';
+import {
+  Canvas,
+  FederatedEvent,
+  Image,
+  CustomEvent,
+  type CanvasConfig,
+} from '@antv/g';
 import {
   createFakeSpreadSheet,
   createFederatedMouseEvent,
   createFederatedPointerEvent,
+  getClientPointOnCanvas,
   sleep,
 } from 'tests/util/helpers';
 import { Renderer } from '@antv/g-canvas';
-import type { CanvasConfig } from '@antv/g-lite';
 import { GEventType, GuiIcon } from '@/common';
 import type { EmitterType } from '@/common/interface/emitter';
 import {
@@ -110,7 +116,7 @@ describe('Interaction Event Controller Tests', () => {
     };
 
   beforeEach(() => {
-    const container = document.createElement('div');
+    const container = document.body.appendChild(document.createElement('div'));
 
     spreadsheet = createFakeSpreadSheet();
     spreadsheet.container = new Canvas({
@@ -484,31 +490,28 @@ describe('Interaction Event Controller Tests', () => {
   });
 
   test('should not reset if current mouse on the canvas container', () => {
-    const containsMock = jest
-      .spyOn(HTMLElement.prototype, 'contains')
-      .mockImplementation(() => true);
-
     const reset = jest.fn();
 
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    window.dispatchEvent(
+    const pointInCanvas = spreadsheet.container.viewport2Client({
+      x: 10,
+      y: 10,
+    });
+
+    spreadsheet.getCanvasElement().dispatchEvent(
       new MouseEvent('click', {
-        clientX: 100,
-        clientY: 100,
+        clientX: pointInCanvas.x,
+        clientY: pointInCanvas.y,
+        bubbles: true,
       } as MouseEventInit),
     );
 
-    expect(containsMock).toHaveBeenCalled();
     expect(reset).not.toHaveBeenCalled();
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
   test('should reset if current mouse not on the canvas container', () => {
-    const containsMock = jest
-      .spyOn(HTMLElement.prototype, 'contains')
-      .mockImplementation(() => true);
-
     spreadsheet.hideTooltip = jest.fn();
     const reset = jest.fn().mockImplementation(() => {
       spreadsheet.hideTooltip();
@@ -532,26 +535,9 @@ describe('Interaction Event Controller Tests', () => {
       } as MouseEventInit),
     );
 
-    expect(containsMock).toHaveBeenCalled();
     expect(reset).toHaveBeenCalled();
     expect(spreadsheet.interaction.reset).toHaveBeenCalled();
     expect(spreadsheet.hideTooltip).toHaveBeenCalled();
-  });
-
-  test('should reset if current mouse outside the canvas container', () => {
-    const reset = jest.fn();
-
-    spreadsheet.on(S2Event.GLOBAL_RESET, reset);
-
-    window.dispatchEvent(
-      new MouseEvent('click', {
-        clientX: 300,
-        clientY: 300,
-      } as MouseEventInit),
-    );
-
-    expect(reset).toHaveBeenCalled();
-    expect(spreadsheet.interaction.reset).toHaveBeenCalled();
   });
 
   test('should reset if current mouse inside the canvas container, but outside the panel facet', () => {
@@ -565,10 +551,16 @@ describe('Interaction Event Controller Tests', () => {
 
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    window.dispatchEvent(
+    const pointInCanvas = spreadsheet.container.viewport2Client({
+      x: 120,
+      y: 120,
+    });
+
+    spreadsheet.getCanvasElement().dispatchEvent(
       new MouseEvent('click', {
-        clientX: 120,
-        clientY: 120,
+        clientX: pointInCanvas.x,
+        clientY: pointInCanvas.y,
+        bubbles: true,
       } as MouseEventInit),
     );
 
@@ -662,28 +654,6 @@ describe('Interaction Event Controller Tests', () => {
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
-  // https://github.com/antvis/S2/issues/363
-  test('should reset if current mouse outside the canvas container and disable tooltip', () => {
-    const reset = jest.fn();
-
-    spreadsheet.on(S2Event.GLOBAL_RESET, reset);
-    Object.defineProperty(spreadsheet.options.tooltip, 'showTooltip', {
-      get() {
-        return false;
-      },
-    });
-
-    window.dispatchEvent(
-      new MouseEvent('click', {
-        clientX: 100,
-        clientY: 100,
-      } as MouseEventInit),
-    );
-
-    expect(reset).not.toHaveBeenCalled();
-    expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
-  });
-
   test('should disable reset if autoResetSheetStyle set to false', () => {
     spreadsheet.facet = {
       panelBBox: {
@@ -720,9 +690,13 @@ describe('Interaction Event Controller Tests', () => {
       cells: [{} as CellMeta],
       stateName: InteractionStateName.HOVER,
     });
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
-      shape: null,
-    });
+
+    spreadsheet.container.dispatchEvent(
+      new CustomEvent(
+        OriginEventType.MOUSE_OUT,
+        getClientPointOnCanvas(spreadsheet.container, -10, -10),
+      ),
+    );
 
     expect(spreadsheet.interaction.reset).toHaveBeenCalled();
     expect(spreadsheet.hideTooltip).toHaveBeenCalled();
@@ -734,9 +708,13 @@ describe('Interaction Event Controller Tests', () => {
       cells: [{} as CellMeta],
       stateName: InteractionStateName.SELECTED,
     });
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
-      shape: 'mock',
-    });
+
+    spreadsheet.container.dispatchEvent(
+      new CustomEvent(
+        OriginEventType.MOUSE_OUT,
+        getClientPointOnCanvas(spreadsheet.container, 10, 10),
+      ),
+    );
 
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
@@ -746,9 +724,13 @@ describe('Interaction Event Controller Tests', () => {
       cells: [{} as CellMeta],
       stateName: InteractionStateName.SELECTED,
     });
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
-      shape: null,
-    });
+
+    spreadsheet.container.dispatchEvent(
+      new CustomEvent(
+        OriginEventType.MOUSE_OUT,
+        getClientPointOnCanvas(spreadsheet.container, -10, -10),
+      ),
+    );
 
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
@@ -760,18 +742,26 @@ describe('Interaction Event Controller Tests', () => {
       },
     });
 
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
-      shape: null,
-    });
+    spreadsheet.container.dispatchEvent(
+      new CustomEvent(
+        OriginEventType.MOUSE_OUT,
+        getClientPointOnCanvas(spreadsheet.container, -10, -10),
+      ),
+    );
+
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
   test('should disable reset if mouse outside the canvas and action tooltip is active', () => {
     spreadsheet.interaction.addIntercepts([InterceptType.HOVER]);
 
-    spreadsheet.container.emit(OriginEventType.MOUSE_OUT, {
-      shape: null,
-    });
+    spreadsheet.container.dispatchEvent(
+      new CustomEvent(
+        OriginEventType.MOUSE_OUT,
+        getClientPointOnCanvas(spreadsheet.container, -10, -10),
+      ),
+    );
+
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
   });
 
@@ -959,12 +949,19 @@ describe('Interaction Event Controller Tests', () => {
 
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
-    window.dispatchEvent(
-      new PointerEvent('click', {
-        clientX: 100,
-        clientY: 100,
-      } as MouseEventInit),
-    );
+    const pointInCanvas = getClientPointOnCanvas(spreadsheet.container, 10, 10);
+    const evt = new window.CustomEvent('click');
+
+    Object.defineProperties(evt, {
+      clientX: {
+        value: pointInCanvas.clientX,
+      },
+      clientY: {
+        value: pointInCanvas.clientY,
+      },
+    });
+    spreadsheet.getCanvasElement().dispatchEvent(evt);
+
     expect(eventController.isCanvasEffect).toBe(true);
     expect(reset).not.toHaveBeenCalled();
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -287,3 +287,26 @@ export const createTableSheet = (
       ...s2Options,
     },
   );
+
+/**
+ * 获取基于 canvas 坐标系的真实 clientX/Y 坐标
+ * @param canvas g canvas 实例
+ * @param x 相对于 canvas 左上角的 x 坐标
+ * @param y 相对于 canvas 左上角的 y 坐标
+ * @returns 全局 clientX/Y 坐标
+ */
+export const getClientPointOnCanvas = (
+  canvas: Canvas,
+  x: number,
+  y: number,
+) => {
+  const point = canvas.viewport2Client({
+    x,
+    y,
+  });
+
+  return {
+    clientX: point.x,
+    clientY: point.y,
+  };
+};

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -204,7 +204,7 @@ export class EventController {
       const { width, height } = this.getContainerRect();
 
       return (
-        canvas.contains(event.target as HTMLElement) &&
+        (event.target === canvas || event.target instanceof DisplayObject) &&
         event.clientX <= x + width &&
         event.clientY <= y + height
       );
@@ -544,7 +544,10 @@ export class EventController {
   };
 
   private onCanvasMouseout = (event: CanvasEvent) => {
-    if (!this.isAutoResetSheetStyle || event?.target instanceof DisplayObject) {
+    if (
+      !this.isAutoResetSheetStyle ||
+      this.isMouseOnTheCanvasContainer(event as Event)
+    ) {
       return;
     }
 

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -1,5 +1,5 @@
 import {
-  type Canvas,
+  Canvas,
   type FederatedPointerEvent as CanvasEvent,
   type Group,
   DisplayObject,
@@ -203,10 +203,16 @@ export class EventController {
        */
       const { width, height } = this.getContainerRect();
 
+      const { target: eventTarget, clientX, clientY } = event;
+
       return (
-        (event.target === canvas || event.target instanceof DisplayObject) &&
-        event.clientX <= x + width &&
-        event.clientY <= y + height
+        (eventTarget === canvas ||
+          eventTarget instanceof DisplayObject ||
+          eventTarget instanceof Canvas) &&
+        clientX <= x + width &&
+        clientX >= x &&
+        clientY <= y + height &&
+        clientY >= y
       );
     }
 


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2115 

### 📝 Description
`canvas mouse out` 时应该清除交互样式，现在没有清除，原因是在 g5.0 的迁移中，判断条件替换错了。

```diff
  private onCanvasMouseout = (event: CanvasEvent) => {
-    if (!this.isAutoResetSheetStyle || event?.shape) {
+    if (!this.isAutoResetSheetStyle || event?.target instanceof DisplayObject) {
```

以前 canvas 内部有事件触发时
- 如果由图形触发事件，则 event.shape 指向该图形
- 如果在 cavas 内，但没 hit 任何图形，则 event.shape 为 null

需要注意的是，上面的事件中 event.target 都是 HTMLCanvas 对象

在 g5.0 中，所有画布、图形、事件都被抽象了
- event.target 指向的图形都是 DisplayObject 对象

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2023-04-27 at 09 29 03](https://user-images.githubusercontent.com/6716092/234736750-cf42d23d-d8d9-41eb-86ea-798cf0ae736c.gif)     |  ![CleanShot 2023-04-27 at 09 27 04](https://user-images.githubusercontent.com/6716092/234736453-76361571-0659-4d8a-ab90-67ba34a13591.gif)     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
