### PR TITLE
【WIP】fix: 修复【指标不在最后一级customValueOrder】+ 【分组汇总】+【按汇总值排序】同时使用时，获取排序数据时为空

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
+++ b/packages/s2-core/__tests__/unit/utils/sort-action-spec.tsx
@@ -715,3 +715,80 @@ describe('GetSortByMeasureValues Total Fallback Tests', () => {
     ]);
   });
 });
+describe('GetSortByMeasureValues Total With Group Fallback Tests', () => {
+  let sheet: PivotSheet;
+  let dataSet: PivotDataSet;
+  const s2Options = {
+    totals: {
+      col: {
+        totalsGroupDimensions: ['city'],
+        showGrandTotals: true,
+      },
+    },
+  } as S2Options;
+
+  const dataConfig = {
+    ...sortData,
+    data: [
+      ...sortData.data,
+      {
+        city: '杭州',
+        type: '纸张',
+        price: '999',
+      },
+      {
+        city: '杭州',
+        type: '笔',
+        price: '666',
+      },
+    ],
+    fields: {
+      rows: ['type'],
+      columns: ['province', 'city'],
+      values: ['price'],
+    },
+  };
+
+  beforeEach(() => {
+    sheet = new PivotSheet(getContainer(), dataConfig, s2Options);
+    dataSet = new PivotDataSet(sheet);
+    dataSet.setDataCfg(dataConfig);
+    sheet.dataSet = dataSet;
+  });
+
+  test('should sort by col total whit group', () => {
+    sheet.render();
+    // 根据列（类别）的总和排序
+    const sortParam: SortParam = {
+      sortFieldId: 'type',
+      sortByMeasure: TOTAL_VALUE,
+      sortMethod: 'desc',
+      query: {
+        [EXTRA_FIELD]: 'price',
+        city: '杭州',
+      },
+    };
+
+    const params: SortActionParams = {
+      dataSet,
+      sortParam,
+    };
+    const measureValues = getSortByMeasureValues(params);
+    expect(measureValues).toEqual([
+      {
+        $$extra$$: 'price',
+        $$value$$: '666',
+        city: '杭州',
+        price: '666',
+        type: '笔',
+      },
+      {
+        $$extra$$: 'price',
+        $$value$$: '999',
+        city: '杭州',
+        price: '999',
+        type: '纸张',
+      },
+    ]);
+  });
+});

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -577,8 +577,8 @@ export class PivotDataSet extends BaseDataSet {
   getTotalGroupQueries(dimensions: string[], originQuery: DataType) {
     let queries = [originQuery];
     let existDimensionGroupKey = null;
-    for (let i = dimensions.length; i > 0; i--) {
-      const key = dimensions[i - 1];
+    for (let i = dimensions.length - 1; i >= 0; i--) {
+      const key = dimensions[i];
       if (keys(originQuery).includes(key)) {
         if (key !== EXTRA_FIELD) {
           existDimensionGroupKey = key;
@@ -587,8 +587,6 @@ export class PivotDataSet extends BaseDataSet {
         const allCurrentFieldDimensionValues =
           this.sortedDimensionValues[existDimensionGroupKey];
         let res = [];
-        const arrayLength =
-          allCurrentFieldDimensionValues[0].split(ID_SEPARATOR).length;
         for (const query of queries) {
           const resKeys = [];
           for (const dimValue of allCurrentFieldDimensionValues) {
@@ -601,14 +599,12 @@ export class PivotDataSet extends BaseDataSet {
               })
             ) {
               const arrTypeValue = dimValue.split(ID_SEPARATOR);
-              const currentKey = arrTypeValue[arrayLength - 2];
-              if (currentKey !== 'undefined') {
-                resKeys.push(currentKey);
-              }
+              const currentKey = arrTypeValue[i];
+              resKeys.push(currentKey);
             }
           }
           const queryList = uniq(resKeys).map((v) => {
-            return { ...query, [key]: v };
+            return { ...query, [key]: v === 'undefined' ? undefined : v };
           });
           res = concat(res, queryList);
         }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
修复修复指标不在最后一级配置与分组汇总同时使用时，获取排序数据元为空。
原因：undefined 值作为汇总标记，不可过滤，需要判断当 key 为 undefined 字符串时手动赋值 undefined
### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
|  ![image](https://github.com/antvis/S2/assets/56724970/aed692ca-eedf-43f6-854d-0c8f14a28700) | ![image](https://github.com/antvis/S2/assets/56724970/54f27f94-4116-49f9-b4b0-fe0aed55ceb0) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
