### PR TITLE
fix: 点击列头后hover拦截消失

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -147,6 +147,7 @@ describe('Interaction Row & Column Cell Click Tests', () => {
       });
       expect(s2.showTooltipWithInfo).toHaveBeenCalled();
       expect(selected).toHaveBeenCalled();
+      expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTrue();
 
       isSelectedCellSpy.mockRestore();
     },
@@ -177,6 +178,7 @@ describe('Interaction Row & Column Cell Click Tests', () => {
       expect(s2.interaction.getState().cells).toEqual([]);
       expect(s2.showTooltipWithInfo).toHaveBeenCalled();
       expect(selected).toHaveBeenCalled();
+      expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeFalse();
 
       getInteractedCellsSpy.mockRestore();
     },

--- a/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/range-selection-spec.ts
@@ -10,10 +10,12 @@ import {
   S2Event,
 } from '@/common/constant';
 import { RangeSelection } from '@/interaction/range-selection';
+import { getCellMeta } from '@/utils';
 
 jest.mock('@/utils/tooltip');
 jest.mock('@/interaction/event-controller');
 jest.mock('@/interaction/base-interaction/click/data-cell-click');
+jest.mock('@/interaction/base-interaction/click/row-column-click');
 
 describe('Interaction Range Selection Tests', () => {
   let rangeSelection: RangeSelection;
@@ -86,6 +88,27 @@ describe('Interaction Range Selection Tests', () => {
     } as unknown as GEvent);
 
     expect(s2.store.get('lastClickedCell')).toEqual(mockCell00.mockCell);
+  });
+
+  test('should remove hover intercepts when col cell unselected', () => {
+    const mockCell00 = createMockCellInfo('3-3', { rowIndex: 3, colIndex: 3 });
+    s2.getCell = () => mockCell00.mockCell as any;
+
+    s2.interaction.addIntercepts([InterceptType.HOVER]);
+
+    // 有选中时，不应清理 hover 拦截
+    s2.interaction.getCells = () => [getCellMeta(mockCell00.mockCell)];
+    s2.emit(S2Event.COL_CELL_CLICK, {
+      stopPropagation() {},
+    } as unknown as GEvent);
+    expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeTrue();
+
+    // 无选中时，应清理拦截
+    s2.interaction.getCells = () => [];
+    s2.emit(S2Event.COL_CELL_CLICK, {
+      stopPropagation() {},
+    } as unknown as GEvent);
+    expect(s2.interaction.hasIntercepts([InterceptType.HOVER])).toBeFalse();
   });
 
   // should use data cell click interaction for single cell select

--- a/packages/s2-core/src/interaction/range-selection.ts
+++ b/packages/s2-core/src/interaction/range-selection.ts
@@ -1,5 +1,5 @@
 import type { Event } from '@antv/g-canvas';
-import { inRange, isNil, range } from 'lodash';
+import { inRange, isEmpty, isNil, range } from 'lodash';
 import { DataCell } from '../cell';
 import {
   CellTypes,
@@ -187,7 +187,9 @@ export class RangeSelection extends BaseEvent implements BaseEventImplement {
           stateName: InteractionStateName.SELECTED,
         });
       } else {
-        interaction.removeIntercepts([InterceptType.HOVER]);
+        if (isEmpty(interaction.getCells())) {
+          interaction.removeIntercepts([InterceptType.HOVER]);
+        }
         this.spreadsheet.store.set('lastClickedCell', cell);
       }
 


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close

### 📝 Description

为了处理列头反选后，hover 不生效的问题，#2263 里 range-selection 暴力去除了 hover 拦截。
导致列头在选中状态下，hover 拦截始终失效（range-selection 和 row-column-click 两个交互的冲突了）
如点击列头后，用户将鼠标移动到 data-cell 区，列头的 tooltip 会被销毁。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
|    ![CleanShot 2023-07-18 at 18 11 17](https://github.com/antvis/S2/assets/6716092/80954735-dd39-48bd-a2a3-177a6a7577c3)    |   ![CleanShot 2023-07-18 at 18 10 32](https://github.com/antvis/S2/assets/6716092/49ce0e2c-7831-4417-b2a1-66a40e012a1b)     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
