### PR TITLE
fix: 修复趋势分析表自定义列头 tooltip 后错误的使用行头的 tooltip

### DIFF
--- a/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/strategy-sheet/index.tsx
@@ -1,14 +1,13 @@
-import type { S2CellType } from '@antv/s2';
+import type { S2CellType, S2DataConfig } from '@antv/s2';
 import {
-  type ColHeaderConfig,
-  customMerge,
   Node,
-  type S2DataConfig,
-  type S2Options,
   SpreadSheet,
-  type ViewMeta,
+  customMerge,
+  type ColHeaderConfig,
   type MultiData,
+  type S2Options,
   type TooltipShowOptions,
+  type ViewMeta,
 } from '@antv/s2';
 import { isArray, isEmpty, isFunction, isNil, size } from 'lodash';
 import React from 'react';
@@ -114,7 +113,7 @@ export const StrategySheet: React.FC<SheetComponentsProps> = React.memo(
           },
           col: {
             content: (cell, tooltipOptions) =>
-              getContent('row')(cell, tooltipOptions) ?? (
+              getContent('col')(cell, tooltipOptions) ?? (
                 <StrategySheetColTooltip cell={cell} />
               ),
           },


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->


🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

如果 rowCell 自定义了 tooltip, 点击 colCell 时会错误的使用 rowCell 的 tooltip, 默认值一直写错了, 最近业务侧恰好触发这个场景了

![image](https://github.com/antvis/S2/assets/21015895/6900a6d7-b924-4f92-a8f8-8dc12656b1f9)


### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
