### PR TITLE
fix(table-sheet): 修复明细表配置自定义行高后展示异常 close #2501

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2501-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2501-spec.ts
@@ -1,0 +1,63 @@
+/**
+ * @description spec for issue #2501
+ * https://github.com/antvis/S2/issues/2501
+ */
+
+import type { TableFacet } from '../../src/facet';
+import * as mockDataConfig from '../data/simple-table-data.json';
+import { getContainer } from '../util/helpers';
+import type { SpreadSheet, S2DataConfig, S2Options } from '@/index';
+import { TableSheet } from '@/sheet-type';
+
+const s2DataConfig: S2DataConfig = {
+  ...mockDataConfig,
+};
+
+const s2Options: S2Options = {
+  width: 800,
+  height: 400,
+  style: {
+    rowCfg: {
+      heightByField: {
+        '0': 100,
+        '1': 150,
+      },
+    },
+  },
+};
+
+describe('Table Sheet Row Offsets Tests', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(() => {
+    s2 = new TableSheet(getContainer(), s2DataConfig, s2Options);
+
+    s2.render();
+  });
+
+  test('should get correctly row offset data', () => {
+    expect((s2.facet as TableFacet).rowOffsets).toMatchInlineSnapshot(`
+      Array [
+        0,
+        100,
+        250,
+        280,
+      ]
+    `);
+  });
+
+  test('should get correctly data cell offset for heightByField', () => {
+    const { getCellOffsetY, getTotalHeight } = s2.facet.getViewCellHeights();
+
+    expect(getCellOffsetY(0)).toEqual(0);
+    expect(getCellOffsetY(1)).toEqual(100);
+    expect(getCellOffsetY(2)).toEqual(250);
+    expect(getTotalHeight()).toEqual(280);
+  });
+
+  test('should get correctly row layout for heightByField', () => {
+    const { getTotalLength } = s2.facet.getViewCellHeights();
+
+    expect(getTotalLength()).toEqual(3);
+  });
+});

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -131,7 +131,7 @@ export abstract class BaseFacet {
   public abstract getContentHeight(): number;
 
   public abstract getViewCellHeights(
-    layoutResult: LayoutResult,
+    layoutResult?: LayoutResult,
   ): ViewCellHeights;
 
   protected scrollFrameId: ReturnType<typeof requestAnimationFrame> = null;

--- a/packages/s2-core/src/facet/frozen-facet.ts
+++ b/packages/s2-core/src/facet/frozen-facet.ts
@@ -634,9 +634,8 @@ export abstract class FrozenFacet extends BaseFacet {
     });
   }
 
-  protected init(): void {
+  protected init() {
     super.init();
-    this.initRowOffsets();
   }
 
   public render(): void {
@@ -688,27 +687,6 @@ export abstract class FrozenFacet extends BaseFacet {
     }
     return { colCount, trailingColCount };
   };
-
-  private initRowOffsets() {
-    const { dataSet } = this.cfg;
-    const heightByField = get(
-      this.spreadsheet,
-      'options.style.rowCfg.heightByField',
-      {},
-    );
-    if (Object.keys(heightByField).length) {
-      const data = dataSet.getDisplayDataSet();
-      this.rowOffsets = [0];
-      let lastOffset = 0;
-      data.forEach((_, idx) => {
-        const currentHeight =
-          heightByField?.[String(idx)] ?? this.getDefaultCellHeight();
-        const currentOffset = lastOffset + currentHeight;
-        this.rowOffsets.push(currentOffset);
-        lastOffset = currentOffset;
-      });
-    }
-  }
 
   public getTotalHeightForRange = (start: number, end: number) => {
     if (start < 0 || end < 0) {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->


🐛 Bugfix

- [x] Solve the issue and close #2501

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

在 https://github.com/antvis/S2/pull/2416 支持冻结首行后, 抽象了 `FrozenFacet` 类, 导致继承链路改变, 执行时序有问题, 在用户配置了 `rowCfg.heightByField` 后布局错误

```ts
const s2Options: S2Options = {
  style: {
    rowCfg: {
      heightByField: {
        '0': 100,
        '1': 150,
      },
    },
  },
};
```

```diff
public init() {
-  super.init();
-  this.initRowOffsets();

+  this.initRowOffsets();
+  super.init();
}
```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/8f6ff341-d899-42d1-8865-eee34588fdb3) | ![image](https://github.com/antvis/S2/assets/21015895/73fd8e50-9b32-4e5c-ab16-afc30001c0c7) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
