### PR TITLE
fix: 区分 GuiIcon 报错类型 close #2345

### DIFF
--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -1,8 +1,9 @@
 /**
- * @Description: 请严格要求 svg 的 viewBox，若设计产出的 svg 不是此规格，请叫其修改为 '0 0 1024 1024'
+ * @description: 请严格要求 svg 的 viewBox，若设计产出的 svg 不是此规格，请叫其修改为 '0 0 1024 1024'
  */
 import { Group, Shape, type ShapeAttrs } from '@antv/g-canvas';
 import { omit, clone } from 'lodash';
+import { DebuggerUtil, type S2CellType } from '..';
 import { getIcon } from './factory';
 
 const STYLE_PLACEHOLDER = '<svg';
@@ -118,16 +119,28 @@ export class GuiIcon extends Group {
     } else {
       this.getImage(name, cacheKey, fill)
         .then((value: HTMLImageElement) => {
-          // 加载完成后，当前 Cell 可能已经销毁了
-          if (this.destroyed) {
+          // 异步加载完成后，当前 Cell 可能已经销毁了
+          const canvas = (this.getParent() as S2CellType)?.getMeta?.()
+            .spreadsheet?.container;
+
+          // G 底层 refreshElements 默认是个数组, 销毁时获取不到, 没有兜底 https://github.com/antvis/S2/issues/2435
+          if (this.destroyed || (canvas && !canvas.get('refreshElements'))) {
+            DebuggerUtil.getInstance().logger(`GuiIcon ${name} destroyed.`);
             return;
           }
+
           image.attr('img', value);
           this.addShape('image', image);
         })
-        .catch((event: Event) => {
+        .catch((event: string | Event) => {
+          // 如果是 TypeError, 则是 G 底层渲染有问题, 其他场景才报加载异常的错误
+          if (event instanceof TypeError) {
+            // eslint-disable-next-line no-console
+            console.warn(`GuiIcon ${name} destroyed:`, event);
+            return;
+          }
           // eslint-disable-next-line no-console
-          console.error(`GuiIcon ${name} load failed`, event);
+          console.error(`GuiIcon ${name} load failed:`, event);
         });
     }
   }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2435

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

`GuiIcon load fielad` 报错的本质是要捕获图片加载错误的场景, 但会捕获到 G 绘制过程中无效的错误信息 (cell 已卸载, 此时 addShape 的容错场景), 之前 https://github.com/antvis/S2/pull/1997 已经处理过类似的问题

https://github.com/antvis/S2/blob/6490f32e426f72a808f710e4966c357d750758c9/packages/s2-core/src/common/icons/gui-icon.ts#L48-L52

![image](https://github.com/antvis/S2/assets/21015895/3b5c1f15-6157-4a22-98f0-72a01feec07c)

![image](https://github.com/antvis/S2/assets/21015895/6f8c998d-f781-4ae6-8ec4-f57049aa09a4)

1. 区分 TypeError 和加载 Error, 输出不同的提示
2. 增加容错, 如果 canvas 没有 refreshElements, 就不需要绘制图层


### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

ref https://github.com/antvis/S2/pull/1997

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
