### PR TITLE
fix(table): 修复明细表获取到错误的实际渲染内容高度

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/table-sheet-spec.ts
@@ -214,4 +214,8 @@ describe('TableSheet Tests', () => {
 
     expect(onDestroy).toHaveBeenCalledTimes(1);
   });
+
+  test('should get content height', () => {
+    expect(s2.getContentHeight()).toEqual(120);
+  });
 });

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -126,6 +126,8 @@ export abstract class BaseFacet {
 
   protected abstract doLayout(): LayoutResult;
 
+  public abstract getContentHeight(): number;
+
   public abstract getViewCellHeights(
     layoutResult: LayoutResult,
   ): ViewCellHeights;
@@ -253,11 +255,6 @@ export abstract class BaseFacet {
       width: this.cfg.width,
       height: this.cfg.height,
     };
-  }
-
-  public getContentHeight(): number {
-    const { rowsHierarchy, colsHierarchy } = this.layoutResult;
-    return rowsHierarchy.height + colsHierarchy.height;
   }
 
   public updateScrollOffset(offsetConfig: OffsetConfig) {

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -42,6 +42,11 @@ export class PivotFacet extends BaseFacet {
     return this.spreadsheet.theme.rowCell.cell;
   }
 
+  public getContentHeight(): number {
+    const { rowsHierarchy, colsHierarchy } = this.layoutResult;
+    return rowsHierarchy.height + colsHierarchy.height;
+  }
+
   protected doLayout(): LayoutResult {
     // 1、layout all nodes in rowHeader and colHeader
     const { leafNodes: rowLeafNodes, hierarchy: rowsHierarchy } =

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -102,6 +102,13 @@ export class TableFacet extends BaseFacet {
     s2.on(S2Event.RANGE_FILTER, this.onFilterHandler);
   }
 
+  public getContentHeight(): number {
+    const { getTotalHeight } = this.getViewCellHeights();
+    const { colsHierarchy } = this.layoutResult;
+
+    return getTotalHeight() + colsHierarchy.height;
+  }
+
   private onSortHandler = (sortParams) => {
     const s2 = this.spreadsheet;
     let params = sortParams;

--- a/packages/s2-core/src/sheet-type/pivot-sheet.ts
+++ b/packages/s2-core/src/sheet-type/pivot-sheet.ts
@@ -35,6 +35,10 @@ export class PivotSheet extends SpreadSheet {
     return realDataSet;
   }
 
+  public getContentHeight() {
+    return this.facet.getContentHeight();
+  }
+
   /**
    * Check if is pivot mode
    */


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #2289 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

上层业务有使用 `getContentHeight()` 明细表没有适配这个 api, 导致获取到错误的高度了

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/293adf0e-6bf6-445e-979e-9de18d083bc7) | ![image](https://github.com/antvis/S2/assets/21015895/088a8d55-38e9-4914-9aa2-566d7d478645) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

close #2289 

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
