### PR TITLE
fix: 修复透视表数据为空时，行列交叉单元格缺失的问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/empty-dataset-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/empty-dataset-spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { getContainer } from 'tests/util/helpers';
+import { PivotSheet, TableSheet } from '@/sheet-type';
+import type { S2Options } from '@/common/interface/s2Options';
+
+const s2Options: S2Options = {
+  width: 400,
+  height: 400,
+  hierarchyType: 'grid',
+};
+
+describe('Empty Dataset Structure Tests', () => {
+  test('should generate placeholder for pivot mode with single dimension', () => {
+    const container = getContainer();
+
+    const s2DataCfg = {
+      fields: {
+        rows: ['province', 'city'],
+        columns: ['type'],
+        values: ['price'],
+        valueInCols: true,
+      },
+      data: [],
+    };
+    const s2 = new PivotSheet(container, s2DataCfg, s2Options);
+    s2.render();
+
+    // @ts-ignore
+    expect(s2.facet.panelScrollGroupIndexes).toEqual([0, 0, 0, 0]);
+  });
+
+  test('should generate placeholder for pivot mode with two dimensions', () => {
+    const container = getContainer();
+
+    const s2DataCfg = {
+      fields: {
+        rows: ['province', 'city'],
+        columns: ['type'],
+        values: ['price', 'cost'],
+        valueInCols: true,
+      },
+      data: [],
+    };
+    const s2 = new PivotSheet(container, s2DataCfg, s2Options);
+    s2.render();
+    // @ts-ignore
+    expect(s2.facet.panelScrollGroupIndexes).toEqual([0, 1, 0, 0]);
+  });
+
+  test(`shouldn't generate placeholder for table mode`, () => {
+    const container = getContainer();
+
+    const s2DataCfg = {
+      fields: {
+        columns: ['province', 'city', 'type', 'price', 'cost'],
+      },
+      data: [],
+    };
+    const s2 = new TableSheet(container, s2DataCfg, s2Options);
+    s2.render();
+    // @ts-ignore
+    expect(s2.facet.panelScrollGroupIndexes).toEqual([]);
+  });
+});

--- a/packages/s2-core/src/data-set/base-data-set.ts
+++ b/packages/s2-core/src/data-set/base-data-set.ts
@@ -26,6 +26,7 @@ import {
 } from '../utils/condition/state-controller';
 import type { CellMeta, RowData } from '../common';
 import { generateExtraFieldMeta } from '../utils/dataset/pivot-data-set';
+import type { Indexes } from '../utils/indexes';
 import type { CellDataParams, DataType } from './index';
 
 export abstract class BaseDataSet {
@@ -120,6 +121,11 @@ export abstract class BaseDataSet {
 
   public isEmpty() {
     return isEmpty(this.getDisplayDataSet());
+  }
+
+  // https://github.com/antvis/S2/issues/2255
+  public getEmptyViewIndexes(): Indexes {
+    return [];
   }
 
   public getValueRangeByField(field: string): ValueRange {

--- a/packages/s2-core/src/facet/frozen-facet.ts
+++ b/packages/s2-core/src/facet/frozen-facet.ts
@@ -199,17 +199,17 @@ export abstract class FrozenFacet extends BaseFacet {
       }
     }
 
-    // https://github.com/antvis/S2/issues/2255
-    const indexes = this.spreadsheet.dataSet?.isEmpty?.()
-      ? ([] as unknown as Indexes)
-      : calculateInViewIndexes(
-          scrollX,
-          scrollY,
-          this.viewCellWidths,
-          this.viewCellHeights,
-          finalViewport,
-          this.getRealScrollX(this.cornerBBox.width),
-        );
+    const indexes =
+      this.spreadsheet.isTableMode() && this.spreadsheet.dataSet?.isEmpty?.()
+        ? this.spreadsheet.dataSet.getEmptyViewIndexes()
+        : calculateInViewIndexes(
+            scrollX,
+            scrollY,
+            this.viewCellWidths,
+            this.viewCellHeights,
+            finalViewport,
+            this.getRealScrollX(this.cornerBBox.width),
+          );
 
     this.panelScrollGroupIndexes = indexes;
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
ref: #2357 
明细表不需要默认的空结构，但是透视表的 Grid 模式 依旧需要，否则会出现单元格缺失

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/17964556/fae6296a-011f-4ad0-9d2b-f84ffb2e4732) ![image](https://github.com/antvis/S2/assets/17964556/6978d864-d4f2-4c44-99f1-fe573ea3ced9)      | ![image](https://github.com/antvis/S2/assets/17964556/5f46ff81-fd9c-4847-ae14-71173c252f80)![image](https://github.com/antvis/S2/assets/17964556/11b8134b-0263-4e16-8574-4c4b9af99411)![image](https://github.com/antvis/S2/assets/17964556/caa044ac-d720-4ece-be36-74151a791a66)|


     

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
