### PR TITLE
fix: 修复行头字段为空字符串时, getDimensionValues 获取数据错误的问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/empty-string-values-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/empty-string-values-spec.ts
@@ -1,0 +1,120 @@
+import { getContainer } from 'tests/util/helpers';
+import type { S2DataConfig, S2Options } from '@/common';
+import { PivotSheet, SpreadSheet } from '@/sheet-type';
+
+const s2Options: S2Options = {
+  debug: true,
+  width: 600,
+  height: 400,
+  hierarchyType: 'grid',
+  style: {
+    layoutWidthType: 'adaptive',
+    cellCfg: {
+      height: 30,
+    },
+  },
+};
+
+const testDataCfg: S2DataConfig = {
+  meta: [
+    {
+      field: 'first',
+      name: '一级维度',
+    },
+    {
+      field: 'second',
+      name: '二级维度',
+    },
+    {
+      field: 'number',
+      name: '数值',
+    },
+  ],
+  fields: {
+    rows: ['first', 'second'],
+    columns: [],
+    values: ['number'],
+    valueInCols: true,
+  },
+  data: [
+    {
+      first: '',
+      second: '维值1',
+      number: 100,
+    },
+    {
+      first: '',
+      second: '维值2',
+      number: 200,
+    },
+    {
+      first: null,
+      second: '维值3',
+      number: 300,
+    },
+    {
+      first: null,
+      second: '维值4',
+      number: 400,
+    },
+    {
+      first: '非空维度',
+      second: '维值5',
+      number: 500,
+    },
+    {
+      first: '非空维度',
+      second: '维值6',
+      number: 600,
+    },
+  ],
+};
+
+describe('Empty String Values Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    s2 = new PivotSheet(getContainer(), testDataCfg, s2Options);
+    s2.render();
+  });
+
+  test('should get correctly first dimension values', () => {
+    const values = s2.dataSet.getDimensionValues('first');
+    expect(values).toEqual(['', 'null', '非空维度']);
+  });
+
+  test('should get correctly second dimension values', () => {
+    const values = s2.dataSet.getDimensionValues('second');
+    expect(values).toEqual([
+      '维值1',
+      '维值2',
+      '维值3',
+      '维值4',
+      '维值5',
+      '维值6',
+    ]);
+  });
+
+  test('should get correctly second dimension values by specific query', () => {
+    let values = s2.dataSet.getDimensionValues('second', { first: '' });
+    expect(values).toEqual(['维值1', '维值2']);
+
+    values = s2.dataSet.getDimensionValues('second', { first: 'null' });
+    expect(values).toEqual(['维值3', '维值4']);
+
+    values = s2.dataSet.getDimensionValues('second', { first: '非空维度' });
+    expect(values).toEqual(['维值5', '维值6']);
+  });
+
+  test('should get correctly layout result', () => {
+    const nodes = s2.facet.layoutResult.rowLeafNodes;
+    expect(nodes.map((node) => node.id)).toEqual([
+      'root[&][&]维值1',
+      'root[&][&]维值2',
+      'root[&]null[&]维值3',
+      'root[&]null[&]维值4',
+      'root[&]非空维度[&]维值5',
+      'root[&]非空维度[&]维值6',
+    ]);
+  });
+});

--- a/packages/s2-core/src/utils/dataset/pivot-data-set.ts
+++ b/packages/s2-core/src/utils/dataset/pivot-data-set.ts
@@ -496,7 +496,7 @@ export function getSatisfiedPivotMetaValues(params: {
   for (let i = 0; i <= fieldIdx; i++) {
     const dimensionValue = dimensionValues[i];
     const field = fields[i];
-    if (!dimensionValue || dimensionValue === MULTI_VALUE) {
+    if (isMultiValue(dimensionValue)) {
       metaValueList = flattenMetaValue(metaValueList, field);
     } else {
       metaValueList = metaValueList


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

在做 `getDimensionValues` 查询时，意外的将空字符串作为了查全量的标志，导致查询结果有误，且命中了 flatten 逻辑，耗时较久
| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/17964556/11a1dacc-883a-40f9-8b16-a2e46320f91b) ![image](https://github.com/antvis/S2/assets/17964556/9059cf6d-04b1-4557-bf1d-06f2839d5a21)  | ![image](https://github.com/antvis/S2/assets/17964556/0b0740f7-1d8e-4722-94e7-680dfc87156f)![image](https://github.com/antvis/S2/assets/17964556/bb391903-d468-4364-ab68-c4674cedea0a)     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
