### PR TITLE
fix(core): 删除范围选择中的错误拦截器

### DIFF
--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -187,6 +187,7 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
           stateName: InteractionStateName.SELECTED,
         });
       } else {
+        interaction.removeIntercepts([InterceptType.HOVER]);
         this.spreadsheet.store.set('lastClickedCell', cell);
       }
 


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2260 

🔧 Chore

- [ ] Test case

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

背景请看 #2260 

在点击列头的时候会触发两次 GLOBAL_SELECTED，一次是正常的，另一次是 range-selection 的，range-selection 目前无论如何都会添加一个 hover 的拦截器，需要在不是 range-selection 的情况下把这个拦截器给清除掉！

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
