### PR TITLE
fix: use actualText replace value label in copy

### DIFF
--- a/packages/s2-core/src/utils/export/copy.ts
+++ b/packages/s2-core/src/utils/export/copy.ts
@@ -4,6 +4,7 @@ import {
   filter,
   forEach,
   isEmpty,
+  isEqual,
   isNil,
   map,
   max,
@@ -12,25 +13,25 @@ import {
   repeat,
   zip,
 } from 'lodash';
+import type { ColCell, RowCell } from '../../cell';
 import {
-  type CellMeta,
   CellTypes,
   CopyType,
   EMPTY_PLACEHOLDER,
   EXTRA_FIELD,
   ID_SEPARATOR,
   InteractionStateName,
-  VALUE_FIELD,
   SERIES_NUMBER_FIELD,
+  VALUE_FIELD,
+  type CellMeta,
   type RowData,
 } from '../../common';
 import type { DataType } from '../../data-set/interface';
 import type { Node } from '../../facet/layout/node';
 import type { SpreadSheet } from '../../sheet-type';
 import { copyToClipboard } from '../../utils/export';
-import type { ColCell, RowCell } from '../../cell';
-import { getEmptyPlaceholder } from '../text';
 import { flattenDeep } from '../data-set-operate';
+import { getEmptyPlaceholder } from '../text';
 
 export function keyEqualTo(key: string, compareKey: string) {
   if (!key || !compareKey) {
@@ -659,11 +660,20 @@ function getCellMatrix(
     const meta = cell.getMeta();
     const { id, label, isTotals, level } = meta;
     let cellId = id;
+
     // 为总计小计补齐高度
     if (isTotals && level !== maxLevel) {
       cellId = id + ID_SEPARATOR + repeat(label, maxLevel - level);
     }
-    return getHeaderList(cellId, allLevel.size);
+
+    // 将指标维度单元格的标签替换为实际文本
+    const actualText = cell.getActualText();
+    const headerList = getHeaderList(cellId, allLevel.size);
+    const formattedHeaderList = map(headerList, (header) =>
+      isEqual(header, label) ? actualText : header,
+    );
+
+    return formattedHeaderList;
   });
 }
 


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2252 

### 📝 Description

use actualText replace value label in copy

只有指标维度在复制的时候有问题，用实际文本替换指标维度的标签

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
