### PR TITLE
fix: 修复 React 18 StrictMode 同时挂载两个表格的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,5 +167,8 @@
     "vue-jest": "^5.0.0-alpha.10"
   },
   "license": "MIT",
-  "repository": "git@github.com:antvis/S2.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/S2.git"
+  }
 }

--- a/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
+++ b/packages/s2-react/__tests__/spreadsheet/spread-sheet-spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { waitFor } from '@testing-library/react';
 import { SheetComponent, type SheetComponentsProps } from '../../src';
 import * as mockDataConfig from '../data/simple-data.json';
 import { getContainer, renderComponent } from '../util/helpers';
@@ -31,7 +32,7 @@ describe('Spread Sheet Tests', () => {
       container?.remove();
     });
 
-    test('should display scroll bar if s2Options.width more than browser window width', () => {
+    test('should display scroll bar if s2Options.width more than browser window width', async () => {
       renderComponent(
         <SheetComponent
           options={{
@@ -43,7 +44,9 @@ describe('Spread Sheet Tests', () => {
         container,
       );
 
-      expect(hasScrollBar(container)).toBeTruthy();
+      await waitFor(() => {
+        expect(hasScrollBar(container)).toBeTruthy();
+      });
     });
 
     test.skip('should hidden scroll bar if window width more than s2Options.width', () => {
@@ -52,6 +55,31 @@ describe('Spread Sheet Tests', () => {
       );
 
       expect(hasScrollBar(container)).toBeFalsy();
+    });
+
+    test('should only mount container once in strict mode for React 18', async () => {
+      // eslint-disable-next-line no-console
+      console.table(process.env);
+      const onMounted = jest.fn();
+
+      renderComponent(
+        <React.StrictMode>
+          <SheetComponent
+            options={s2Options}
+            dataCfg={mockDataConfig}
+            onMounted={onMounted}
+          />
+          ,
+        </React.StrictMode>,
+        container,
+      );
+
+      await waitFor(() => {
+        expect(
+          Array.from(document.querySelectorAll('.antv-s2-container canvas')),
+        ).toHaveLength(1);
+        expect(onMounted).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -48,11 +48,12 @@ import reactPkg from '../package.json';
 import type { SheetComponentOptions } from '../src';
 import { SheetComponent } from '../src';
 import { ConfigProvider } from '../src/components/config-provider';
-import { PlaygroundContext } from './context/playground.context';
 import { CustomGrid } from './components/CustomGrid';
 import { CustomTree } from './components/CustomTree';
 import { EditableSheet } from './components/EditableSheet';
 import { GridAnalysisSheet } from './components/GridAnalysisSheet';
+import { MobileSheetComponent } from './components/Mobile';
+import { PluginsSheet } from './components/Plugins';
 import { ResizeConfig } from './components/ResizeConfig';
 import { StrategySheet } from './components/StrategySheet';
 import { Links } from './components/links';
@@ -67,15 +68,12 @@ import {
   tableSheetMultipleColumns,
   tableSheetSingleColumns,
 } from './config';
+import { PlaygroundContext } from './context/playground.context';
 import { partDrillDown } from './drill-down';
-import { MobileSheetComponent } from './components/Mobile';
 import { onSheetMounted } from './utils';
-import { PluginsSheet } from './components/Plugins';
 import './index.less';
 
 type TableSheetColumnType = 'single' | 'multiple';
-
-import './index.less';
 
 const CustomTooltip = () => (
   <div>
@@ -247,6 +245,8 @@ function MainLayout() {
   }, [sheetType]);
 
   React.useEffect(() => {
+    console.log('env:', process.env);
+
     if (sheetType !== 'table') {
       return;
     }
@@ -373,938 +373,1001 @@ function MainLayout() {
                 label: '基础表',
                 children: (
                   <>
-                    <Collapse defaultActiveKey={['filter']}>
-                      <Collapse.Panel header="筛选器" key="filter">
-                        <Space>
-                          <Tooltip title="表格类型">
-                            <Radio.Group
-                              onChange={onSheetTypeChange}
-                              defaultValue={sheetType}
-                            >
-                              <Radio.Button value="pivot">透视表</Radio.Button>
-                              <Radio.Button value="table">明细表</Radio.Button>
-                            </Radio.Group>
-                          </Tooltip>
-                          {sheetType === 'table' && (
-                            <Tooltip title="明细表多级表头">
-                              <Radio.Group
-                                onChange={onTableColumnTypeChange}
-                                defaultValue={tableSheetColumnType}
-                              >
-                                <Radio.Button value="single">
-                                  单列头
-                                </Radio.Button>
-                                <Radio.Button value="multiple">
-                                  多列头
-                                </Radio.Button>
-                              </Radio.Group>
-                            </Tooltip>
-                          )}
-                          <Tooltip title="布局类型">
-                            <Radio.Group
-                              onChange={onLayoutWidthTypeChange}
-                              defaultValue="adaptive"
-                            >
-                              <Radio.Button value="adaptive">
-                                行列等宽
-                              </Radio.Button>
-                              <Radio.Button value="colAdaptive">
-                                列等宽
-                              </Radio.Button>
-                              <Radio.Button value="compact">紧凑</Radio.Button>
-                            </Radio.Group>
-                          </Tooltip>
-                          <Button
-                            danger
-                            onClick={() => {
-                              s2Ref.current?.destroy();
-                              s2Ref.current?.render();
-                            }}
-                          >
-                            卸载组件 (s2.destroy)
-                          </Button>
-                        </Space>
-                        <Space className="filter-container">
-                          <Switch
-                            checkedChildren="渲染组件"
-                            unCheckedChildren="卸载组件"
-                            defaultChecked={render}
-                            onChange={onToggleRender}
-                          />
-                          <Switch
-                            checkedChildren="调试模式开"
-                            unCheckedChildren="调试模式关"
-                            defaultChecked={mergedOptions.debug}
-                            onChange={(checked) => {
-                              updateOptions({ debug: checked });
-                            }}
-                          />
-                          <Switch
-                            checkedChildren="树形"
-                            unCheckedChildren="平铺"
-                            checked={mergedOptions.hierarchyType === 'tree'}
-                            onChange={(checked) => {
-                              updateOptions({
-                                hierarchyType: checked ? 'tree' : 'grid',
-                              });
-                            }}
-                            disabled={sheetType === 'table'}
-                          />
-                          <Switch
-                            checkedChildren="数值挂列头"
-                            unCheckedChildren="数值挂行头"
-                            defaultChecked={dataCfg.fields?.valueInCols}
-                            onChange={(checked) => {
-                              updateDataCfg({
-                                fields: {
-                                  valueInCols: checked,
-                                },
-                              });
-                            }}
-                            disabled={sheetType === 'table'}
-                          />
-                          <Switch
-                            checkedChildren="隐藏数值"
-                            unCheckedChildren="显示数值"
-                            defaultChecked={
-                              mergedOptions.style?.colCell?.hideValue
-                            }
-                            onChange={(checked) => {
-                              updateOptions({
-                                style: {
-                                  colCell: {
-                                    hideValue: checked,
-                                  },
-                                },
-                              });
-                            }}
-                            disabled={sheetType === 'table'}
-                          />
-                          <Switch
-                            checkedChildren="显示行小计/总计"
-                            unCheckedChildren="隐藏行小计/总计"
-                            defaultChecked={
-                              mergedOptions.totals?.row
-                                ?.showSubTotals as boolean
-                            }
-                            onChange={(checked) => {
-                              updateOptions({
-                                totals: {
-                                  row: {
-                                    showGrandTotals: checked,
-                                    showSubTotals: checked,
-                                    reverseGrandTotalsLayout: true,
-                                    reverseSubTotalsLayout: true,
-                                    subTotalsDimensions: ['province'],
-                                  },
-                                },
-                              });
-                            }}
-                            disabled={sheetType === 'table'}
-                          />
-                          <Switch
-                            checkedChildren="显示列小计/总计"
-                            unCheckedChildren="隐藏列小计/总计"
-                            defaultChecked={
-                              mergedOptions.totals?.col
-                                ?.showSubTotals as boolean
-                            }
-                            onChange={(checked) => {
-                              updateOptions({
-                                totals: {
-                                  col: {
-                                    showGrandTotals: checked,
-                                    showSubTotals: checked,
-                                    reverseGrandTotalsLayout: true,
-                                    reverseSubTotalsLayout: true,
-                                    subTotalsDimensions: ['type'],
-                                  },
-                                },
-                              });
-                            }}
-                            disabled={sheetType === 'table'}
-                          />
-                          <Tooltip title="透视表有效">
-                            <Switch
-                              checkedChildren="冻结行头开"
-                              unCheckedChildren="冻结行头关"
-                              defaultChecked={!!mergedOptions.frozen?.rowHeader}
-                              onChange={(checked) => {
-                                updateOptions({
-                                  frozen: {
-                                    rowHeader: checked,
-                                  },
-                                });
-                              }}
-                              disabled={sheetType === 'table'}
-                            />
-                          </Tooltip>
-                          <Tooltip title="明细表有效">
-                            <Switch
-                              checkedChildren="冻结列头开"
-                              unCheckedChildren="冻结列头关"
-                              defaultChecked={
-                                !!mergedOptions.frozen?.trailingColCount
-                              }
-                              onChange={(checked) => {
-                                if (checked) {
-                                  updateOptions({
-                                    frozen: TableSheetFrozenOptions,
-                                  });
-                                } else {
-                                  updateOptions({
-                                    frozen: {
-                                      rowCount: 0,
-                                      colCount: 0,
-                                      trailingColCount: 0,
-                                      trailingRowCount: 0,
-                                    },
-                                  });
-                                }
-                              }}
-                              disabled={sheetType === 'pivot'}
-                            />
-                          </Tooltip>
-                          <Switch
-                            checkedChildren="显示序号"
-                            unCheckedChildren="不显示序号"
-                            checked={mergedOptions.showSeriesNumber}
-                            onChange={(checked) => {
-                              updateOptions({
-                                showSeriesNumber: checked,
-                              });
-                            }}
-                          />
-                          <Switch
-                            checkedChildren="自定义序号文本"
-                            unCheckedChildren="默认序号文本"
-                            checked={
-                              mergedOptions.seriesNumberText ===
-                              '自定义序号文本'
-                            }
-                            onChange={(checked) => {
-                              updateOptions({
-                                seriesNumberText: checked
-                                  ? '自定义序号文本'
-                                  : getDefaultSeriesNumberText(),
-                              });
-                            }}
-                            disabled={!mergedOptions.showSeriesNumber}
-                          />
-                          <Switch
-                            checkedChildren="分页"
-                            unCheckedChildren="不分页"
-                            checked={showPagination}
-                            onChange={setShowPagination}
-                          />
-                          <Switch
-                            checkedChildren="汇总"
-                            unCheckedChildren="无汇总"
-                            checked={showTotals}
-                            onChange={setShowTotals}
-                          />
-                          <Switch
-                            checkedChildren="默认 headerActionIcons"
-                            unCheckedChildren="自定义 headerActionIcons"
-                            checked={mergedOptions.showDefaultHeaderActionIcon}
-                            onChange={(checked) => {
-                              updateOptions({
-                                showDefaultHeaderActionIcon: checked,
-                              });
-                            }}
-                          />
-                          <Switch
-                            checkedChildren="打开链接跳转"
-                            unCheckedChildren="无链接跳转"
-                            checked={
-                              !isEmpty(mergedOptions.interaction?.linkFields)
-                            }
-                            onChange={(checked) => {
-                              updateOptions({
-                                interaction: {
-                                  linkFields: checked
-                                    ? ['province', 'city']
-                                    : [],
-                                },
-                              });
-                            }}
-                          />
-                          <Tooltip title="将列头高度设为0">
-                            <Switch
-                              checkedChildren="隐藏列头和对应角头"
-                              unCheckedChildren="显示列头和对应角头"
-                              checked={
-                                mergedOptions.style?.colCell?.height === 0
-                              }
-                              onChange={(checked) => {
-                                updateOptions({
-                                  style: {
-                                    colCell: {
-                                      height: checked
-                                        ? 0
-                                        : s2Options?.style?.colCell?.height ??
-                                          DEFAULT_STYLE.colCell?.height,
-                                    },
-                                  },
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Tooltip title="改变 dataConfig 配置">
-                            <Switch
-                              checkedChildren="隐藏列头但保留角头"
-                              unCheckedChildren="显示列头"
-                              checked={isEmpty(dataCfg.fields?.columns)}
-                              onChange={(checked) => {
-                                setDataCfg(
-                                  customMerge(dataCfg, {
-                                    fields: {
-                                      columns: checked
-                                        ? []
-                                        : pivotSheetDataCfg.fields.columns,
-                                    },
-                                  }),
-                                );
-                              }}
-                            />
-                          </Tooltip>
-                          <Switch
-                            checkedChildren="字段标记开"
-                            unCheckedChildren="字段标记关"
-                            checked={!isEmpty(mergedOptions.conditions)}
-                            onChange={(checked) => {
-                              updateOptions({
-                                conditions: checked
-                                  ? s2ConditionsOptions
-                                  : null,
-                              });
-                            }}
-                          />
-                        </Space>
-                        <Space className="filter-container">
-                          <span className="label">
-                            主题配置
-                            <Divider type="vertical" />
-                          </span>
-                          <Tooltip title={`当前主题名: ${themeCfg.name}`}>
-                            <Radio.Group
-                              onChange={onThemeChange}
-                              defaultValue="default"
-                              value={themeCfg.name}
-                            >
-                              <Radio.Button value="default">默认</Radio.Button>
-                              <Radio.Button value="gray">简约灰</Radio.Button>
-                              <Radio.Button value="colorful">
-                                多彩蓝
-                              </Radio.Button>
-                              <Radio.Button value="dark">暗黑</Radio.Button>
-                            </Radio.Group>
-                          </Tooltip>
-                          <Popover
-                            placement="bottomRight"
-                            content={
-                              <>
-                                <ChromePicker
-                                  color={themeColor}
-                                  onChangeComplete={(color) => {
-                                    setThemeColor(color.hex);
-                                    const palette = getPalette(themeCfg.name);
-                                    const newPalette = generatePalette({
-                                      ...palette,
-                                      brandColor: color.hex,
+                    <Collapse
+                      defaultActiveKey={['filter']}
+                      items={[
+                        {
+                          key: 'filter',
+                          label: '筛选器',
+                          children: (
+                            <>
+                              <Space>
+                                <Tooltip title="表格类型">
+                                  <Radio.Group
+                                    onChange={onSheetTypeChange}
+                                    defaultValue={sheetType}
+                                  >
+                                    <Radio.Button value="pivot">
+                                      透视表
+                                    </Radio.Button>
+                                    <Radio.Button value="table">
+                                      明细表
+                                    </Radio.Button>
+                                  </Radio.Group>
+                                </Tooltip>
+                                {sheetType === 'table' && (
+                                  <Tooltip title="明细表多级表头">
+                                    <Radio.Group
+                                      onChange={onTableColumnTypeChange}
+                                      defaultValue={tableSheetColumnType}
+                                    >
+                                      <Radio.Button value="single">
+                                        单列头
+                                      </Radio.Button>
+                                      <Radio.Button value="multiple">
+                                        多列头
+                                      </Radio.Button>
+                                    </Radio.Group>
+                                  </Tooltip>
+                                )}
+                                <Tooltip title="布局类型">
+                                  <Radio.Group
+                                    onChange={onLayoutWidthTypeChange}
+                                    defaultValue="adaptive"
+                                  >
+                                    <Radio.Button value="adaptive">
+                                      行列等宽
+                                    </Radio.Button>
+                                    <Radio.Button value="colAdaptive">
+                                      列等宽
+                                    </Radio.Button>
+                                    <Radio.Button value="compact">
+                                      紧凑
+                                    </Radio.Button>
+                                  </Radio.Group>
+                                </Tooltip>
+                                <Button
+                                  danger
+                                  onClick={() => {
+                                    s2Ref.current?.destroy();
+                                    s2Ref.current?.render();
+                                  }}
+                                >
+                                  卸载组件 (s2.destroy)
+                                </Button>
+                              </Space>
+                              <Space className="filter-container">
+                                <Switch
+                                  checkedChildren="渲染组件"
+                                  unCheckedChildren="卸载组件"
+                                  defaultChecked={render}
+                                  onChange={onToggleRender}
+                                />
+                                <Switch
+                                  checkedChildren="调试模式开"
+                                  unCheckedChildren="调试模式关"
+                                  defaultChecked={mergedOptions.debug}
+                                  onChange={(checked) => {
+                                    updateOptions({ debug: checked });
+                                  }}
+                                />
+                                <Switch
+                                  checkedChildren="树形"
+                                  unCheckedChildren="平铺"
+                                  checked={
+                                    mergedOptions.hierarchyType === 'tree'
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      hierarchyType: checked ? 'tree' : 'grid',
                                     });
-
-                                    setThemeCfg({
-                                      name: themeCfg.name,
-                                      palette: newPalette,
+                                  }}
+                                  disabled={sheetType === 'table'}
+                                />
+                                <Switch
+                                  checkedChildren="数值挂列头"
+                                  unCheckedChildren="数值挂行头"
+                                  defaultChecked={dataCfg.fields?.valueInCols}
+                                  onChange={(checked) => {
+                                    updateDataCfg({
+                                      fields: {
+                                        valueInCols: checked,
+                                      },
+                                    });
+                                  }}
+                                  disabled={sheetType === 'table'}
+                                />
+                                <Switch
+                                  checkedChildren="隐藏数值"
+                                  unCheckedChildren="显示数值"
+                                  defaultChecked={
+                                    mergedOptions.style?.colCell?.hideValue
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      style: {
+                                        colCell: {
+                                          hideValue: checked,
+                                        },
+                                      },
+                                    });
+                                  }}
+                                  disabled={sheetType === 'table'}
+                                />
+                                <Switch
+                                  checkedChildren="显示行小计/总计"
+                                  unCheckedChildren="隐藏行小计/总计"
+                                  defaultChecked={
+                                    mergedOptions.totals?.row
+                                      ?.showSubTotals as boolean
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      totals: {
+                                        row: {
+                                          showGrandTotals: checked,
+                                          showSubTotals: checked,
+                                          reverseGrandTotalsLayout: true,
+                                          reverseSubTotalsLayout: true,
+                                          subTotalsDimensions: ['province'],
+                                        },
+                                      },
+                                    });
+                                  }}
+                                  disabled={sheetType === 'table'}
+                                />
+                                <Switch
+                                  checkedChildren="显示列小计/总计"
+                                  unCheckedChildren="隐藏列小计/总计"
+                                  defaultChecked={
+                                    mergedOptions.totals?.col
+                                      ?.showSubTotals as boolean
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      totals: {
+                                        col: {
+                                          showGrandTotals: checked,
+                                          showSubTotals: checked,
+                                          reverseGrandTotalsLayout: true,
+                                          reverseSubTotalsLayout: true,
+                                          subTotalsDimensions: ['type'],
+                                        },
+                                      },
+                                    });
+                                  }}
+                                  disabled={sheetType === 'table'}
+                                />
+                                <Tooltip title="透视表有效">
+                                  <Switch
+                                    checkedChildren="冻结行头开"
+                                    unCheckedChildren="冻结行头关"
+                                    defaultChecked={
+                                      !!mergedOptions.frozen?.rowHeader
+                                    }
+                                    onChange={(checked) => {
+                                      updateOptions({
+                                        frozen: {
+                                          rowHeader: checked,
+                                        },
+                                      });
+                                    }}
+                                    disabled={sheetType === 'table'}
+                                  />
+                                </Tooltip>
+                                <Tooltip title="明细表有效">
+                                  <Switch
+                                    checkedChildren="冻结列头开"
+                                    unCheckedChildren="冻结列头关"
+                                    defaultChecked={
+                                      !!mergedOptions.frozen?.trailingColCount
+                                    }
+                                    onChange={(checked) => {
+                                      if (checked) {
+                                        updateOptions({
+                                          frozen: TableSheetFrozenOptions,
+                                        });
+                                      } else {
+                                        updateOptions({
+                                          frozen: {
+                                            rowCount: 0,
+                                            colCount: 0,
+                                            trailingColCount: 0,
+                                            trailingRowCount: 0,
+                                          },
+                                        });
+                                      }
+                                    }}
+                                    disabled={sheetType === 'pivot'}
+                                  />
+                                </Tooltip>
+                                <Switch
+                                  checkedChildren="显示序号"
+                                  unCheckedChildren="不显示序号"
+                                  checked={mergedOptions.showSeriesNumber}
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      showSeriesNumber: checked,
                                     });
                                   }}
                                 />
-                              </>
-                            }
-                          >
-                            <Button>主题色调整</Button>
-                          </Popover>
-                        </Space>
-                        <Space className="filter-container">
-                          <span className="label">
-                            Tooltip 配置
-                            <Divider type="vertical" />
-                          </span>
-                          <Switch
-                            checkedChildren="开启Tooltip"
-                            unCheckedChildren="关闭Tooltip"
-                            checked={mergedOptions.tooltip?.enable}
-                            onChange={(checked) => {
-                              updateOptions({
-                                tooltip: {
-                                  enable: checked,
-                                },
-                              });
-                            }}
-                          />
-                          <Switch
-                            checkedChildren="自定义Tooltip"
-                            unCheckedChildren="默认Tooltip"
-                            checked={showCustomTooltip}
-                            onChange={setShowCustomTooltip}
-                          />
-                          <Tooltip title="操作项菜单类型, 透传 https://ant-design.antgroup.com/components/menu-cn#api">
-                            <Switch
-                              checkedChildren="操作项-水平展示"
-                              unCheckedChildren="操作项-垂直展示"
-                              onChange={(checked) => {
-                                updateOptions({
-                                  tooltip: {
-                                    operation: {
-                                      menu: {
-                                        mode: checked
-                                          ? 'horizontal'
-                                          : 'vertical',
+                                <Switch
+                                  checkedChildren="自定义序号文本"
+                                  unCheckedChildren="默认序号文本"
+                                  checked={
+                                    mergedOptions.seriesNumberText ===
+                                    '自定义序号文本'
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      seriesNumberText: checked
+                                        ? '自定义序号文本'
+                                        : getDefaultSeriesNumberText(),
+                                    });
+                                  }}
+                                  disabled={!mergedOptions.showSeriesNumber}
+                                />
+                                <Switch
+                                  checkedChildren="分页"
+                                  unCheckedChildren="不分页"
+                                  checked={showPagination}
+                                  onChange={setShowPagination}
+                                />
+                                <Switch
+                                  checkedChildren="汇总"
+                                  unCheckedChildren="无汇总"
+                                  checked={showTotals}
+                                  onChange={setShowTotals}
+                                />
+                                <Switch
+                                  checkedChildren="默认 headerActionIcons"
+                                  unCheckedChildren="自定义 headerActionIcons"
+                                  checked={
+                                    mergedOptions.showDefaultHeaderActionIcon
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      showDefaultHeaderActionIcon: checked,
+                                    });
+                                  }}
+                                />
+                                <Switch
+                                  checkedChildren="打开链接跳转"
+                                  unCheckedChildren="无链接跳转"
+                                  checked={
+                                    !isEmpty(
+                                      mergedOptions.interaction?.linkFields,
+                                    )
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      interaction: {
+                                        linkFields: checked
+                                          ? ['province', 'city']
+                                          : [],
                                       },
-                                    },
-                                  },
-                                });
-                              }}
+                                    });
+                                  }}
+                                />
+                                <Tooltip title="将列头高度设为0">
+                                  <Switch
+                                    checkedChildren="隐藏列头和对应角头"
+                                    unCheckedChildren="显示列头和对应角头"
+                                    checked={
+                                      mergedOptions.style?.colCell?.height === 0
+                                    }
+                                    onChange={(checked) => {
+                                      updateOptions({
+                                        style: {
+                                          colCell: {
+                                            height: checked
+                                              ? 0
+                                              : s2Options?.style?.colCell
+                                                  ?.height ??
+                                                DEFAULT_STYLE.colCell?.height,
+                                          },
+                                        },
+                                      });
+                                    }}
+                                  />
+                                </Tooltip>
+                                <Tooltip title="改变 dataConfig 配置">
+                                  <Switch
+                                    checkedChildren="隐藏列头但保留角头"
+                                    unCheckedChildren="显示列头"
+                                    checked={isEmpty(dataCfg.fields?.columns)}
+                                    onChange={(checked) => {
+                                      setDataCfg(
+                                        customMerge(dataCfg, {
+                                          fields: {
+                                            columns: checked
+                                              ? []
+                                              : pivotSheetDataCfg.fields
+                                                  .columns,
+                                          },
+                                        }),
+                                      );
+                                    }}
+                                  />
+                                </Tooltip>
+                                <Switch
+                                  checkedChildren="字段标记开"
+                                  unCheckedChildren="字段标记关"
+                                  checked={!isEmpty(mergedOptions.conditions)}
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      conditions: checked
+                                        ? s2ConditionsOptions
+                                        : null,
+                                    });
+                                  }}
+                                />
+                              </Space>
+                              <Space className="filter-container">
+                                <span className="label">
+                                  主题配置
+                                  <Divider type="vertical" />
+                                </span>
+                                <Tooltip title={`当前主题名: ${themeCfg.name}`}>
+                                  <Radio.Group
+                                    onChange={onThemeChange}
+                                    defaultValue="default"
+                                    value={themeCfg.name}
+                                  >
+                                    <Radio.Button value="default">
+                                      默认
+                                    </Radio.Button>
+                                    <Radio.Button value="gray">
+                                      简约灰
+                                    </Radio.Button>
+                                    <Radio.Button value="colorful">
+                                      多彩蓝
+                                    </Radio.Button>
+                                    <Radio.Button value="dark">
+                                      暗黑
+                                    </Radio.Button>
+                                  </Radio.Group>
+                                </Tooltip>
+                                <Popover
+                                  placement="bottomRight"
+                                  content={
+                                    <>
+                                      <ChromePicker
+                                        color={themeColor}
+                                        onChangeComplete={(color) => {
+                                          setThemeColor(color.hex);
+                                          const palette = getPalette(
+                                            themeCfg.name,
+                                          );
+                                          const newPalette = generatePalette({
+                                            ...palette,
+                                            brandColor: color.hex,
+                                          });
+
+                                          setThemeCfg({
+                                            name: themeCfg.name,
+                                            palette: newPalette,
+                                          });
+                                        }}
+                                      />
+                                    </>
+                                  }
+                                >
+                                  <Button>主题色调整</Button>
+                                </Popover>
+                              </Space>
+                              <Space className="filter-container">
+                                <span className="label">
+                                  Tooltip 配置
+                                  <Divider type="vertical" />
+                                </span>
+                                <Switch
+                                  checkedChildren="开启Tooltip"
+                                  unCheckedChildren="关闭Tooltip"
+                                  checked={mergedOptions.tooltip?.enable}
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      tooltip: {
+                                        enable: checked,
+                                      },
+                                    });
+                                  }}
+                                />
+                                <Switch
+                                  checkedChildren="自定义Tooltip"
+                                  unCheckedChildren="默认Tooltip"
+                                  checked={showCustomTooltip}
+                                  onChange={setShowCustomTooltip}
+                                />
+                                <Tooltip title="操作项菜单类型, 透传 https://ant-design.antgroup.com/components/menu-cn#api">
+                                  <Switch
+                                    checkedChildren="操作项-水平展示"
+                                    unCheckedChildren="操作项-垂直展示"
+                                    onChange={(checked) => {
+                                      updateOptions({
+                                        tooltip: {
+                                          operation: {
+                                            menu: {
+                                              mode: checked
+                                                ? 'horizontal'
+                                                : 'vertical',
+                                            },
+                                          },
+                                        },
+                                      });
+                                    }}
+                                  />
+                                </Tooltip>
+                                <Tooltip title="tooltip 自动调整: 显示的tooltip超过指定区域时自动调整, 使其不遮挡">
+                                  <Select
+                                    defaultValue={
+                                      mergedOptions.tooltip?.autoAdjustBoundary
+                                    }
+                                    onChange={onAutoAdjustBoundaryChange}
+                                    style={{ width: 230 }}
+                                    size="small"
+                                  >
+                                    <Select.Option value="container">
+                                      container (表格区域)
+                                    </Select.Option>
+                                    <Select.Option value="body">
+                                      body (浏览器可视区域)
+                                    </Select.Option>
+                                    <Select.Option value="">关闭</Select.Option>
+                                  </Select>
+                                </Tooltip>
+                              </Space>
+                              <Space className="filter-container">
+                                <span className="label">
+                                  宽高配置
+                                  <Divider type="vertical" />
+                                </span>
+                                <Switch
+                                  checkedChildren="容器宽高自适应开"
+                                  unCheckedChildren="容器宽高自适应关"
+                                  defaultChecked={Boolean(adaptive)}
+                                  onChange={setAdaptive}
+                                />
+                                <Input
+                                  style={{ width: 150 }}
+                                  onChange={onSizeChange('width')}
+                                  defaultValue={mergedOptions.width}
+                                  suffix="px"
+                                  prefix="宽度"
+                                  size="small"
+                                />
+                                <Input
+                                  style={{ width: 150 }}
+                                  onChange={onSizeChange('height')}
+                                  defaultValue={mergedOptions.height}
+                                  suffix="px"
+                                  prefix="高度"
+                                  size="small"
+                                />
+                                <Button
+                                  size="small"
+                                  onClick={() => {
+                                    s2Ref.current?.changeSheetSize(400, 400);
+                                    s2Ref.current?.render(false);
+                                  }}
+                                >
+                                  改变表格大小 (s2.changeSheetSize)
+                                </Button>
+                              </Space>
+                              <Space className="filter-container">
+                                <span className="label">
+                                  滚动
+                                  <Divider type="vertical" />
+                                </span>
+                                <Popover
+                                  placement="bottomRight"
+                                  content={
+                                    <>
+                                      <div style={{ width: '600px' }}>
+                                        水平滚动速率 ：
+                                        <Slider
+                                          {...sliderOptions}
+                                          defaultValue={
+                                            mergedOptions.interaction!
+                                              .scrollSpeedRatio!.horizontal
+                                          }
+                                          onChange={onScrollSpeedRatioChange(
+                                            'horizontal',
+                                          )}
+                                        />
+                                        垂直滚动速率 ：
+                                        <Slider
+                                          {...sliderOptions}
+                                          defaultValue={
+                                            mergedOptions.interaction!
+                                              .scrollSpeedRatio!.vertical
+                                          }
+                                          onChange={onScrollSpeedRatioChange(
+                                            'vertical',
+                                          )}
+                                        />
+                                      </div>
+                                    </>
+                                  }
+                                >
+                                  <Button size="small">滚动速率调整</Button>
+                                </Popover>
+                                <Tooltip title="滚动链控制(overscrollBehavior): https://developer.mozilla.org/zh-CN/docs/Web/CSS/overscroll-behavior">
+                                  <Select
+                                    defaultValue={
+                                      mergedOptions.interaction!
+                                        .overscrollBehavior
+                                    }
+                                    onChange={onOverscrollBehaviorChange}
+                                    style={{ width: 150 }}
+                                    size="small"
+                                  >
+                                    <Select.Option value="auto">
+                                      auto
+                                    </Select.Option>
+                                    <Select.Option value="contain">
+                                      contain
+                                    </Select.Option>
+                                    <Select.Option value="none">
+                                      none
+                                    </Select.Option>
+                                  </Select>
+                                </Tooltip>
+                                <Button
+                                  size="small"
+                                  onClick={() => {
+                                    const rowNode = s2Ref.current?.facet
+                                      .getRowNodes()
+                                      .find(
+                                        ({ id }) =>
+                                          id === 'root[&]四川省[&]成都市',
+                                      );
+
+                                    clearInterval(scrollTimer.current!);
+                                    s2Ref.current?.updateScrollOffset({
+                                      offsetY: {
+                                        value: rowNode?.y,
+                                        animate: true,
+                                      },
+                                    });
+                                  }}
+                                >
+                                  滚动至 [成都市]
+                                </Button>
+                                <Button
+                                  size="small"
+                                  onClick={() => {
+                                    clearInterval(scrollTimer.current!);
+                                    s2Ref.current?.updateScrollOffset({
+                                      offsetY: {
+                                        value: 0,
+                                        animate: true,
+                                      },
+                                    });
+                                  }}
+                                >
+                                  滚动到顶部
+                                </Button>
+                                <Button
+                                  size="small"
+                                  onClick={() => {
+                                    clearInterval(scrollTimer.current);
+                                    s2Ref.current?.updateScrollOffset({
+                                      rowHeaderOffsetX: {
+                                        value: 100,
+                                        animate: true,
+                                      },
+                                    });
+                                  }}
+                                >
+                                  滚动行头
+                                </Button>
+                                <Button
+                                  size="small"
+                                  danger
+                                  onClick={() => {
+                                    if (
+                                      scrollTimer.current ||
+                                      !s2Ref.current?.facet.vScrollBar
+                                    ) {
+                                      clearInterval(scrollTimer.current!);
+
+                                      return;
+                                    }
+
+                                    scrollTimer.current = setInterval(() => {
+                                      const { scrollY } =
+                                        s2Ref.current?.facet.getScrollOffset()!;
+
+                                      if (
+                                        s2Ref.current?.facet.isScrollToBottom(
+                                          scrollY,
+                                        )
+                                      ) {
+                                        console.log('滚动到底部');
+                                        s2Ref.current.updateScrollOffset({
+                                          offsetY: {
+                                            value: 0,
+                                            animate: false,
+                                          },
+                                        });
+
+                                        return;
+                                      }
+
+                                      s2Ref.current!.updateScrollOffset({
+                                        offsetY: {
+                                          value: scrollY + 50,
+                                          animate: true,
+                                        },
+                                      });
+                                    }, 500) as unknown as number;
+                                  }}
+                                >
+                                  {scrollTimer.current
+                                    ? '停止滚动'
+                                    : '循环滚动'}
+                                </Button>
+                              </Space>
+                              <Space className="filter-container">
+                                <span className="label">
+                                  折叠 / 展开
+                                  <Divider type="vertical" />
+                                </span>
+                                <Tooltip title="树状模式生效 (平铺模式 TODO)">
+                                  <Switch
+                                    checkedChildren="收起所有"
+                                    unCheckedChildren="展开所有"
+                                    disabled={
+                                      mergedOptions.hierarchyType !== 'tree'
+                                    }
+                                    checked={
+                                      mergedOptions.style?.rowCell?.collapseAll!
+                                    }
+                                    onChange={(checked) => {
+                                      updateOptions({
+                                        style: {
+                                          rowCell: {
+                                            collapseAll: checked,
+                                            collapseFields: null,
+                                            expandDepth: null,
+                                          },
+                                        },
+                                      });
+                                    }}
+                                  />
+                                </Tooltip>
+                                <Switch
+                                  checkedChildren="折叠浙江省"
+                                  unCheckedChildren="展开浙江省"
+                                  disabled={
+                                    mergedOptions.hierarchyType !== 'tree'
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      style: {
+                                        rowCell: {
+                                          collapseAll: null,
+                                          expandDepth: null,
+                                          collapseFields: {
+                                            'root[&]浙江省': checked,
+                                          },
+                                        },
+                                      },
+                                    });
+                                  }}
+                                />
+                                <Tooltip
+                                  title={
+                                    <p>透视表树状模式默认行头展开层级配置</p>
+                                  }
+                                >
+                                  <Select
+                                    style={{ width: 180 }}
+                                    defaultValue={
+                                      mergedOptions?.style?.rowCell?.expandDepth
+                                    }
+                                    placeholder="默认行头展开层级"
+                                    size="small"
+                                    onChange={(level) => {
+                                      updateOptions({
+                                        style: {
+                                          rowCell: {
+                                            collapseAll: false,
+                                            expandDepth: level,
+                                            collapseFields: null,
+                                          },
+                                        },
+                                      });
+                                    }}
+                                  >
+                                    {pivotSheetDataCfg.fields.rows?.map(
+                                      (_, i) => (
+                                        <Select.Option value={i} key={i}>
+                                          第 {i + 1} 级
+                                        </Select.Option>
+                                      ),
+                                    )}
+                                  </Select>
+                                </Tooltip>
+                              </Space>
+                            </>
+                          ),
+                        },
+                        {
+                          key: 'interaction',
+                          label: '交互配置',
+                          children: (
+                            <Space>
+                              <Tooltip title="高亮选中单元格">
+                                <Switch
+                                  checkedChildren="选中聚光灯开"
+                                  unCheckedChildren="选中聚光灯关"
+                                  checked={
+                                    mergedOptions?.interaction
+                                      ?.selectedCellsSpotlight
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      interaction: {
+                                        selectedCellsSpotlight: checked,
+                                      },
+                                    });
+                                  }}
+                                />
+                              </Tooltip>
+                              <Tooltip title="高亮选中单元格行为，演示这里旧配置优先级最高">
+                                <Select
+                                  style={{ width: 260 }}
+                                  placeholder="单元格选中高亮"
+                                  allowClear
+                                  mode="multiple"
+                                  onChange={(type) => {
+                                    let selectedCellHighlight:
+                                      | boolean
+                                      | InteractionCellSelectedHighlightOptions =
+                                      false;
+                                    const oldIdx = type.findIndex(
+                                      (typeItem: any) => isBoolean(typeItem),
+                                    );
+
+                                    if (oldIdx > -1) {
+                                      selectedCellHighlight = type[oldIdx];
+                                    } else {
+                                      selectedCellHighlight = {
+                                        rowHeader: false,
+                                        colHeader: false,
+                                        currentCol: false,
+                                        currentRow: false,
+                                      };
+                                      type.forEach((i: number) => {
+                                        // @ts-ignore
+                                        selectedCellHighlight[i] = true;
+                                      });
+                                    }
+
+                                    updateOptions({
+                                      interaction: {
+                                        // @ts-ignore
+                                        selectedCellHighlight,
+                                      },
+                                    });
+                                  }}
+                                >
+                                  <Select.Option value={true}>
+                                    （旧）高亮选中单元格所在行列头
+                                  </Select.Option>
+                                  <Select.Option value="rowHeader">
+                                    rowHeader: 高亮所在行头
+                                  </Select.Option>
+                                  <Select.Option value="colHeader">
+                                    colHeader: 高亮所在列头
+                                  </Select.Option>
+                                  <Select.Option value="currentRow">
+                                    currentRow: 高亮所在行
+                                  </Select.Option>
+                                  <Select.Option value="currentCol">
+                                    currentCol: 高亮所在列
+                                  </Select.Option>
+                                </Select>
+                              </Tooltip>
+                              <Tooltip title="高亮当前行列单元格">
+                                <Switch
+                                  checkedChildren="hover十字器开"
+                                  unCheckedChildren="hover十字器关"
+                                  checked={
+                                    mergedOptions?.interaction?.hoverHighlight
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      interaction: {
+                                        hoverHighlight: checked,
+                                      },
+                                    });
+                                  }}
+                                />
+                              </Tooltip>
+                              <Tooltip title="在数值单元格悬停800ms,显示tooltip">
+                                <Switch
+                                  checkedChildren="hover聚焦开"
+                                  unCheckedChildren="hover聚焦关"
+                                  checked={
+                                    mergedOptions?.interaction
+                                      ?.hoverFocus as boolean
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      interaction: {
+                                        hoverFocus: checked,
+                                      },
+                                    });
+                                  }}
+                                />
+                              </Tooltip>
+                              <Tooltip title="开启后,点击空白处,按下ESC键, 取消高亮, 清空选中单元格, 等交互样式">
+                                <Switch
+                                  checkedChildren="自动重置交互样式开"
+                                  unCheckedChildren="自动重置交互样式关"
+                                  defaultChecked={
+                                    mergedOptions?.interaction
+                                      ?.autoResetSheetStyle
+                                  }
+                                  onChange={(checked) => {
+                                    updateOptions({
+                                      interaction: {
+                                        autoResetSheetStyle: checked,
+                                      },
+                                    });
+                                  }}
+                                />
+                              </Tooltip>
+                              <Tooltip
+                                title={
+                                  <>
+                                    <p>默认隐藏列 </p>
+                                    <p>明细表: 列头指定 field: number</p>
+                                    <p>
+                                      透视表: 列头指定id:
+                                      root[&]家具[&]沙发[&]number
+                                    </p>
+                                  </>
+                                }
+                              >
+                                <Select
+                                  style={{ width: 300 }}
+                                  defaultValue={
+                                    mergedOptions?.interaction
+                                      ?.hiddenColumnFields
+                                  }
+                                  mode="multiple"
+                                  placeholder="默认隐藏列"
+                                  onChange={(fields) => {
+                                    updateOptions({
+                                      interaction: {
+                                        hiddenColumnFields: fields,
+                                      },
+                                    });
+                                  }}
+                                >
+                                  {columnOptions.map((column) => (
+                                    <Select.Option
+                                      value={column}
+                                      key={column as string}
+                                    >
+                                      {column as string}
+                                    </Select.Option>
+                                  ))}
+                                </Select>
+                              </Tooltip>
+                            </Space>
+                          ),
+                        },
+                        {
+                          key: 'resize',
+                          label: '宽高调整热区配置',
+                          children: (
+                            <ResizeConfig
+                              options={mergedOptions}
+                              setOptions={setOptions}
+                              setThemeCfg={setThemeCfg}
                             />
-                          </Tooltip>
-                          <Tooltip title="tooltip 自动调整: 显示的tooltip超过指定区域时自动调整, 使其不遮挡">
-                            <Select
-                              defaultValue={
-                                mergedOptions.tooltip?.autoAdjustBoundary
-                              }
-                              onChange={onAutoAdjustBoundaryChange}
-                              style={{ width: 230 }}
-                              size="small"
-                            >
-                              <Select.Option value="container">
-                                container (表格区域)
-                              </Select.Option>
-                              <Select.Option value="body">
-                                body (浏览器可视区域)
-                              </Select.Option>
-                              <Select.Option value="">关闭</Select.Option>
-                            </Select>
-                          </Tooltip>
-                        </Space>
-                        <Space className="filter-container">
-                          <span className="label">
-                            宽高配置
-                            <Divider type="vertical" />
-                          </span>
-                          <Switch
-                            checkedChildren="容器宽高自适应开"
-                            unCheckedChildren="容器宽高自适应关"
-                            defaultChecked={Boolean(adaptive)}
-                            onChange={setAdaptive}
-                          />
-                          <Input
-                            style={{ width: 150 }}
-                            onChange={onSizeChange('width')}
-                            defaultValue={mergedOptions.width}
-                            suffix="px"
-                            prefix="宽度"
-                            size="small"
-                          />
-                          <Input
-                            style={{ width: 150 }}
-                            onChange={onSizeChange('height')}
-                            defaultValue={mergedOptions.height}
-                            suffix="px"
-                            prefix="高度"
-                            size="small"
-                          />
-                          <Button
-                            size="small"
-                            onClick={() => {
-                              s2Ref.current?.changeSheetSize(400, 400);
-                              s2Ref.current?.render(false);
-                            }}
-                          >
-                            改变表格大小 (s2.changeSheetSize)
-                          </Button>
-                        </Space>
-                        <Space className="filter-container">
-                          <span className="label">
-                            滚动
-                            <Divider type="vertical" />
-                          </span>
-                          <Popover
-                            placement="bottomRight"
-                            content={
-                              <>
-                                <div style={{ width: '600px' }}>
-                                  水平滚动速率 ：
-                                  <Slider
-                                    {...sliderOptions}
-                                    defaultValue={
-                                      mergedOptions.interaction!
-                                        .scrollSpeedRatio!.horizontal
-                                    }
-                                    onChange={onScrollSpeedRatioChange(
-                                      'horizontal',
-                                    )}
-                                  />
-                                  垂直滚动速率 ：
-                                  <Slider
-                                    {...sliderOptions}
-                                    defaultValue={
-                                      mergedOptions.interaction!
-                                        .scrollSpeedRatio!.vertical
-                                    }
-                                    onChange={onScrollSpeedRatioChange(
-                                      'vertical',
-                                    )}
-                                  />
-                                </div>
-                              </>
-                            }
-                          >
-                            <Button size="small">滚动速率调整</Button>
-                          </Popover>
-                          <Tooltip title="滚动链控制(overscrollBehavior): https://developer.mozilla.org/zh-CN/docs/Web/CSS/overscroll-behavior">
-                            <Select
-                              defaultValue={
-                                mergedOptions.interaction!.overscrollBehavior
-                              }
-                              onChange={onOverscrollBehaviorChange}
-                              style={{ width: 150 }}
-                              size="small"
-                            >
-                              <Select.Option value="auto">auto</Select.Option>
-                              <Select.Option value="contain">
-                                contain
-                              </Select.Option>
-                              <Select.Option value="none">none</Select.Option>
-                            </Select>
-                          </Tooltip>
-                          <Button
-                            size="small"
-                            onClick={() => {
-                              const rowNode = s2Ref.current?.facet
-                                .getRowNodes()
-                                .find(
-                                  ({ id }) => id === 'root[&]四川省[&]成都市',
-                                );
-
-                              clearInterval(scrollTimer.current!);
-                              s2Ref.current?.updateScrollOffset({
-                                offsetY: {
-                                  value: rowNode?.y,
-                                  animate: true,
-                                },
-                              });
-                            }}
-                          >
-                            滚动至 [成都市]
-                          </Button>
-                          <Button
-                            size="small"
-                            onClick={() => {
-                              clearInterval(scrollTimer.current!);
-                              s2Ref.current?.updateScrollOffset({
-                                offsetY: {
-                                  value: 0,
-                                  animate: true,
-                                },
-                              });
-                            }}
-                          >
-                            滚动到顶部
-                          </Button>
-                          <Button
-                            size="small"
-                            onClick={() => {
-                              clearInterval(scrollTimer.current);
-                              s2Ref.current?.updateScrollOffset({
-                                rowHeaderOffsetX: {
-                                  value: 100,
-                                  animate: true,
-                                },
-                              });
-                            }}
-                          >
-                            滚动行头
-                          </Button>
-                          <Button
-                            size="small"
-                            danger
-                            onClick={() => {
-                              if (
-                                scrollTimer.current ||
-                                !s2Ref.current?.facet.vScrollBar
-                              ) {
-                                clearInterval(scrollTimer.current!);
-
+                          ),
+                        },
+                      ]}
+                    />
+                    {render && (
+                      <React.StrictMode>
+                        <SheetComponent
+                          dataCfg={dataCfg as S2DataConfig}
+                          options={mergedOptions}
+                          sheetType={sheetType}
+                          adaptive={adaptive}
+                          ref={s2Ref}
+                          themeCfg={themeCfg}
+                          partDrillDown={partDrillDown}
+                          showPagination={showPagination}
+                          header={{
+                            title: (
+                              <a href="https://github.com/antvis/S2">
+                                {reactPkg.name} playground
+                              </a>
+                            ),
+                            description: (
+                              <Space>
+                                <span>
+                                  {reactPkg.name}: <Tag>{reactPkg.version}</Tag>
+                                </span>
+                                <span>
+                                  {corePkg.name}: <Tag>{corePkg.version}</Tag>
+                                </span>
+                                <span>
+                                  antd: <Tag>{AntdVersion}</Tag>
+                                </span>
+                                <span>
+                                  react: <Tag>{React.version}</Tag>
+                                </span>
+                                <span>
+                                  lang: <Tag>{getLang()}</Tag>
+                                </span>
+                              </Space>
+                            ),
+                            switcherCfg: { open: true },
+                            exportCfg: { open: true },
+                            advancedSortCfg: {
+                              open: true,
+                            },
+                          }}
+                          onAfterRender={logHandler('onAfterRender')}
+                          onRangeSort={logHandler('onRangeSort')}
+                          onRangeSorted={logHandler('onRangeSorted')}
+                          onMounted={onSheetMounted}
+                          onDestroy={onSheetDestroy}
+                          onColCellClick={onColCellClick}
+                          onRowCellClick={logHandler('onRowCellClick')}
+                          onCornerCellClick={logHandler(
+                            'onCornerCellClick',
+                            (cellInfo) => {
+                              if (!showCustomTooltip) {
                                 return;
                               }
 
-                              scrollTimer.current = setInterval(() => {
-                                const { scrollY } =
-                                  s2Ref.current?.facet.getScrollOffset()!;
-
-                                if (
-                                  s2Ref.current?.facet.isScrollToBottom(scrollY)
-                                ) {
-                                  console.log('滚动到底部');
-                                  s2Ref.current.updateScrollOffset({
-                                    offsetY: {
-                                      value: 0,
-                                      animate: false,
-                                    },
-                                  });
-
-                                  return;
-                                }
-
-                                s2Ref.current!.updateScrollOffset({
-                                  offsetY: {
-                                    value: scrollY + 50,
-                                    animate: true,
-                                  },
-                                });
-                              }, 500) as unknown as number;
-                            }}
-                          >
-                            {scrollTimer.current ? '停止滚动' : '循环滚动'}
-                          </Button>
-                        </Space>
-                        <Space className="filter-container">
-                          <span className="label">
-                            折叠 / 展开
-                            <Divider type="vertical" />
-                          </span>
-                          <Tooltip title="树状模式生效 (平铺模式 TODO)">
-                            <Switch
-                              checkedChildren="收起所有"
-                              unCheckedChildren="展开所有"
-                              disabled={mergedOptions.hierarchyType !== 'tree'}
-                              checked={
-                                mergedOptions.style?.rowCell?.collapseAll!
-                              }
-                              onChange={(checked) => {
-                                updateOptions({
-                                  style: {
-                                    rowCell: {
-                                      collapseAll: checked,
-                                      collapseFields: null,
-                                      expandDepth: null,
-                                    },
-                                  },
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Switch
-                            checkedChildren="折叠浙江省"
-                            unCheckedChildren="展开浙江省"
-                            disabled={mergedOptions.hierarchyType !== 'tree'}
-                            onChange={(checked) => {
-                              updateOptions({
-                                style: {
-                                  rowCell: {
-                                    collapseAll: null,
-                                    expandDepth: null,
-                                    collapseFields: {
-                                      'root[&]浙江省': checked,
-                                    },
-                                  },
+                              s2Ref.current?.showTooltip({
+                                position: {
+                                  x: cellInfo.event.clientX,
+                                  y: cellInfo.event.clientY,
                                 },
+                                content: 'click',
                               });
-                            }}
-                          />
-                          <Tooltip
-                            title={<p>透视表树状模式默认行头展开层级配置</p>}
-                          >
-                            <Select
-                              style={{ width: 180 }}
-                              defaultValue={
-                                mergedOptions?.style?.rowCell?.expandDepth
-                              }
-                              placeholder="默认行头展开层级"
-                              size="small"
-                              onChange={(level) => {
-                                updateOptions({
-                                  style: {
-                                    rowCell: {
-                                      collapseAll: false,
-                                      expandDepth: level,
-                                      collapseFields: null,
-                                    },
-                                  },
-                                });
-                              }}
-                            >
-                              {pivotSheetDataCfg.fields.rows?.map((_, i) => (
-                                <Select.Option value={i} key={i}>
-                                  第 {i + 1} 级
-                                </Select.Option>
-                              ))}
-                            </Select>
-                          </Tooltip>
-                        </Space>
-                      </Collapse.Panel>
-                      <Collapse.Panel header="交互配置" key="interaction">
-                        <Space>
-                          <Tooltip title="高亮选中单元格">
-                            <Switch
-                              checkedChildren="选中聚光灯开"
-                              unCheckedChildren="选中聚光灯关"
-                              checked={
-                                mergedOptions?.interaction
-                                  ?.selectedCellsSpotlight
-                              }
-                              onChange={(checked) => {
-                                updateOptions({
-                                  interaction: {
-                                    selectedCellsSpotlight: checked,
-                                  },
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Tooltip title="高亮选中单元格行为，演示这里旧配置优先级最高">
-                            <Select
-                              style={{ width: 260 }}
-                              placeholder="单元格选中高亮"
-                              allowClear
-                              mode="multiple"
-                              onChange={(type) => {
-                                let selectedCellHighlight:
-                                  | boolean
-                                  | InteractionCellSelectedHighlightOptions =
-                                  false;
-                                const oldIdx = type.findIndex((typeItem: any) =>
-                                  isBoolean(typeItem),
-                                );
-
-                                if (oldIdx > -1) {
-                                  selectedCellHighlight = type[oldIdx];
-                                } else {
-                                  selectedCellHighlight = {
-                                    rowHeader: false,
-                                    colHeader: false,
-                                    currentCol: false,
-                                    currentRow: false,
-                                  };
-                                  type.forEach((i: number) => {
-                                    // @ts-ignore
-                                    selectedCellHighlight[i] = true;
-                                  });
-                                }
-
-                                updateOptions({
-                                  interaction: {
-                                    // @ts-ignore
-                                    selectedCellHighlight,
-                                  },
-                                });
-                              }}
-                            >
-                              <Select.Option value={true}>
-                                （旧）高亮选中单元格所在行列头
-                              </Select.Option>
-                              <Select.Option value="rowHeader">
-                                rowHeader: 高亮所在行头
-                              </Select.Option>
-                              <Select.Option value="colHeader">
-                                colHeader: 高亮所在列头
-                              </Select.Option>
-                              <Select.Option value="currentRow">
-                                currentRow: 高亮所在行
-                              </Select.Option>
-                              <Select.Option value="currentCol">
-                                currentCol: 高亮所在列
-                              </Select.Option>
-                            </Select>
-                          </Tooltip>
-                          <Tooltip title="高亮当前行列单元格">
-                            <Switch
-                              checkedChildren="hover十字器开"
-                              unCheckedChildren="hover十字器关"
-                              checked={
-                                mergedOptions?.interaction?.hoverHighlight
-                              }
-                              onChange={(checked) => {
-                                updateOptions({
-                                  interaction: {
-                                    hoverHighlight: checked,
-                                  },
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Tooltip title="在数值单元格悬停800ms,显示tooltip">
-                            <Switch
-                              checkedChildren="hover聚焦开"
-                              unCheckedChildren="hover聚焦关"
-                              checked={
-                                mergedOptions?.interaction
-                                  ?.hoverFocus as boolean
-                              }
-                              onChange={(checked) => {
-                                updateOptions({
-                                  interaction: {
-                                    hoverFocus: checked,
-                                  },
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Tooltip title="开启后,点击空白处,按下ESC键, 取消高亮, 清空选中单元格, 等交互样式">
-                            <Switch
-                              checkedChildren="自动重置交互样式开"
-                              unCheckedChildren="自动重置交互样式关"
-                              defaultChecked={
-                                mergedOptions?.interaction?.autoResetSheetStyle
-                              }
-                              onChange={(checked) => {
-                                updateOptions({
-                                  interaction: {
-                                    autoResetSheetStyle: checked,
-                                  },
-                                });
-                              }}
-                            />
-                          </Tooltip>
-                          <Tooltip
-                            title={
-                              <>
-                                <p>默认隐藏列 </p>
-                                <p>明细表: 列头指定 field: number</p>
-                                <p>
-                                  透视表: 列头指定id:
-                                  root[&]家具[&]沙发[&]number
-                                </p>
-                              </>
-                            }
-                          >
-                            <Select
-                              style={{ width: 300 }}
-                              defaultValue={
-                                mergedOptions?.interaction?.hiddenColumnFields
-                              }
-                              mode="multiple"
-                              placeholder="默认隐藏列"
-                              onChange={(fields) => {
-                                updateOptions({
-                                  interaction: {
-                                    hiddenColumnFields: fields,
-                                  },
-                                });
-                              }}
-                            >
-                              {columnOptions.map((column) => (
-                                <Select.Option
-                                  value={column}
-                                  key={column as string}
-                                >
-                                  {column as string}
-                                </Select.Option>
-                              ))}
-                            </Select>
-                          </Tooltip>
-                        </Space>
-                      </Collapse.Panel>
-                      <Collapse.Panel header="宽高调整热区配置" key="resize">
-                        <ResizeConfig
-                          options={mergedOptions}
-                          setOptions={setOptions}
-                          setThemeCfg={setThemeCfg}
+                            },
+                          )}
+                          onDataCellClick={logHandler('onDataCellClick')}
+                          onLayoutResize={logHandler('onLayoutResize')}
+                          onCopied={logHandler('onCopied')}
+                          onColCellHidden={logHandler('onColCellHidden')}
+                          onColCellExpanded={logHandler('onColCellExpanded')}
+                          onSelected={logHandler('onSelected')}
+                          onScroll={logHandler('onScroll')}
+                          onRowCellScroll={logHandler('onRowCellScroll')}
+                          onLinkFieldJump={logHandler('onLinkFieldJump', () => {
+                            window.open(
+                              'https://s2.antv.antgroup.com/zh/docs/manual/advanced/interaction/link-jump#%E6%A0%87%E8%AE%B0%E9%93%BE%E6%8E%A5%E5%AD%97%E6%AE%B5',
+                            );
+                          })}
+                          onDataCellBrushSelection={logHandler(
+                            'onDataCellBrushSelection',
+                          )}
+                          onColCellBrushSelection={logHandler(
+                            'onColCellBrushSelection',
+                          )}
+                          onRowCellBrushSelection={logHandler(
+                            'onRowCellBrushSelection',
+                          )}
+                          onRowCellCollapsed={logHandler('onRowCellCollapsed')}
+                          onRowCellAllCollapsed={logHandler(
+                            'onRowCellAllCollapsed',
+                          )}
                         />
-                      </Collapse.Panel>
-                    </Collapse>
-                    {render && (
-                      <SheetComponent
-                        dataCfg={dataCfg as S2DataConfig}
-                        options={mergedOptions}
-                        sheetType={sheetType}
-                        adaptive={adaptive}
-                        ref={s2Ref}
-                        themeCfg={themeCfg}
-                        partDrillDown={partDrillDown}
-                        showPagination={showPagination}
-                        header={{
-                          title: (
-                            <a href="https://github.com/antvis/S2">
-                              {reactPkg.name} playground
-                            </a>
-                          ),
-                          description: (
-                            <Space>
-                              <span>
-                                {reactPkg.name}: <Tag>{reactPkg.version}</Tag>
-                              </span>
-                              <span>
-                                {corePkg.name}: <Tag>{corePkg.version}</Tag>
-                              </span>
-                              <span>
-                                antd: <Tag>{AntdVersion}</Tag>
-                              </span>
-                              <span>
-                                react: <Tag>{React.version}</Tag>
-                              </span>
-                              <span>
-                                lang: <Tag>{getLang()}</Tag>
-                              </span>
-                            </Space>
-                          ),
-                          switcherCfg: { open: true },
-                          exportCfg: { open: true },
-                          advancedSortCfg: {
-                            open: true,
-                          },
-                        }}
-                        onAfterRender={logHandler('onAfterRender')}
-                        onRangeSort={logHandler('onRangeSort')}
-                        onRangeSorted={logHandler('onRangeSorted')}
-                        onMounted={onSheetMounted}
-                        onDestroy={onSheetDestroy}
-                        onColCellClick={onColCellClick}
-                        onRowCellClick={logHandler('onRowCellClick')}
-                        onCornerCellClick={logHandler(
-                          'onCornerCellClick',
-                          (cellInfo) => {
-                            if (!showCustomTooltip) {
-                              return;
-                            }
-
-                            s2Ref.current?.showTooltip({
-                              position: {
-                                x: cellInfo.event.clientX,
-                                y: cellInfo.event.clientY,
-                              },
-                              content: 'click',
-                            });
-                          },
-                        )}
-                        onDataCellClick={logHandler('onDataCellClick')}
-                        onLayoutResize={logHandler('onLayoutResize')}
-                        onCopied={logHandler('onCopied')}
-                        onColCellHidden={logHandler('onColCellHidden')}
-                        onColCellExpanded={logHandler('onColCellExpanded')}
-                        onSelected={logHandler('onSelected')}
-                        onScroll={logHandler('onScroll')}
-                        onRowCellScroll={logHandler('onRowCellScroll')}
-                        onLinkFieldJump={logHandler('onLinkFieldJump', () => {
-                          window.open(
-                            'https://s2.antv.antgroup.com/zh/docs/manual/advanced/interaction/link-jump#%E6%A0%87%E8%AE%B0%E9%93%BE%E6%8E%A5%E5%AD%97%E6%AE%B5',
-                          );
-                        })}
-                        onDataCellBrushSelection={logHandler(
-                          'onDataCellBrushSelection',
-                        )}
-                        onColCellBrushSelection={logHandler(
-                          'onColCellBrushSelection',
-                        )}
-                        onRowCellBrushSelection={logHandler(
-                          'onRowCellBrushSelection',
-                        )}
-                        onRowCellCollapsed={logHandler('onRowCellCollapsed')}
-                        onRowCellAllCollapsed={logHandler(
-                          'onRowCellAllCollapsed',
-                        )}
-                      />
+                      </React.StrictMode>
                     )}
                   </>
                 ),


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

React 18 StrictMode 在非生产环境下会强制执行两次, 导致会挂载两个 canvas, 体验不是很好

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/3fb4953d-0ff8-4e41-a532-415858d6419f) | ![image](https://github.com/antvis/S2/assets/21015895/88951183-b9df-4077-9a6a-846ae181f4c9) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

https://github.com/antvis/S2/pull/2373 遗留问题

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
