### PR TITLE
fix(interaction): 修复行列头圈选后滑出可视范围后, 错误的选择了数值单元格 close #2340

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2340-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2340-spec.ts
@@ -1,0 +1,78 @@
+/**
+ * @description spec for issue #2340
+ * https://github.com/antvis/S2/issues/2340
+ */
+import { map } from 'lodash';
+import {
+  CellTypes,
+  InteractionStateName,
+  getCellMeta,
+  type S2Options,
+  HeaderCell,
+} from '../../src';
+import { createPivotSheet, sleep } from '../util/helpers';
+
+const s2Options: S2Options = {
+  width: 800,
+  height: 600,
+  style: {
+    cellCfg: {
+      width: 200,
+      height: 200,
+    },
+  },
+};
+
+describe('Header Brush Selection Tests', () => {
+  test.each([CellTypes.COL_CELL, CellTypes.ROW_CELL])(
+    'should not trigger data cell selected when header selected and scroll out of viewport',
+    async (cellType) => {
+      const s2 = createPivotSheet(s2Options, { useSimpleData: false });
+      s2.render();
+
+      const isRow = cellType === CellTypes.ROW_CELL;
+      const targetCells = isRow
+        ? s2.interaction.getAllRowHeaderCells()
+        : s2.interaction.getAllColHeaderCells();
+
+      const cells = [
+        (targetCells as HeaderCell[]).find((cell) => {
+          const meta = cell.getMeta();
+          return meta.isLeaf;
+        }),
+      ];
+
+      s2.interaction.changeState({
+        cells: map(cells, getCellMeta),
+        stateName: InteractionStateName.BRUSH_SELECTED,
+      });
+
+      await sleep(500);
+
+      const offsetKey = isRow ? 'offsetY' : 'offsetX';
+      // 将圈选的单元格滑出可视范围
+      s2.facet.updateScrollOffset({
+        [offsetKey]: { value: 300 },
+      });
+
+      await sleep(500);
+
+      // 还原
+      s2.facet.updateScrollOffset({
+        [offsetKey]: { value: 0 },
+      });
+
+      expect(s2.interaction.getActiveCells()).toHaveLength(1);
+      expect(s2.interaction.getCurrentStateName()).toEqual(
+        InteractionStateName.BRUSH_SELECTED,
+      );
+
+      // 交互过的不应该有 dataCell (未触发过列头多选)
+      s2.interaction.getInteractedCells().forEach((cell) => {
+        expect(cell.cellType).toEqual(
+          isRow ? CellTypes.ROW_CELL : CellTypes.COL_CELL,
+        );
+      });
+    },
+  );
+});

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -393,7 +393,7 @@ export class DataCell extends BaseCell<ViewMeta> {
     );
   }
 
-  // dataCell根据state 改变当前样式，
+  // dataCell 根据 state 改变当前样式，
   protected changeRowColSelectState(indexType: ViewMetaIndexType) {
     const { interaction } = this.spreadsheet;
     const currentIndex = get(this.meta, indexType);

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -415,6 +415,7 @@ export abstract class HeaderCell extends BaseCell<Node> {
 
     switch (stateInfo?.stateName) {
       case InteractionStateName.SELECTED:
+      case InteractionStateName.BRUSH_SELECTED:
         this.handleSelect(cells, stateInfo?.nodes);
         break;
       case InteractionStateName.HOVER_FOCUS:

--- a/packages/s2-core/src/common/constant/interaction.ts
+++ b/packages/s2-core/src/common/constant/interaction.ts
@@ -18,6 +18,7 @@ export enum InteractionName {
 export enum InteractionStateName {
   ALL_SELECTED = 'allSelected',
   SELECTED = 'selected',
+  BRUSH_SELECTED = 'brushSelected',
   UNSELECTED = 'unselected',
   HOVER = 'hover',
   HOVER_FOCUS = 'hoverFocus',

--- a/packages/s2-core/src/facet/header/col.ts
+++ b/packages/s2-core/src/facet/header/col.ts
@@ -77,14 +77,14 @@ export class ColHeader extends BaseHeader<ColHeaderConfig> {
     return this.scrollGroup;
   }
 
-  protected isColCellInRect(item: Node): boolean {
+  protected isColCellInRect(node: Node): boolean {
     const { spreadsheet, cornerWidth, width, scrollX } = this.headerConfig;
 
     return (
       // don't care about scrollY, because there is only freeze col-header exist
-      width + scrollX > item.x &&
+      width + scrollX > node.x &&
       scrollX - (spreadsheet.isFrozenRowHeader() ? 0 : cornerWidth) <
-        item.x + item.width
+        node.x + node.width
     );
   }
 

--- a/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
@@ -96,16 +96,14 @@ export class ColBrushSelection extends BaseBrushSelection {
     );
   }
 
-  // 最终刷选的cell
+  // 最终刷选的 cell
   protected updateSelectedCells() {
     const { interaction } = this.spreadsheet;
 
     interaction.changeState({
       cells: map(this.brushRangeCells, getCellMeta),
       stateName: InteractionStateName.SELECTED,
-      onUpdateCells: (root) => {
-        root.updateCells(root.getAllColHeaderCells());
-      },
+      onUpdateCells: this.onUpdateCells,
     });
 
     this.spreadsheet.emit(

--- a/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
@@ -102,7 +102,7 @@ export class ColBrushSelection extends BaseBrushSelection {
 
     interaction.changeState({
       cells: map(this.brushRangeCells, getCellMeta),
-      stateName: InteractionStateName.SELECTED,
+      stateName: InteractionStateName.BRUSH_SELECTED,
       onUpdateCells: this.onUpdateCells,
     });
 

--- a/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
@@ -94,13 +94,14 @@ export class DataCellBrushSelection extends BaseBrushSelection {
     return metas;
   };
 
-  // 最终刷选的cell
+  // 最终刷选的 cell
   protected updateSelectedCells() {
     const brushRange = this.getBrushRange();
     const selectedCellMetas = this.getSelectedCellMetas(brushRange);
 
     this.spreadsheet.interaction.changeState({
       cells: selectedCellMetas,
+      // TODO: 怕上层有直接消费 stateName, 暂时保留, 2.0 版本改成 InteractionStateName.BRUSH_SELECTED
       stateName: InteractionStateName.SELECTED,
       onUpdateCells: afterSelectDataCells,
     });

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -96,7 +96,7 @@ export class RowBrushSelection extends BaseBrushSelection {
 
     this.spreadsheet.interaction.changeState({
       cells: selectedCellMetas,
-      stateName: InteractionStateName.SELECTED,
+      stateName: InteractionStateName.BRUSH_SELECTED,
       onUpdateCells: this.onUpdateCells,
     });
 

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -144,7 +144,10 @@ export class RootInteraction {
   }
 
   public isSelectedState() {
-    return this.isStateOf(InteractionStateName.SELECTED);
+    return (
+      this.isStateOf(InteractionStateName.SELECTED) ||
+      this.isStateOf(InteractionStateName.BRUSH_SELECTED)
+    );
   }
 
   public isAllSelectedState() {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2340 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

问题: 行列头圈选后, 当前交互状态是 `selected`, 如果滑出可视范围 (单元格被销毁) 再滑动回来 (重新实例化), 会触发列头的多选, 导致数值也被选中

解法: 增加一个 `brushSelected` 状态, 以区分 `selected`

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![Kapture 2023-11-13 at 17 29 58](https://github.com/antvis/S2/assets/21015895/480be45a-06bf-43c3-8f6c-7116a534c196) | ![Kapture 2023-11-13 at 17 31 25](https://github.com/antvis/S2/assets/21015895/c5ffa876-c262-4174-bac4-c8de81959378) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
