### PR TITLE
fix(core): 使用客户端的位置来计算调整大小的偏移量

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -182,10 +182,15 @@ describe('TableSheet normal spec', () => {
 
     await sleep(30);
 
+    let columnNodes = s2.getColumnNodes();
+    let lastColumnCell = columnNodes[columnNodes.length - 1]
+      .belongsCell as ColCell;
+    const startCellWidth = lastColumnCell.getMeta().width;
+
     const { x, width, top } = s2.getCanvasElement().getBoundingClientRect();
     s2.getCanvasElement().dispatchEvent(
       new MouseEvent('mousedown', {
-        clientX: x + width - 1,
+        clientX: x + width,
         clientY: top + 25,
       }),
     );
@@ -207,11 +212,11 @@ describe('TableSheet normal spec', () => {
 
     await sleep(300);
 
-    const columnNodes = s2.getColumnNodes();
-    const lastColumnCell = columnNodes[columnNodes.length - 1]
-      .belongsCell as ColCell;
+    columnNodes = s2.getColumnNodes();
+    lastColumnCell = columnNodes[columnNodes.length - 1].belongsCell as ColCell;
+    const endCellWidth = lastColumnCell.getMeta().width;
 
-    expect(lastColumnCell.getMeta().width).toBe(199);
+    expect(endCellWidth - startCellWidth).toBe(100);
   });
 
   test('should render link shape', () => {

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -199,6 +199,8 @@ describe('Interaction Row Column Resize Tests', () => {
       {
         offsetX: 10,
         offsetY: 20,
+        clientX: 10,
+        clientY: 20,
       },
       resizeInfo,
     );
@@ -206,6 +208,7 @@ describe('Interaction Row Column Resize Tests', () => {
     expect(s2.store.get('resized')).toBeFalsy();
     expect(rowColumnResizeInstance.resizeStartPosition).toStrictEqual({
       offsetX: 10,
+      clientX: 10,
     });
     expect(getStartGuideLine().attr('path')).toStrictEqual([
       ['M', 2, 2],
@@ -312,12 +315,15 @@ describe('Interaction Row Column Resize Tests', () => {
       {
         offsetX: 10,
         offsetY: 20,
+        clientX: 10,
+        clientY: 20,
       },
       resizeInfo,
     );
 
-    expect(rowColumnResizeInstance.resizeStartPosition).toStrictEqual({
+    expect(rowColumnResizeInstance.resizeStartPosition).toEqual({
       offsetY: 20,
+      clientY: 20,
     });
     expect(getStartGuideLine().attr('path')).toStrictEqual([
       ['M', 2, 2],
@@ -605,6 +611,8 @@ describe('Interaction Row Column Resize Tests', () => {
       {
         offsetX: 10,
         offsetY: 20,
+        clientX: 10,
+        clientY: 20,
       },
       resizeInfo,
     );
@@ -614,6 +622,8 @@ describe('Interaction Row Column Resize Tests', () => {
       {
         offsetX: 20,
         offsetY: 20,
+        clientX: 20,
+        clientY: 20,
       },
       resizeInfo,
     );

--- a/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/row-column-resize-spec.ts
@@ -321,7 +321,7 @@ describe('Interaction Row Column Resize Tests', () => {
       resizeInfo,
     );
 
-    expect(rowColumnResizeInstance.resizeStartPosition).toEqual({
+    expect(rowColumnResizeInstance.resizeStartPosition).toStrictEqual({
       offsetY: 20,
       clientY: 20,
     });

--- a/packages/s2-core/src/common/interface/resize.ts
+++ b/packages/s2-core/src/common/interface/resize.ts
@@ -34,6 +34,8 @@ export interface ResizeGuideLinePosition {
 export interface ResizePosition {
   offsetX?: number;
   offsetY?: number;
+  clientX?: number;
+  clientY?: number;
 }
 
 export interface ResizeDetail {

--- a/packages/s2-core/src/interaction/row-column-resize.ts
+++ b/packages/s2-core/src/interaction/row-column-resize.ts
@@ -10,12 +10,12 @@ import {
   InterceptType,
   MIN_CELL_HEIGHT,
   MIN_CELL_WIDTH,
-  ResizeAreaEffect,
-  ResizeDirectionType,
-  ResizeType,
   RESIZE_END_GUIDE_LINE_ID,
   RESIZE_MASK_ID,
   RESIZE_START_GUIDE_LINE_ID,
+  ResizeAreaEffect,
+  ResizeDirectionType,
+  ResizeType,
   S2Event,
 } from '../common/constant';
 import type {
@@ -137,6 +137,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
         ['L', offsetX + width, guideLineMaxHeight],
       ]);
       this.resizeStartPosition.offsetX = event.offsetX;
+      this.resizeStartPosition.clientX = event.clientX;
       return;
     }
 
@@ -149,6 +150,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
       ['L', guideLineMaxWidth, offsetY + height],
     ]);
     this.resizeStartPosition.offsetY = event.offsetY;
+    this.resizeStartPosition.clientY = event.clientY;
   }
 
   private bindMouseDown() {
@@ -425,7 +427,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     guideLineStart: ResizeGuideLinePath,
     guideLineEnd: ResizeGuideLinePath,
   ) {
-    let offsetX = originalEvent.offsetX - this.resizeStartPosition.offsetX;
+    let offsetX = originalEvent.clientX - this.resizeStartPosition.clientX;
     if (resizeInfo.width + offsetX < MIN_CELL_WIDTH) {
       // 禁止拖到最小宽度
       offsetX = -(resizeInfo.width - MIN_CELL_WIDTH);
@@ -447,7 +449,7 @@ export class RowColumnResize extends BaseEvent implements BaseEventImplement {
     guideLineStart: ResizeGuideLinePath,
     guideLineEnd: ResizeGuideLinePath,
   ) {
-    let offsetY = originalEvent.offsetY - this.resizeStartPosition.offsetY;
+    let offsetY = originalEvent.clientY - this.resizeStartPosition.clientY;
 
     if (resizeInfo.height + offsetY < MIN_CELL_HEIGHT) {
       offsetY = -(resizeInfo.height - MIN_CELL_HEIGHT);


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #2269 

### 📝 Description

当 Sheet 周围存在其它元素时，因为原本的计算方式使用 `offsetX` 来计算，当鼠标移到其它元素上时，`offsetX` 又重新从 0 开始累增，其实这的意思是 Sheet 的 `offsetX` 和鼠标 Target 的 `offsetX` 已经不是同一个元素了，需要更改为适应性更强的 `clientX` 来计算

保留原本的属性和类型，防止造成 break change

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |
|![Screen Recording 2023-06-28 at 23 26 56](https://github.com/antvis/S2/assets/56076317/7d7e20d8-7eaa-47fe-9a2f-68fdc8e21006)|![Screen Recording 2023-06-28 at 23 25 09](https://github.com/antvis/S2/assets/56076317/eb5010ea-6fd0-4038-9c17-b9f23074f96a)|

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
