### PR TITLE
fix: 列头绘制多列文本时错误的使用了数值单元格的样式 close #2359

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2359-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2359-spec.ts
@@ -1,0 +1,140 @@
+/**
+ * @description spec for issue #2359
+ * https://github.com/antvis/S2/issues/2359
+ * 明细表: 自定义列头误用 dataCell 样式
+ */
+import { pick } from 'lodash';
+import { createTableSheet } from 'tests/util/helpers';
+import { TableColCell, drawObjectText } from '../../src';
+import type { S2CellType, S2Options } from '@/common/interface';
+
+class TestColCell extends TableColCell {
+  drawTextShape() {
+    drawObjectText(this, {
+      values: [['A', 'B', 'C']],
+    });
+  }
+}
+
+const s2Options: S2Options = {
+  width: 300,
+  height: 480,
+  showSeriesNumber: true,
+  colCell: (...args) => new TestColCell(...args),
+};
+
+describe('Table Sheet Custom Multiple Values Tests', () => {
+  test('should use current cell text theme', () => {
+    const s2 = createTableSheet(s2Options);
+
+    s2.setTheme({
+      colCell: {
+        measureText: {
+          fontSize: 12,
+        },
+        bolderText: {
+          fontSize: 14,
+        },
+        text: {
+          fontSize: 20,
+          fill: 'red',
+        },
+      },
+      dataCell: {
+        text: {
+          fontSize: 30,
+          fill: 'green',
+        },
+      },
+    });
+    s2.render();
+
+    const mapTheme = (cell: S2CellType) => {
+      return cell
+        .getTextShapes()
+        .map((shape) => pick(shape.attr(), ['fill', 'fontSize']));
+    };
+
+    const colCellTexts = s2
+      .getColumnNodes()
+      .map((node) => mapTheme(node.belongsCell));
+
+    const dataCellTexts = s2.interaction
+      .getPanelGroupAllDataCells()
+      .map(mapTheme);
+
+    expect(colCellTexts).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "fill": "red",
+            "fontSize": 20,
+          },
+          Object {
+            "fill": "red",
+            "fontSize": 20,
+          },
+          Object {
+            "fill": "red",
+            "fontSize": 20,
+          },
+        ],
+        Array [
+          Object {
+            "fill": "red",
+            "fontSize": 20,
+          },
+          Object {
+            "fill": "red",
+            "fontSize": 20,
+          },
+          Object {
+            "fill": "red",
+            "fontSize": 20,
+          },
+        ],
+      ]
+    `);
+
+    expect(dataCellTexts).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "fill": "#000000",
+            "fontSize": 12,
+          },
+        ],
+        Array [
+          Object {
+            "fill": "#000000",
+            "fontSize": 12,
+          },
+        ],
+        Array [
+          Object {
+            "fill": "#000000",
+            "fontSize": 12,
+          },
+        ],
+        Array [
+          Object {
+            "fill": "green",
+            "fontSize": 30,
+          },
+        ],
+        Array [
+          Object {
+            "fill": "green",
+            "fontSize": 30,
+          },
+        ],
+        Array [
+          Object {
+            "fill": "green",
+            "fontSize": 30,
+          },
+        ],
+      ]
+    `);
+  });
+});

--- a/packages/s2-core/src/utils/text.ts
+++ b/packages/s2-core/src/utils/text.ts
@@ -357,9 +357,7 @@ const calX = (
 const getDrawStyle = (cell: S2CellType) => {
   const { isTotals } = cell.getMeta();
   const isMeasureField = (cell as ColCell).isMeasureField?.();
-  const cellStyle = cell.getStyle(
-    isMeasureField ? CellTypes.COL_CELL : CellTypes.DATA_CELL,
-  );
+  const cellStyle = cell.getStyle(cell.cellType || CellTypes.DATA_CELL);
 
   let textStyle: TextTheme;
   if (isMeasureField) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

使用 `drawObjectText` 绘制多列文本时, 根据当前单元格类型的样式绘制, 而不是写死 `dataCell`

```ts
  s2.setTheme({
    colCell: {
      measureText: {
        fontSize: 12,
      },
      bolderText: {
        fontSize: 14,
      },
      text: {
        fontSize: 20,
        fill: 'red',
      },
    },
    dataCell: {
      text: {
        fontSize: 30,
        fill: 'green',
      },
    },
  });
```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

> 如图, colCell 使用了 dataCell 的 theme

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/87bebefa-6d87-49f6-a05c-101c24cdbe6c) | ![image](https://github.com/antvis/S2/assets/21015895/76696ac6-6c65-443e-ba59-a89da60171b0) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

close #2359

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
