### PR TITLE
fix(table-facet): 修复过滤多列时，删除一列过滤将同时清空后续过滤列

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2322-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2322-spec.ts
@@ -1,0 +1,45 @@
+/**
+ * @description spec for issue #2322
+ * https://github.com/antvis/S2/issues/2322
+ * 明细表: 多列筛选后清空其中一列筛选，导致其他筛选也清空
+ */
+import { getContainer } from 'tests/util/helpers';
+import dataCfg from '../data/data-issue-2322.json';
+import { TableSheet } from '@/sheet-type';
+import type { S2Options } from '@/common/interface';
+import { S2Event } from '@/common';
+
+const s2Options: S2Options = {
+  width: 300,
+  height: 480,
+  showSeriesNumber: true,
+  frozenColCount: 1,
+};
+
+describe('Table Sheet Filter Test', () => {
+  test('should filter correctly when part of the filter is cleaned', () => {
+    const s2 = new TableSheet(getContainer(), dataCfg, s2Options);
+    s2.render();
+
+    // 为两个不同的列设定过滤
+    s2.emit(S2Event.RANGE_FILTER, {
+      filterKey: 'province',
+      filteredValues: ['吉林'],
+    });
+    s2.emit(S2Event.RANGE_FILTER, {
+      filterKey: 'city',
+      filteredValues: ['杭州'],
+    });
+
+    // 删除一列过滤
+    s2.emit(S2Event.RANGE_FILTER, {
+      filterKey: 'province',
+      filteredValues: [],
+    });
+
+    // 应过滤掉 city = 杭州 的值，共4行
+    expect(s2.dataSet.getDisplayDataSet().length).toBe(
+      s2.dataSet.originData.length - 4,
+    );
+  });
+});

--- a/packages/s2-core/__tests__/data/data-issue-2322.json
+++ b/packages/s2-core/__tests__/data/data-issue-2322.json
@@ -1,0 +1,147 @@
+{
+  "fields": {
+    "columns": [
+      {
+        "key": "area",
+        "children": ["province", "city"]
+      },
+      "type",
+      {
+        "key": "money",
+        "children": [
+          {
+            "key": "price"
+          }
+        ]
+      }
+    ]
+  },
+  "meta": [
+    {
+      "field": "province",
+      "name": "省份"
+    },
+    {
+      "field": "city",
+      "name": "城市"
+    },
+    {
+      "field": "type",
+      "name": "商品类别"
+    },
+    {
+      "field": "price",
+      "name": "价格"
+    },
+    {
+      "field": "cost",
+      "name": "成本"
+    },
+    {
+      "field": "area",
+      "name": "位置"
+    },
+    {
+      "field": "money",
+      "name": "金额"
+    }
+  ],
+  "data": [
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "笔",
+      "price": 1
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "纸张",
+      "price": 2
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "笔",
+      "price": 17
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "纸张",
+      "price": 6
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "笔",
+      "price": 8
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "笔",
+      "price": 12
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "纸张",
+      "price": 3
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "纸张",
+      "price": 25
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "笔",
+      "price": 20
+    },
+    {
+      "province": "浙江",
+      "city": "杭州",
+      "type": "纸张",
+      "price": 10
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "笔",
+      "price": 15
+    },
+    {
+      "province": "浙江",
+      "city": "舟山",
+      "type": "纸张",
+      "price": 2
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "笔",
+      "price": 15
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "笔",
+      "price": 30
+    },
+    {
+      "province": "吉林",
+      "city": "长春",
+      "type": "纸张",
+      "price": 40
+    },
+    {
+      "province": "吉林",
+      "city": "白山",
+      "type": "纸张",
+      "price": 50
+    }
+  ]
+}

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -165,7 +165,7 @@ export class TableFacet extends BaseFacet {
     if (oldIndex !== -1) {
       if (unFilter) {
         // remove filter params on current key if passed an empty filterValues field
-        oldConfig.splice(oldIndex);
+        oldConfig.splice(oldIndex, 1);
       } else {
         // if filter with same key already exists, replace it
         oldConfig[oldIndex] = params;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #2322 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
原过滤逻辑在先后过滤A列和B列后，取消A列过滤时，会清空B列过滤，因为调用 `oldConfig.splice()` 方法时没有传入 deleteCount 参数，默认删除了从 `oldIndex` 开始的后续全部内容
<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |


### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
