### PR TITLE
feat: 条件格式mapping增加格式化后的文本参数

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:ci-coverage": "pnpm -r --filter './packages/*' --stream test:ci-coverage",
     "lint": "run-s lint:type lint:script lint:style lint:docs lint:word",
     "lint:type": "pnpm -r --filter './packages/*' --stream tsc",
-    "lint:script": "eslint . --ext '.js,.jsx,.ts,.tsx,.vue'",
+    "lint:script": "eslint --ext '.js,.jsx,.ts,.tsx,.vue'",
     "lint:style": "stylelint packages/**/*.less",
     "lint:docs": "markdownlint '**/*.md'",
     "lint:word": "case-police '**/*.md'",

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -407,16 +407,30 @@ describe('Data Cell Tests', () => {
     });
 
     test('should test condition mapping params when the sheet is pivot', () => {
+      const formatter = (v: any) => {
+        return `${v}%`;
+      };
+
+      s2.setDataCfg({
+        ...s2.dataCfg,
+        meta: [
+          {
+            field: 'cost',
+            formatter,
+          },
+        ],
+      });
       s2.setOptions({
         conditions: {
           background: [
             {
               field: 'cost',
-              mapping(value, dataInfo) {
+              mapping(value, dataInfo, formattedValue) {
                 const originData = s2.dataSet.originData;
                 const resultData = find(originData, dataInfo);
 
                 expect(resultData).toEqual(dataInfo);
+                expect(formatter(value)).toEqual(formattedValue);
                 // @ts-ignore
                 expect(value).toEqual(resultData.cost);
 

--- a/packages/s2-core/package.json
+++ b/packages/s2-core/package.json
@@ -88,7 +88,7 @@
   "bundlesize": [
     {
       "path": "./dist/index.min.js",
-      "maxSize": "200 kB"
+      "maxSize": "300 kB"
     },
     {
       "path": "./dist/style.min.css",

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -428,7 +428,11 @@ export class DataCell extends BaseCell<ViewMeta> {
         })
       : getFieldValueOfViewMetaData(this.meta.data);
 
-    return condition?.mapping(value, rowDataInfo as RawData);
+    return condition?.mapping(
+      value,
+      rowDataInfo as RawData,
+      this.getFormattedFieldValue().formattedValue,
+    );
   }
 
   public updateByState(stateName: InteractionStateName) {

--- a/packages/s2-core/src/common/interface/condition.ts
+++ b/packages/s2-core/src/common/interface/condition.ts
@@ -31,6 +31,7 @@ export interface MappingResult extends ValueRange {
 export type MappingFunction = (
   fieldValue: number | string,
   data: RawData,
+  formattedValue?: number | string,
 ) => MappingResult | undefined | null;
 
 /**

--- a/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
@@ -166,12 +166,16 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
       map(customRows, (row, rowIndex) => {
         // 角头的最后一行，为行头
         if (colIndex === customColumns.length - 1) {
-          return find(meta, ['field', row])?.name ?? row;
+          return this.config.isFormatData
+            ? find(meta, ['field', row])?.name ?? row
+            : row;
         }
 
         // 角头的最后一列，为列头
         if (rowIndex === maxRowLen - 1) {
-          return find(meta, ['field', col])?.name ?? col;
+          return this.config.isFormatData
+            ? find(meta, ['field', col])?.name ?? col
+            : col;
         }
 
         return '';
@@ -221,6 +225,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
 
     return this.matrixTransformer(
       assembleMatrix({ rowMatrix, colMatrix, dataMatrix }),
+      this.config.separator,
     );
   };
 
@@ -231,7 +236,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
 
     // 不带表头复制
     if (!copyWithHeader) {
-      return this.matrixTransformer(dataMatrix);
+      return this.matrixTransformer(dataMatrix, this.config.separator);
     }
 
     // 带表头复制
@@ -241,6 +246,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
 
     return this.matrixTransformer(
       assembleMatrix({ rowMatrix, colMatrix, dataMatrix }),
+      this.config.separator,
     );
   }
 
@@ -254,6 +260,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
 
     return this.matrixTransformer(
       assembleMatrix({ rowMatrix, colMatrix, dataMatrix, cornerMatrix }),
+      this.config.separator,
     );
   };
 }

--- a/packages/s2-core/src/utils/export/copy/table-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/table-copy.ts
@@ -124,13 +124,14 @@ class TableDataCellCopy extends BaseDataCellCopy {
     ) as string[][];
 
     if (!copyWithHeader) {
-      return this.matrixTransformer(dataMatrix);
+      return this.matrixTransformer(dataMatrix, this.config.separator);
     }
 
     const colMatrix = this.getColMatrix();
 
     return this.matrixTransformer(
       assembleMatrix({ colMatrix: [colMatrix], dataMatrix }),
+      this.config.separator,
     );
   }
 
@@ -144,13 +145,14 @@ class TableDataCellCopy extends BaseDataCellCopy {
     const matrix = this.getDataMatrix();
 
     if (!allSelected) {
-      return this.matrixTransformer(matrix);
+      return this.matrixTransformer(matrix, this.config.separator);
     }
 
     const colMatrix = this.getColMatrix();
 
     return this.matrixTransformer(
       assembleMatrix({ colMatrix: [colMatrix], dataMatrix: matrix }),
+      this.config.separator,
     );
   }
 }

--- a/s2-site/docs/common/conditions.en.md
+++ b/s2-site/docs/common/conditions.en.md
@@ -32,7 +32,8 @@ Function description: Configure conditional formatting. Including text (text), b
 ```ts
 type MappingFunction = (
   fieldValue: number | string | null,
-  data: Record<string, any>
+  data: Record<string, any>,
+  formattedValue: number | string | null
 ) => {
   // 仅用于图标字段标记，可选
   icon?: string;

--- a/s2-site/docs/common/conditions.zh.md
+++ b/s2-site/docs/common/conditions.zh.md
@@ -32,7 +32,8 @@ order: 2
 ```ts
 type MappingFunction = (
   fieldValue: number | string | null,
-  data: Record<string, any>
+  data: Record<string, any>,
+  formattedValue: number | string | null
 ) => {
   // 仅用于图标字段标记，可选
   icon?: string;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
如下图透视表通过格式化实现了列小计占比计算，此时单元格显示的值已经转换为父级的小计占比。
在设置条件格式时原来的mapping里没有没法获取格式化后的值，只能单元格本身的值；这样就没有办法根据占比设置条件格式
增加了第三个参数后就可以根据格式化后的占比设置不同的条件格式
### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![4CC6BAFA-0269-42bd-A944-B5BAF1333A7B](https://github.com/antvis/S2/assets/25057951/2647911c-9de2-4296-8724-c06a05799af3)  |  ![F321B2D2-F1EC-440a-9AD5-12F51D268A2A](https://github.com/antvis/S2/assets/25057951/9d6d7fb6-2657-43ba-9a43-657d0e0a63b2) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
