### PR TITLE
fix: 系统拦截快捷键后多选交互异常

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -9,7 +9,12 @@ import type {
   ViewMeta,
 } from '@/common/interface';
 import type { SpreadSheet } from '@/sheet-type';
-import { InteractionStateName, S2Event } from '@/common/constant';
+import {
+  InteractionKeyboardKey,
+  InteractionStateName,
+  InterceptType,
+  S2Event,
+} from '@/common/constant';
 import type { Node } from '@/facet/layout/node';
 
 jest.mock('@/interaction/event-controller');
@@ -83,6 +88,42 @@ describe('Interaction Row & Column Cell Click Tests', () => {
   test('should bind events', () => {
     expect(rowColumnClick.bindEvents).toBeDefined();
   });
+
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should add click intercept when %s keydown',
+    (key) => {
+      s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
+        key,
+      } as KeyboardEvent);
+
+      expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeTruthy();
+    },
+  );
+
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should remove click intercept when %s keyup',
+    (key) => {
+      s2.interaction.addIntercepts([InterceptType.CLICK]);
+      s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
+        key,
+      } as KeyboardEvent);
+
+      expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
+    },
+  );
+
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should remove click intercept when %s released',
+    () => {
+      Object.defineProperty(rowColumnClick, 'isMultiSelection', {
+        value: true,
+      });
+      s2.interaction.addIntercepts([InterceptType.CLICK]);
+      s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {} as MouseEvent);
+
+      expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
+    },
+  );
 
   // https://github.com/antvis/S2/issues/1243
   test.each([S2Event.ROW_CELL_CLICK, S2Event.COL_CELL_CLICK])(

--- a/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/data-cell-multi-selection-spec.ts
@@ -47,7 +47,7 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
   });
 
   test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
-    'should add click intercept when keydown',
+    'should add click intercept when %s keydown',
     (key) => {
       s2.emit(S2Event.GLOBAL_KEYBOARD_DOWN, {
         key,
@@ -58,11 +58,25 @@ describe('Interaction Data Cell Multi Selection Tests', () => {
   );
 
   test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
-    'should remove click intercept when  keyup',
+    'should remove click intercept when %s keyup',
     (key) => {
+      s2.interaction.addIntercepts([InterceptType.CLICK]);
       s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
         key,
       } as KeyboardEvent);
+
+      expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
+    },
+  );
+
+  test.each([InteractionKeyboardKey.META, InteractionKeyboardKey.CONTROL])(
+    'should remove click intercept when %s released',
+    () => {
+      Object.defineProperty(dataCellMultiSelection, 'isMultiSelection', {
+        value: true,
+      });
+      s2.interaction.addIntercepts([InterceptType.CLICK]);
+      s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {} as MouseEvent);
 
       expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
     },

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -54,9 +54,20 @@ describe('Interaction Range Selection Tests', () => {
   });
 
   test('should remove click intercept when shift keyup', () => {
+    s2.interaction.addIntercepts([InterceptType.CLICK]);
     s2.emit(S2Event.GLOBAL_KEYBOARD_UP, {
       key: InteractionKeyboardKey.SHIFT,
     } as KeyboardEvent);
+
+    expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
+  });
+
+  test('should remove click intercept when shift released', () => {
+    Object.defineProperty(rangeSelection, 'isRangeSelection', {
+      value: true,
+    });
+    s2.interaction.addIntercepts([InterceptType.CLICK]);
+    s2.emit(S2Event.GLOBAL_MOUSE_MOVE, {} as MouseEvent);
 
     expect(s2.interaction.hasIntercepts([InterceptType.CLICK])).toBeFalsy();
   });

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -20,7 +20,10 @@ import {
   hideColumnsByThunkGroup,
   isEqualDisplaySiblingNodeId,
 } from '../../../utils/hide-columns';
-import { isMultiSelectionKey } from '../../../utils/interaction/select-event';
+import {
+  isMouseEventWithMeta,
+  isMultiSelectionKey,
+} from '../../../utils/interaction/select-event';
 import {
   getTooltipOptions,
   getTooltipVisibleOperator,
@@ -36,6 +39,12 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     this.bindColCellClick();
     this.bindRowCellClick();
     this.bindTableColExpand();
+    this.bindMouseMove();
+  }
+
+  public reset() {
+    this.isMultiSelection = false;
+    this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
   }
 
   private bindKeyboardDown() {
@@ -52,8 +61,16 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
       if (isMultiSelectionKey(event)) {
-        this.isMultiSelection = false;
-        this.spreadsheet.interaction.removeIntercepts([InterceptType.CLICK]);
+        this.reset();
+      }
+    });
+  }
+
+  private bindMouseMove() {
+    this.spreadsheet.on(S2Event.GLOBAL_MOUSE_MOVE, (event) => {
+      // 当快捷键被系统拦截后，按需补充调用一次 reset
+      if (this.isMultiSelection && !isMouseEventWithMeta(event)) {
+        this.reset();
       }
     });
   }

--- a/packages/s2-core/src/interaction/data-cell-multi-selection.ts
+++ b/packages/s2-core/src/interaction/data-cell-multi-selection.ts
@@ -11,7 +11,7 @@ import type { CellMeta, S2CellType, ViewMeta } from '../common/interface';
 import {
   getCellMeta,
   isMultiSelectionKey,
-  getInteractionCellsBySelectedCells,
+  isMouseEventWithMeta,
 } from '../utils/interaction/select-event';
 import { getCellsTooltipData } from '../utils/tooltip';
 import { afterSelectDataCells } from '../utils/interaction/select-event';
@@ -27,6 +27,7 @@ export class DataCellMultiSelection
     this.bindKeyboardDown();
     this.bindDataCellClick();
     this.bindKeyboardUp();
+    this.bindMouseMove();
   }
 
   public reset() {
@@ -49,6 +50,15 @@ export class DataCellMultiSelection
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
       if (isMultiSelectionKey(event)) {
+        this.reset();
+      }
+    });
+  }
+
+  private bindMouseMove() {
+    this.spreadsheet.on(S2Event.GLOBAL_MOUSE_MOVE, (event) => {
+      // 当快捷键被系统拦截后，按需补充调用一次 reset
+      if (this.isMultiSelection && !isMouseEventWithMeta(event)) {
         this.reset();
       }
     });

--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -22,6 +22,7 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
     this.bindDataCellClick();
     this.bindColCellClick();
     this.bindKeyboardUp();
+    this.bindMouseMove();
   }
 
   public reset() {
@@ -44,6 +45,15 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
   private bindKeyboardUp() {
     this.spreadsheet.on(S2Event.GLOBAL_KEYBOARD_UP, (event: KeyboardEvent) => {
       if (event.key === InteractionKeyboardKey.SHIFT) {
+        this.reset();
+      }
+    });
+  }
+
+  private bindMouseMove() {
+    // 当快捷键被系统拦截后，按需补充调用一次 reset
+    this.spreadsheet.on(S2Event.GLOBAL_MOUSE_MOVE, (event) => {
+      if (this.isRangeSelection && !event.shiftKey) {
         this.reset();
       }
     });

--- a/packages/s2-core/src/utils/interaction/select-event.ts
+++ b/packages/s2-core/src/utils/interaction/select-event.ts
@@ -25,6 +25,10 @@ export const isMultiSelectionKey = (e: KeyboardEvent) => {
   );
 };
 
+export const isMouseEventWithMeta = (e: MouseEvent) => {
+  return e.ctrlKey || e.metaKey;
+};
+
 export const getCellMeta = (cell: S2CellType): CellMeta => {
   const meta = cell.getMeta();
   const { id, colIndex, rowIndex, rowQuery } = meta || {};


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2190 

### 📝 Description

#### 问题：
以 `range-selection` 为例，该交互通过监听 `shift` 的 keyup/keydown 事件，来置标志位。
当 shift 按下，标志位置为 true，用户可以进行多选。
但如果不松 shfit，继续按下 shift+cmd+4 组合进行截图，之后即使松开组合键，也无法获取到 keydown 事件，进而导致多选交互异常。
类似的问题还存在于 `行列头多个点选`、`单元格多个点选`，都是类似的 pattern。

#### 修复方法：
监听 mouseMove 事件，查看对应的修饰键是否还在被按压，补充调用 reset 一下状态。
为什么还要保留 keydown 的 reset？因为用户可能不移动鼠标，直接点选单元格。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

> 以 dataCell cmd 点选多选为例

| Before | After |
| ------ | ----- |
|  ![CleanShot 2023-05-06 at 16 30 16](https://user-images.githubusercontent.com/6716092/236612982-5b57d8a3-88f5-465b-b0d7-ea0d9679c8a5.gif)     |   ![CleanShot 2023-05-06 at 16 29 03](https://user-images.githubusercontent.com/6716092/236612886-4a37ea77-77a5-4311-a999-f621c2ae505e.gif)    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
