### PR TITLE
fix: 修复隐藏列总计时行总计也被隐藏问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -554,6 +554,39 @@ describe('SpreadSheet Hidden Columns Tests', () => {
         expect(leafNodes.some((node) => node.id === nodeId)).toBeFalsy();
         expect(leafNodes).toHaveLength(5);
       });
+
+      test('hiding the column totals should not hide the row totals', () => {
+        sheet.render();
+        const nodeId = 'root[&]总计';
+        const preRowNodes = sheet.facet.layoutResult.rowNodes;
+        const preColumnNodes = sheet.facet.layoutResult.colNodes;
+        sheet.interaction.hideColumns([nodeId]);
+
+        expect(sheet.facet.layoutResult.rowNodes[0].id).toBe(nodeId);
+        expect(sheet.facet.layoutResult.rowNodes.length).toBe(
+          preRowNodes.length,
+        );
+        expect(sheet.facet.layoutResult.colNodes.length).toBe(
+          preColumnNodes.length - 1,
+        );
+      });
+
+      test('hiding the column totals should not hide the row totals tree', () => {
+        sheet.setOptions({ hierarchyType: 'tree' });
+        sheet.render();
+        const nodeId = 'root[&]总计';
+        const preRowNodes = sheet.facet.layoutResult.rowNodes;
+        const preColumnNodes = sheet.facet.layoutResult.colNodes;
+        sheet.interaction.hideColumns([nodeId]);
+
+        expect(sheet.facet.layoutResult.rowNodes[0].id).toBe(nodeId);
+        expect(sheet.facet.layoutResult.rowNodes.length).toBe(
+          preRowNodes.length,
+        );
+        expect(sheet.facet.layoutResult.colNodes.length).toBe(
+          preColumnNodes.length - 1,
+        );
+      });
     });
   });
 });

--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -555,38 +555,25 @@ describe('SpreadSheet Hidden Columns Tests', () => {
         expect(leafNodes).toHaveLength(5);
       });
 
-      test('hiding the column totals should not hide the row totals', () => {
-        sheet.render();
-        const nodeId = 'root[&]总计';
-        const preRowNodes = sheet.facet.layoutResult.rowNodes;
-        const preColumnNodes = sheet.facet.layoutResult.colNodes;
-        sheet.interaction.hideColumns([nodeId]);
+      test.each(['grid', 'tree'])(
+        'hiding the column totals should not hide the row totals for %s mode',
+        (hierarchyType: 'grid' | 'tree') => {
+          sheet.setOptions({ hierarchyType });
+          sheet.render();
+          const nodeId = 'root[&]总计';
+          const preRowNodes = sheet.facet.layoutResult.rowNodes;
+          const preColumnNodes = sheet.facet.layoutResult.colNodes;
+          sheet.interaction.hideColumns([nodeId]);
 
-        expect(sheet.facet.layoutResult.rowNodes[0].id).toBe(nodeId);
-        expect(sheet.facet.layoutResult.rowNodes.length).toBe(
-          preRowNodes.length,
-        );
-        expect(sheet.facet.layoutResult.colNodes.length).toBe(
-          preColumnNodes.length - 1,
-        );
-      });
-
-      test('hiding the column totals should not hide the row totals tree', () => {
-        sheet.setOptions({ hierarchyType: 'tree' });
-        sheet.render();
-        const nodeId = 'root[&]总计';
-        const preRowNodes = sheet.facet.layoutResult.rowNodes;
-        const preColumnNodes = sheet.facet.layoutResult.colNodes;
-        sheet.interaction.hideColumns([nodeId]);
-
-        expect(sheet.facet.layoutResult.rowNodes[0].id).toBe(nodeId);
-        expect(sheet.facet.layoutResult.rowNodes.length).toBe(
-          preRowNodes.length,
-        );
-        expect(sheet.facet.layoutResult.colNodes.length).toBe(
-          preColumnNodes.length - 1,
-        );
-      });
+          expect(sheet.facet.layoutResult.rowNodes[0].id).toBe(nodeId);
+          expect(sheet.facet.layoutResult.rowNodes.length).toBe(
+            preRowNodes.length,
+          );
+          expect(sheet.facet.layoutResult.colNodes.length).toBe(
+            preColumnNodes.length - 1,
+          );
+        },
+      );
     });
   });
 });

--- a/packages/s2-core/src/facet/layout/layout-hooks.ts
+++ b/packages/s2-core/src/facet/layout/layout-hooks.ts
@@ -45,6 +45,7 @@ export const layoutHierarchy = (
 
   if (
     hiddenColumnNode &&
+    // fix: Only hiding the column headers is supported to prevent the row subtotals from being hidden when the IDs of the row totals and column totals are the same.
     facetCfg.columns.find((field) => field === currentNode.field)
   ) {
     return false;

--- a/packages/s2-core/src/facet/layout/layout-hooks.ts
+++ b/packages/s2-core/src/facet/layout/layout-hooks.ts
@@ -43,7 +43,10 @@ export const layoutHierarchy = (
   const hiddenColumnNode =
     facetCfg.spreadsheet?.facet?.getHiddenColumnsInfo(currentNode);
 
-  if (hiddenColumnNode) {
+  if (
+    hiddenColumnNode &&
+    facetCfg.columns.find((field) => field === currentNode.field)
+  ) {
     return false;
   }
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] 修复隐藏列总计时行总计也被隐藏问题

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
- 解决：目前仅支持隐藏列头部分，行总计和列总计ID 一致时也会被隐藏问题
- 其他说明：行头、列头实际场景不会出现同样的维度

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![iShot_2023-11-16_14 40 39](https://github.com/antvis/S2/assets/8447716/866d3db3-017c-45d3-9080-9ccd986a7501)       |  ![iShot_2023-11-16_14 39 27](https://github.com/antvis/S2/assets/8447716/f406c441-d55a-4fc6-89e2-c71e3ccb5327)    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
