### PR TITLE
fix(interaction): 修复拖动水平滚动条后单元格选中状态被重置 close #2376

### DIFF
--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -207,21 +207,32 @@ export class EventController {
       // 比如实际 400 * 300 => hd (800 * 600)
       // 从视觉来看, 虽然点击了空白处, 但其实还是处于 放大后的 canvas 区域, 所以还需要额外判断一下坐标
       const { width, height } = this.getContainerRect();
+
       return (
         canvas.contains(event.target as HTMLElement) &&
         event.clientX <= x + width &&
         event.clientY <= y + height
       );
     }
+
     return false;
   }
 
   private getContainerRect() {
-    const { maxX, maxY } = this.spreadsheet.facet?.panelBBox || {};
-    const { width, height } = this.spreadsheet.options;
+    const { facet, options } = this.spreadsheet;
+    const scrollBar = facet.hRowScrollBar || facet.hScrollBar;
+    const { maxX, maxY } = facet?.panelBBox || {};
+    const { width, height } = options;
+
+    /**
+     * https://github.com/antvis/S2/issues/2376
+     * 横向的滚动条在表格外 (Canvas 内), 点击滚动条(含滑道区域) 不应该重置交互
+     */
+    const trackHeight = scrollBar?.theme?.size || 0;
+
     return {
       width: Math.min(width, maxX),
-      height: Math.min(height, maxY),
+      height: Math.min(height, maxY + trackHeight),
     };
   }
 

--- a/packages/s2-react/playground/config.ts
+++ b/packages/s2-react/playground/config.ts
@@ -110,6 +110,7 @@ export const s2Options: SheetComponentOptions = {
     },
     cellCfg: {
       height: 50,
+      width: 200,
     },
   },
 };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2376 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

拖动横向滚动条, 会触发 Canvas 的 click, 从而触发 "点击空白处重置交互", 导致选中状态被重置

https://github.com/antvis/S2/blob/24437622e1b259288bf7f8f3505837088a6e1b9d/packages/s2-core/src/interaction/event-controller.ts#L182-L190

水平/垂直滚动条都绘制在 Canvas 内, 垂直滚动条没问题是因为滚动条在表格内, 而水平滚动条在表格外

![image](https://github.com/antvis/S2/assets/21015895/268a6381-280e-45a2-a500-e2786bed64c1)


### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![Kapture 2023-10-23 at 14 15 17](https://github.com/antvis/S2/assets/21015895/02f34126-89e6-4f68-83f7-78e5a9b0c25e) | ![Kapture 2023-10-23 at 14 13 44](https://github.com/antvis/S2/assets/21015895/b2f59f08-d3bb-4fe3-8311-37d7109a1446) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
