### PR TITLE
fix: 复制时移除空控制符

### DIFF
--- a/packages/s2-core/src/utils/export/index.ts
+++ b/packages/s2-core/src/utils/export/index.ts
@@ -67,9 +67,11 @@ export const copyToClipboardByClipboard = (data: Copyable): Promise<void> => {
       new ClipboardItem(
         [].concat(data).reduce((prev, copyable: CopyableItem) => {
           const { type, content } = copyable;
+          // eslint-disable-next-line no-control-regex
+          const contentToCopy = content.replace(/\x00/g, '');
           return {
             ...prev,
-            [type]: new Blob([content], { type }),
+            [type]: new Blob([contentToCopy], { type }),
           };
         }, {}),
       ),


### PR DESCRIPTION
### 👀 PR includes


🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description
复制会使用 `navigator.clipboard` 或 `document.execCommand` 方法
当复制的数据中存在 `\x00` `NUL` 字符时，二者的表现不一致
- `navigator.clipboard`：new Blob 时会保留 `NUL` 字符，进而导致 excel 粘贴时出错
- `document.execCommand`：由于借助了 textarea 中转，会去掉 `NUL` 字符

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
