### PR TITLE
fix: 修复自定义目录树同名节点展示异常 & 导出缺失角头 close #2455

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/custom-cell-style-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/custom-cell-style-spec.ts.snap
@@ -411,37 +411,37 @@ exports[`SpreadSheet Custom Cell Style Tests TableSheet Custom Cell Style Tests 
 Array [
   Object {
     "height": 30,
-    "id": "root[&]地区",
+    "id": "root[&]area",
     "width": 180,
   },
   Object {
     "height": 30,
-    "id": "root[&]地区[&]省份",
+    "id": "root[&]area[&]province",
     "width": 100,
   },
   Object {
     "height": 30,
-    "id": "root[&]地区[&]城市",
+    "id": "root[&]area[&]city",
     "width": 80,
   },
   Object {
     "height": 60,
-    "id": "root[&]类型",
+    "id": "root[&]type",
     "width": 119.8,
   },
   Object {
     "height": 30,
-    "id": "root[&]金额",
+    "id": "root[&]money",
     "width": 210,
   },
   Object {
     "height": 30,
-    "id": "root[&]金额[&]价格",
+    "id": "root[&]money[&]price",
     "width": 90,
   },
   Object {
     "height": 30,
-    "id": "root[&]金额[&]数量",
+    "id": "root[&]money[&]number",
     "width": 120,
   },
 ]

--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/custom-tree-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/custom-tree-spec.ts.snap
@@ -33,11 +33,15 @@ exports[`SpreadSheet Custom Tree Tests should collapse node by collapsed 1`] = `
 Array [
   Object {
     "iconName": "Plus",
-    "id": "root[&]自定义节点A",
+    "id": "root[&]custom-node-1",
+    "isCollapsed": true,
+    "value": "自定义节点A",
   },
   Object {
     "iconName": "Plus",
-    "id": "root[&]指标E",
+    "id": "root[&]measure-e",
+    "isCollapsed": true,
+    "value": "指标E",
   },
 ]
 `;
@@ -46,19 +50,27 @@ exports[`SpreadSheet Custom Tree Tests should collapse node by collapsed field 1
 Array [
   Object {
     "iconName": "Minus",
-    "id": "root[&]自定义节点 a-1",
+    "id": "root[&]a-1",
+    "isCollapsed": false,
+    "value": "自定义节点 a-1",
   },
   Object {
     "iconName": "Plus",
-    "id": "root[&]自定义节点 a-1[&]自定义节点 a-1-1",
+    "id": "root[&]a-1[&]a-1-1",
+    "isCollapsed": true,
+    "value": "自定义节点 a-1-1",
   },
   Object {
     "iconName": undefined,
-    "id": "root[&]自定义节点 a-1[&]自定义节点 a-1-2",
+    "id": "root[&]a-1[&]a-1-2",
+    "isCollapsed": false,
+    "value": "自定义节点 a-1-2",
   },
   Object {
     "iconName": undefined,
-    "id": "root[&]自定义节点 a-2",
+    "id": "root[&]a-2",
+    "isCollapsed": false,
+    "value": "自定义节点 a-2",
   },
 ]
 `;
@@ -66,12 +78,40 @@ Array [
 exports[`SpreadSheet Custom Tree Tests should collapse node by collapsed fields id 1`] = `
 Array [
   Object {
-    "iconName": "Plus",
-    "id": "root[&]自定义节点 a-1",
+    "iconName": "Minus",
+    "id": "root[&]a-1",
+    "isCollapsed": false,
+    "value": "自定义节点 a-1",
+  },
+  Object {
+    "iconName": "Minus",
+    "id": "root[&]a-1[&]a-1-1",
+    "isCollapsed": false,
+    "value": "自定义节点 a-1-1",
   },
   Object {
     "iconName": undefined,
-    "id": "root[&]自定义节点 a-2",
+    "id": "root[&]a-1[&]a-1-1[&]measure-1",
+    "isCollapsed": false,
+    "value": "指标1",
+  },
+  Object {
+    "iconName": undefined,
+    "id": "root[&]a-1[&]a-1-1[&]measure-2",
+    "isCollapsed": false,
+    "value": "指标2",
+  },
+  Object {
+    "iconName": undefined,
+    "id": "root[&]a-1[&]a-1-2",
+    "isCollapsed": false,
+    "value": "自定义节点 a-1-2",
+  },
+  Object {
+    "iconName": undefined,
+    "id": "root[&]a-2",
+    "isCollapsed": false,
+    "value": "自定义节点 a-2",
   },
 ]
 `;
@@ -80,11 +120,44 @@ exports[`SpreadSheet Custom Tree Tests should collapse node by user collapseFiel
 Array [
   Object {
     "iconName": "Plus",
-    "id": "root[&]自定义节点A",
+    "id": "root[&]custom-node-1",
+    "isCollapsed": true,
+    "value": "自定义节点A",
   },
   Object {
     "iconName": "Plus",
-    "id": "root[&]指标E",
+    "id": "root[&]measure-e",
+    "isCollapsed": true,
+    "value": "指标E",
+  },
+]
+`;
+
+exports[`SpreadSheet Custom Tree Tests should only collapse first node by node id 1`] = `
+Array [
+  Object {
+    "iconName": "Plus",
+    "id": "root[&]custom-node-1",
+    "isCollapsed": true,
+    "value": "自定义节点A",
+  },
+  Object {
+    "iconName": "Minus",
+    "id": "root[&]measure-e",
+    "isCollapsed": false,
+    "value": "自定义节点A",
+  },
+  Object {
+    "iconName": undefined,
+    "id": "root[&]measure-e[&]custom-node-3",
+    "isCollapsed": false,
+    "value": "自定义节点C",
+  },
+  Object {
+    "iconName": "Plus",
+    "id": "root[&]measure-e[&]custom-node-4",
+    "isCollapsed": true,
+    "value": "自定义节点D",
   },
 ]
 `;

--- a/packages/s2-core/__tests__/spreadsheet/custom-cell-style-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/custom-cell-style-spec.ts
@@ -38,7 +38,7 @@ describe('SpreadSheet Custom Cell Style Tests', () => {
     });
 
     afterEach(() => {
-      // s2.destroy();
+      s2.destroy();
     });
 
     test('should render default cell style', () => {

--- a/packages/s2-core/__tests__/spreadsheet/custom-grid-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/custom-grid-spec.ts
@@ -144,9 +144,9 @@ describe('SpreadSheet Custom Grid Tests', () => {
       expect(s2.interaction.getActiveCells()).toHaveLength(1);
       // 高亮子节点
       expectHighlightActiveNodes(s2, [
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标1',
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标2',
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-2',
+        'root[&]a-1[&]a-1-1[&]measure-1',
+        'root[&]a-1[&]a-1-1[&]measure-2',
+        'root[&]a-1[&]a-1-2',
       ]);
 
       // 取消选中 a - 1
@@ -319,9 +319,9 @@ describe('SpreadSheet Custom Grid Tests', () => {
       expect(s2.interaction.getActiveCells()).toHaveLength(1);
       // 高亮子节点
       expectHighlightActiveNodes(s2, [
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标1',
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标2',
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-2',
+        'root[&]a-1[&]a-1-1[&]measure-1',
+        'root[&]a-1[&]a-1-1[&]measure-2',
+        'root[&]a-1[&]a-1-2',
       ]);
 
       // 取消选中 a - 1
@@ -374,9 +374,7 @@ describe('SpreadSheet Custom Grid Tests', () => {
     });
 
     test('should hide columns', async () => {
-      const hiddenColumns = [
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标2',
-      ];
+      const hiddenColumns = ['root[&]a-1[&]a-1-1[&]measure-2'];
 
       await waitForRender(s2, () => {
         s2.interaction.hideColumns(hiddenColumns);

--- a/packages/s2-core/__tests__/spreadsheet/custom-table-col-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/custom-table-col-spec.ts
@@ -126,8 +126,8 @@ describe('TableSheet Custom Tests', () => {
     expect(s2.interaction.getActiveCells()).toHaveLength(1);
     // 高亮子节点
     expectHighlightActiveNodes(s2, [
-      'root[&]地区[&]省份',
-      'root[&]地区[&]城市',
+      'root[&]area[&]province',
+      'root[&]area[&]city',
     ]);
 
     // 取消选中 a - 1
@@ -138,7 +138,7 @@ describe('TableSheet Custom Tests', () => {
   });
 
   test('should hide columns', async () => {
-    const hiddenColumns = ['root[&]金额[&]价格'];
+    const hiddenColumns = ['root[&]money[&]price'];
 
     await waitForRender(s2, () => {
       s2.interaction.hideColumns(hiddenColumns);

--- a/packages/s2-core/__tests__/spreadsheet/custom-tree-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/custom-tree-spec.ts
@@ -38,6 +38,8 @@ describe('SpreadSheet Custom Tree Tests', () => {
 
       return {
         id: node.id,
+        value: node.value,
+        isCollapsed: node.isCollapsed,
         iconName,
       };
     });
@@ -119,7 +121,7 @@ describe('SpreadSheet Custom Tree Tests', () => {
     // 选中单元格本身
     expect(s2.interaction.getActiveCells()).toHaveLength(1);
     // 高亮子节点
-    expectHighlightActiveNodes(s2, ['root[&]自定义节点 a-1']);
+    expectHighlightActiveNodes(s2, ['root[&]a-1']);
 
     // 取消选中 a - 1
     s2.interaction.selectHeaderCell({
@@ -158,11 +160,10 @@ describe('SpreadSheet Custom Tree Tests', () => {
 
   test('should render custom corner text by default title', async () => {
     s2.setDataCfg({
-      ...customRowDataCfg,
       meta: [],
     });
 
-    await s2.render();
+    await s2.render(true);
 
     const cornerCellLabels = getCornerCellLabels();
 
@@ -174,7 +175,6 @@ describe('SpreadSheet Custom Tree Tests', () => {
 
   test('should render custom corner text by meta formatter', async () => {
     s2.setDataCfg({
-      ...customRowDataCfg,
       meta: [
         {
           field: 'a-1',
@@ -187,7 +187,7 @@ describe('SpreadSheet Custom Tree Tests', () => {
       ],
     });
 
-    await s2.render();
+    await s2.render(true);
     const cornerCellLabels = getCornerCellLabels();
 
     expect(cornerCellLabels).toEqual(['文本1/文本2/数值', 'type']);
@@ -224,9 +224,7 @@ describe('SpreadSheet Custom Tree Tests', () => {
 
   test('should collapse node by collapsed', async () => {
     s2.setDataCfg({
-      ...customRowDataCfg,
       fields: {
-        ...s2.dataSet.fields,
         rows: customTreeNodes.map((node) => {
           return {
             ...node,
@@ -273,13 +271,42 @@ describe('SpreadSheet Custom Tree Tests', () => {
     const collapsedField = 'custom-node-1';
 
     s2.setDataCfg({
-      ...customRowDataCfg,
       fields: {
-        ...s2.dataSet.fields,
         rows: customTreeNodes.map((node) => {
           return {
             ...node,
             collapsed: node.field !== collapsedField,
+          };
+        }),
+      },
+    });
+
+    s2.setOptions({
+      style: {
+        rowCell: {
+          collapseFields: {
+            [collapsedField]: true,
+          },
+        },
+      },
+    });
+    await s2.render(true);
+
+    expect(mapRowNodes(s2)).toMatchSnapshot();
+  });
+
+  // https://github.com/antvis/S2/issues/2455
+  test('should only collapse first node by node id', async () => {
+    const collapsedField = 'custom-node-1';
+
+    s2.setDataCfg({
+      fields: {
+        rows: customTreeNodes.map((node) => {
+          return {
+            ...node,
+            // 让两个节点名一样
+            title: '自定义节点A',
+            collapsed: false,
           };
         }),
       },

--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -166,9 +166,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
     });
 
     test('should hide columns for multiple columns', async () => {
-      const hiddenColumns = [
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标1',
-      ];
+      const hiddenColumns = ['root[&]a-1[&]a-1-1[&]province'];
 
       tableSheet.setDataCfg({
         ...mockTableDataConfig,
@@ -528,9 +526,7 @@ describe('SpreadSheet Hidden Columns Tests', () => {
     });
 
     test('should hide columns for multiple columns', async () => {
-      const hiddenColumns = [
-        'root[&]自定义节点 a-1[&]自定义节点 a-1-1[&]指标1',
-      ];
+      const hiddenColumns = ['root[&]a-1[&]a-1-1[&]measure-1'];
 
       pivotSheet.setDataCfg({
         ...mockPivotDataConfig,

--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -457,8 +457,6 @@ describe('SpreadSheet Hidden Columns Tests', () => {
         .find((node) => node.isGrandTotals)!;
 
       const rootNode = pivotSheet.facet.getColNodeById('root[&]笔')!;
-      const parentNode = pivotSheet.facet.getColNodeById('root[&]笔[&]义乌')!;
-
       const hiddenColumnsInfo = pivotSheet.store.get('hiddenColumnsDetail')[0];
 
       expect(rootNode.width).toEqual(100);
@@ -466,7 +464,6 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       expect(grandTotalsNode.width).toEqual(100);
       expect(grandTotalsNode.x).toEqual(0);
       expect(hiddenColumnsInfo).toBeTruthy();
-      expect(parentNode.hiddenChildNodeInfo).toEqual(hiddenColumnsInfo);
     });
 
     // https://github.com/antvis/S2/issues/2355

--- a/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/pivot-facet-spec.ts
@@ -91,6 +91,7 @@ jest.mock('@/sheet-type', () => {
             [FrozenGroupType.FROZEN_TRAILING_COL]: {},
           },
           cornerBBox: {},
+          getHeaderNodes: jest.fn().mockReturnValue([]),
         },
         getCanvasElement: () =>
           container.getContextService().getDomElement() as HTMLCanvasElement,
@@ -152,6 +153,8 @@ describe('Pivot Mode Facet Test', () => {
     dataCell: (viewMeta) => new DataCell(viewMeta, s2),
   });
   const facet = new PivotFacet(s2);
+
+  s2.facet = facet;
 
   beforeEach(async () => {
     await s2.container.ready;

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -59,6 +59,7 @@ jest.mock('@/sheet-type', () => {
           getColNodes: jest.fn().mockReturnValue([]),
           getHiddenColumnsInfo: jest.fn(),
           getColNodeHeight: jest.fn(),
+          getHeaderNodes: jest.fn().mockReturnValue([]),
         },
         dataSet: {
           isEmpty: jest.fn(),

--- a/packages/s2-core/__tests__/unit/utils/__snapshots__/tooltip-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/__snapshots__/tooltip-spec.ts.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tooltip Utils Tests Tooltip Get Data Tests Tooltip Description Tests should get col cell descriptions 1`] = `
+Object {
+  "description": "类别说明。。",
+  "details": null,
+  "headInfo": null,
+  "infos": undefined,
+  "interpretation": undefined,
+  "name": null,
+  "summaries": Array [],
+  "tips": undefined,
+}
+`;
+
+exports[`Tooltip Utils Tests Tooltip Get Data Tests Tooltip Description Tests should get data cell description 1`] = `
+Object {
+  "description": "数量说明。。",
+  "details": null,
+  "headInfo": null,
+  "infos": undefined,
+  "interpretation": undefined,
+  "name": null,
+  "summaries": Array [],
+  "tips": undefined,
+}
+`;
+
+exports[`Tooltip Utils Tests Tooltip Get Data Tests Tooltip Description Tests should get row cell description 1`] = `
+Object {
+  "description": "省份说明。。",
+  "details": null,
+  "headInfo": null,
+  "infos": undefined,
+  "interpretation": undefined,
+  "name": null,
+  "summaries": Array [
+    Object {
+      "name": "数量",
+      "originValue": 15420,
+      "selectedData": Array [
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "city": "杭州市",
+            "number": 7789,
+            "province": "浙江省",
+            "sub_type": "桌子",
+            "type": "家具",
+          },
+        },
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "city": "杭州市",
+            "number": 5343,
+            "province": "浙江省",
+            "sub_type": "沙发",
+            "type": "家具",
+          },
+        },
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "city": "杭州市",
+            "number": 945,
+            "province": "浙江省",
+            "sub_type": "笔",
+            "type": "办公用品",
+          },
+        },
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "city": "杭州市",
+            "number": 1343,
+            "province": "浙江省",
+            "sub_type": "纸张",
+            "type": "办公用品",
+          },
+        },
+      ],
+      "value": 15420,
+    },
+  ],
+  "tips": undefined,
+}
+`;
+
+exports[`Tooltip Utils Tests Tooltip Get Data Tests should get custom tree row cell summary data 1`] = `
+Object {
+  "description": "指标1描述",
+  "details": null,
+  "headInfo": null,
+  "infos": undefined,
+  "interpretation": undefined,
+  "name": null,
+  "summaries": Array [
+    Object {
+      "name": "指标1",
+      "selectedData": Array [
+        CellData {
+          "extraField": "measure-1",
+          "raw": Object {
+            "measure-1": 13,
+            "measure-2": 2,
+            "measure-3": 3,
+            "measure-4": 4,
+            "measure-5": 5,
+            "measure-6": 6,
+            "sub_type": "桌子",
+            "type": "家具",
+          },
+        },
+        CellData {
+          "extraField": "measure-1",
+          "raw": Object {
+            "measure-1": 11,
+            "measure-2": 8,
+            "measure-3": 32,
+            "measure-4": 43,
+            "measure-5": 45,
+            "measure-6": 65,
+            "sub_type": "椅子",
+            "type": "家具",
+          },
+        },
+      ],
+      "value": 24,
+    },
+  ],
+  "tips": undefined,
+}
+`;
+
+exports[`Tooltip Utils Tests Tooltip Get Data Tests should get grand totals row cell summary data 1`] = `
+Object {
+  "description": undefined,
+  "details": null,
+  "headInfo": null,
+  "infos": undefined,
+  "interpretation": undefined,
+  "name": null,
+  "summaries": Array [
+    Object {
+      "name": "数量",
+      "originValue": 78868,
+      "selectedData": Array [
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "number": 26193,
+            "sub_type": "桌子",
+            "type": "家具",
+          },
+        },
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "number": 23516,
+            "sub_type": "沙发",
+            "type": "家具",
+          },
+        },
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "number": 12321,
+            "sub_type": "笔",
+            "type": "办公用品",
+          },
+        },
+        CellData {
+          "extraField": "number",
+          "raw": Object {
+            "number": 16838,
+            "sub_type": "纸张",
+            "type": "办公用品",
+          },
+        },
+      ],
+      "value": 78868,
+    },
+  ],
+  "tips": undefined,
+}
+`;

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/copy-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/copy-spec.ts.snap
@@ -180,6 +180,26 @@ Array [
 ]
 `;
 
+exports[`Pivot Table getBrushHeaderCopyable should copy all original row data in tree mode if contains text ellipses 1`] = `
+Array [
+  Object {
+    "content": "浙江省	杭州市
+浙江省	绍兴市
+浙江省	宁波市
+浙江省	舟山市
+四川省	成都市
+四川省	绵阳市
+四川省	南充市
+四川省	乐山市",
+    "type": "text/plain",
+  },
+  Object {
+    "content": "<meta charset=\\"utf-8\\"><table><tbody><tr><td>浙江省</td><td>杭州市</td></tr><tr><td>浙江省</td><td>绍兴市</td></tr><tr><td>浙江省</td><td>宁波市</td></tr><tr><td>浙江省</td><td>舟山市</td></tr><tr><td>四川省</td><td>成都市</td></tr><tr><td>四川省</td><td>绵阳市</td></tr><tr><td>四川省</td><td>南充市</td></tr><tr><td>四川省</td><td>乐山市</td></tr></tbody></table>",
+    "type": "text/html",
+  },
+]
+`;
+
 exports[`Pivot Table getBrushHeaderCopyable should copy all row data in grid mode 1`] = `
 "浙江省	杭州市
 浙江省	绍兴市
@@ -200,6 +220,22 @@ exports[`Pivot Table getBrushHeaderCopyable should copy all row data in grid mod
 四川省	绵阳市	数值
 四川省	南充市	数值
 四川省	乐山市	数值"
+`;
+
+exports[`Pivot Table getBrushHeaderCopyable should copy all row data in tree mode 1`] = `
+"浙江省	杭州市
+浙江省	绍兴市
+浙江省	宁波市
+浙江省	舟山市
+四川省	成都市
+四川省	绵阳市
+四川省	南充市
+四川省	乐山市"
+`;
+
+exports[`Pivot Table getBrushHeaderCopyable should copy all row data in tree mode for custom row cell 1`] = `
+"层级1	自定义节点 a-1-1	指标1
+层级1	自定义节点 a-1-1	指标2"
 `;
 
 exports[`Pivot Table getBrushHeaderCopyable should copy col total data in grid mode 1`] = `
@@ -267,6 +303,15 @@ exports[`Tree Table Core Data Process should copy all data in tree mode 1`] = `
 1943	2333	4276	2457	3551	6008	10284
 2330	2445	4775	2458	352	2810	7585
 26193	23516	49709	12321	16838	29159	78868"
+`;
+
+exports[`Tree Table Core Data Process should copy all data in tree mode for custom row cell 1`] = `
+"			
+			
+13	11		
+2	8		
+			
+			"
 `;
 
 exports[`Tree Table Core Data Process should copy all data in tree mode with format 1`] = `

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-spec.ts.snap
@@ -16,6 +16,26 @@ Array [
 ]
 `;
 
+exports[`PivotSheet Export Test should export correct data in tree mode for custom row cell 1`] = `
+Array [
+  "			家具	家具
+",
+  "			桌子	椅子
+",
+  "层级1				
+",
+  "层级1	自定义节点 a-1-1			
+",
+  "层级1	自定义节点 a-1-1	指标1	13	11
+",
+  "层级1	自定义节点 a-1-1	指标2	2	8
+",
+  "层级1	自定义节点 a-1-2			
+",
+  "层级2				",
+]
+`;
+
 exports[`TableSheet Export Test should export correct data with no series number 1`] = `
 Array [
   "province	city	type	sub_type	number

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-spec.ts.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PivotSheet Export Test Custom Tree Export Test should export correct data in grid mode for custom row cell 1`] = `
+Array [
+  "		类型	家具	家具
+",
+  "层级1	自定义节点 a-1-1	指标1	桌子	椅子
+",
+  "层级1	自定义节点 a-1-1	指标1	13	11
+",
+  "层级1	自定义节点 a-1-1	指标2	2	8
+",
+  "层级1	自定义节点 a-1-2			
+",
+  "层级2				",
+]
+`;
+
+exports[`PivotSheet Export Test Custom Tree Export Test should export correct data in tree mode for custom row cell 1`] = `
+Array [
+  "		类型	家具	家具
+",
+  "		层级1/层级2/数值	桌子	椅子
+",
+  "层级1				
+",
+  "层级1	自定义节点 a-1-1			
+",
+  "层级1	自定义节点 a-1-1	指标1	13	11
+",
+  "层级1	自定义节点 a-1-1	指标2	2	8
+",
+  "层级1	自定义节点 a-1-2			
+",
+  "层级2				",
+]
+`;
+
+exports[`PivotSheet Export Test Custom Tree Export Test should export correct data in tree mode for custom row cell and custom corner text 1`] = `
+Array [
+  "		类型	家具	家具
+",
+  "		自定义	桌子	椅子
+",
+  "层级1				
+",
+  "层级1	自定义节点 a-1-1			
+",
+  "层级1	自定义节点 a-1-1	指标1	13	11
+",
+  "层级1	自定义节点 a-1-1	指标2	2	8
+",
+  "层级1	自定义节点 a-1-2			
+",
+  "层级2				",
+]
+`;
+
 exports[`PivotSheet Export Test should export correct $$extra$$ field name 1`] = `
 Array [
   "type",
@@ -13,26 +69,6 @@ Array [
   "数值",
   "数值
 ",
-]
-`;
-
-exports[`PivotSheet Export Test should export correct data in tree mode for custom row cell 1`] = `
-Array [
-  "			家具	家具
-",
-  "			桌子	椅子
-",
-  "层级1				
-",
-  "层级1	自定义节点 a-1-1			
-",
-  "层级1	自定义节点 a-1-1	指标1	13	11
-",
-  "层级1	自定义节点 a-1-1	指标2	2	8
-",
-  "层级1	自定义节点 a-1-2			
-",
-  "层级2				",
 ]
 `;
 

--- a/packages/s2-core/__tests__/unit/utils/export/export-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-spec.ts
@@ -1,4 +1,7 @@
+import type { S2DataConfig } from '../../../../src';
 import { asyncGetAllPlainData } from '../../../../src/utils';
+import { customRowGridSimpleFields } from '../../../data/custom-grid-simple-fields';
+import { CustomGridData } from '../../../data/data-custom-grid';
 import { assembleDataCfg, assembleOptions } from '../../../util';
 import { getContainer } from '../../../util/helpers';
 import { PivotSheet, TableSheet } from '@/sheet-type';
@@ -473,5 +476,47 @@ describe('PivotSheet Export Test', () => {
     const headers = rows[2].split('\t');
 
     expect(headers).toMatchSnapshot();
+  });
+
+  it('should export correct data in tree mode for custom row cell', async () => {
+    const customRowDataCfg: S2DataConfig = {
+      data: CustomGridData,
+      meta: [
+        {
+          field: 'type',
+          name: '类型',
+        },
+        {
+          field: 'sub_type',
+          name: '子类型',
+        },
+        {
+          field: 'a-1',
+          name: '层级1',
+        },
+        {
+          field: 'a-2',
+          name: '层级2',
+        },
+      ],
+      fields: customRowGridSimpleFields,
+    };
+
+    const s2 = new PivotSheet(
+      getContainer(),
+      customRowDataCfg,
+      assembleOptions({
+        hierarchyType: 'tree',
+      }),
+    );
+
+    await s2.render();
+    const data = await asyncGetAllPlainData({
+      sheetInstance: s2,
+      split: '\t',
+    });
+    const rows = data.split('\n');
+
+    expect(rows).toMatchSnapshot();
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/export/export-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-spec.ts
@@ -1,4 +1,4 @@
-import type { S2DataConfig } from '../../../../src';
+import type { S2DataConfig, SpreadSheet } from '../../../../src';
 import { asyncGetAllPlainData } from '../../../../src/utils';
 import { customRowGridSimpleFields } from '../../../data/custom-grid-simple-fields';
 import { CustomGridData } from '../../../data/data-custom-grid';
@@ -478,45 +478,72 @@ describe('PivotSheet Export Test', () => {
     expect(headers).toMatchSnapshot();
   });
 
-  it('should export correct data in tree mode for custom row cell', async () => {
-    const customRowDataCfg: S2DataConfig = {
-      data: CustomGridData,
-      meta: [
-        {
-          field: 'type',
-          name: '类型',
-        },
-        {
-          field: 'sub_type',
-          name: '子类型',
-        },
-        {
-          field: 'a-1',
-          name: '层级1',
-        },
-        {
-          field: 'a-2',
-          name: '层级2',
-        },
-      ],
-      fields: customRowGridSimpleFields,
+  describe('Custom Tree Export Test', () => {
+    let s2: SpreadSheet;
+
+    const getResult = async () => {
+      const data = await asyncGetAllPlainData({
+        sheetInstance: s2,
+        split: '\t',
+      });
+
+      return data.split('\n');
     };
 
-    const s2 = new PivotSheet(
-      getContainer(),
-      customRowDataCfg,
-      assembleOptions({
-        hierarchyType: 'tree',
-      }),
-    );
+    beforeEach(async () => {
+      const customRowDataCfg: S2DataConfig = {
+        data: CustomGridData,
+        meta: [
+          {
+            field: 'type',
+            name: '类型',
+          },
+          {
+            field: 'sub_type',
+            name: '子类型',
+          },
+          {
+            field: 'a-1',
+            name: '层级1',
+          },
+          {
+            field: 'a-2',
+            name: '层级2',
+          },
+        ],
+        fields: customRowGridSimpleFields,
+      };
 
-    await s2.render();
-    const data = await asyncGetAllPlainData({
-      sheetInstance: s2,
-      split: '\t',
+      s2 = new PivotSheet(getContainer(), customRowDataCfg, assembleOptions());
+
+      await s2.render();
     });
-    const rows = data.split('\n');
 
-    expect(rows).toMatchSnapshot();
+    it('should export correct data in grid mode for custom row cell', async () => {
+      s2.setOptions({ hierarchyType: 'grid' });
+      await s2.render(false);
+
+      const rows = await getResult();
+
+      expect(rows).toMatchSnapshot();
+    });
+
+    it('should export correct data in tree mode for custom row cell', async () => {
+      s2.setOptions({ hierarchyType: 'tree' });
+      await s2.render(false);
+
+      const rows = await getResult();
+
+      expect(rows).toMatchSnapshot();
+    });
+
+    it('should export correct data in tree mode for custom row cell and custom corner text', async () => {
+      s2.setOptions({ hierarchyType: 'tree', cornerText: '自定义' });
+      await s2.render(false);
+
+      const rows = await getResult();
+
+      expect(rows).toMatchSnapshot();
+    });
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/tooltip-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/tooltip-spec.ts
@@ -7,6 +7,8 @@ import {
 } from 'tests/util/helpers';
 import { omit } from 'lodash';
 import * as dataConfig from 'tests/data/mock-dataset.json';
+import { customRowGridSimpleFields } from '../../data/custom-grid-simple-fields';
+import { CustomGridData } from '../../data/data-custom-grid';
 import { CellData } from '@/data-set/cell-data';
 import type { CellMeta } from '@/common/interface/interaction';
 import {
@@ -777,6 +779,7 @@ describe('Tooltip Utils Tests', () => {
       const tooltipData = getMockTooltipData(grandTotalRowCell!);
 
       expect(tooltipData.summaries?.[0].value).toStrictEqual(78868);
+      expect(tooltipData).toMatchSnapshot();
 
       s2.destroy();
     });
@@ -807,6 +810,49 @@ describe('Tooltip Utils Tests', () => {
       },
     );
 
+    // https://github.com/antvis/S2/issues/2455
+    test('should get custom tree row cell summary data', async () => {
+      const customRowDataCfg: S2DataConfig = {
+        data: CustomGridData,
+        meta: [
+          {
+            field: 'type',
+            name: '类型',
+          },
+          {
+            field: 'sub_type',
+            name: '子类型',
+          },
+          {
+            field: 'a-1',
+            name: '层级1',
+          },
+          {
+            field: 'a-2',
+            name: '层级2',
+          },
+        ],
+        fields: customRowGridSimpleFields,
+      };
+
+      s2 = new PivotSheet(getContainer(), customRowDataCfg, {
+        width: 600,
+        height: 600,
+        hierarchyType: 'tree',
+      });
+      await s2.render();
+
+      const measureRowCell = s2.facet.getRowCells().find((cell) => {
+        const meta = cell.getMeta();
+
+        return meta.field === 'measure-1';
+      });
+
+      const tooltipData = getMockTooltipData(measureRowCell!);
+
+      expect(tooltipData).toMatchSnapshot();
+    });
+
     describe('Tooltip Description Tests', () => {
       afterEach(() => {
         s2.destroy();
@@ -821,6 +867,7 @@ describe('Tooltip Utils Tests', () => {
         const tooltipData = getMockTooltipData(rowCell);
 
         expect(tooltipData.description).toEqual('省份说明。。');
+        expect(tooltipData).toMatchSnapshot();
       });
 
       test('should get col cell descriptions', async () => {
@@ -832,6 +879,7 @@ describe('Tooltip Utils Tests', () => {
         const tooltipData = getMockTooltipData(colCell);
 
         expect(tooltipData.description).toEqual('类别说明。。');
+        expect(tooltipData).toMatchSnapshot();
       });
 
       test('should get data cell description', async () => {
@@ -843,6 +891,7 @@ describe('Tooltip Utils Tests', () => {
         const tooltipData = getMockTooltipData(dataCell);
 
         expect(tooltipData.description).toEqual('数量说明。。');
+        expect(tooltipData).toMatchSnapshot();
       });
 
       test.each(['isTotals', 'isSubTotals', 'isGrandTotals'])(

--- a/packages/s2-core/src/data-set/base-data-set.ts
+++ b/packages/s2-core/src/data-set/base-data-set.ts
@@ -109,9 +109,11 @@ export abstract class BaseDataSet {
   public getFieldName(field: CustomHeaderField, defaultValue?: string): string {
     const realField = this.getField(field);
     // 兼容自定义行列头场景
-    const headerNode = this.spreadsheet.facet?.getHeaderNodes().find((node) => {
-      return node.field === realField && node?.extra?.isCustomNode;
-    });
+    const headerNode = this.spreadsheet?.facet
+      ?.getHeaderNodes()
+      .find((node) => {
+        return node.field === realField && node?.extra?.isCustomNode;
+      });
     const realDefaultValue =
       headerNode?.value ||
       (isString(field) ? field : field?.title) ||

--- a/packages/s2-core/src/data-set/base-data-set.ts
+++ b/packages/s2-core/src/data-set/base-data-set.ts
@@ -108,8 +108,14 @@ export abstract class BaseDataSet {
    */
   public getFieldName(field: CustomHeaderField, defaultValue?: string): string {
     const realField = this.getField(field);
+    // 兼容自定义行列头场景
+    const headerNode = this.spreadsheet.facet?.getHeaderNodes().find((node) => {
+      return node.field === realField && node?.extra?.isCustomNode;
+    });
     const realDefaultValue =
-      (isString(field) ? field : field?.title) || (field as string);
+      headerNode?.value ||
+      (isString(field) ? field : field?.title) ||
+      (field as string);
 
     return get(
       this.getFieldMeta(realField, this.meta),

--- a/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
@@ -33,10 +33,10 @@ export const buildCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
       return;
     }
 
-    // query只与值本身有关，不会涉及到 parent节点
+    // query 只与值本身有关，不会涉及到 parent 节点
     const valueQuery = { [EXTRA_FIELD]: field };
-    // 保持和其他场景头部生成id的格式一致
-    const nodeId = generateId(parentNode.id, title || field);
+    // 使用 field 作为 id, 保证其唯一性, 复制时再做二次转换
+    const nodeId = generateId(parentNode.id, field);
 
     const defaultCollapsed = collapsed ?? false;
     const isDefaultCollapsed =

--- a/packages/s2-core/src/facet/layout/node.ts
+++ b/packages/s2-core/src/facet/layout/node.ts
@@ -133,8 +133,6 @@ export class Node {
 
   public isTotalRoot?: boolean;
 
-  public hiddenChildNodeInfo?: HiddenColumnsInfo | null;
-
   public isFrozen?: boolean;
 
   public extra?: {

--- a/packages/s2-core/src/utils/export/copy/base-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/base-data-cell-copy.ts
@@ -9,7 +9,6 @@ import { type DataItem, NewTab } from '../../../common';
 import { CopyMIMEType } from '../../../common/interface/export';
 import { unifyConfig } from './common';
 
-// BaseDataCellCopy class
 export abstract class BaseDataCellCopy {
   protected spreadsheet: SpreadSheet;
 

--- a/packages/s2-core/src/utils/export/copy/pivot-header-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-header-copy.ts
@@ -75,12 +75,13 @@ export function getBrushHeaderCopyable(
 
   // 拼接选中行列头的内容矩阵
   const isCol = interactedCells[0].cellType === CellType.COL_CELL;
-  let cellMatrix = getHeaderCellMatrix(lastLevelCells, maxLevel, allLevels);
-
+  const headerCellMatrix = getHeaderCellMatrix(
+    lastLevelCells,
+    maxLevel,
+    allLevels,
+  );
   // 如果是列头，需要转置
-  if (isCol) {
-    cellMatrix = zip(...cellMatrix) as string[][];
-  }
+  const cellMatrix = isCol ? zip(...headerCellMatrix) : headerCellMatrix;
 
   return [
     matrixPlainTextTransformer(cellMatrix),

--- a/packages/s2-core/src/utils/export/method.ts
+++ b/packages/s2-core/src/utils/export/method.ts
@@ -28,7 +28,6 @@ export const convertString = (value: DataItem) => {
 /**
  * 获取 intersection cell 所有的层级
  * @param {(RowCell | ColCell)[]} interactedCells
- * @returns { Set<number>} allLevels
  */
 export function getAllLevels(interactedCells: (RowCell | ColCell)[]) {
   const allLevels = new Set<number>();

--- a/packages/s2-core/src/utils/layout/generate-header-nodes.ts
+++ b/packages/s2-core/src/utils/layout/generate-header-nodes.ts
@@ -86,7 +86,6 @@ export const generateHeaderNodes = (params: HeaderNodesParams) => {
       return;
     }
 
-    // TODO need merge with collapseFields
     const isCollapsed = false;
     // create new header nodes
     const node = new Node({
@@ -116,11 +115,6 @@ export const generateHeaderNodes = (params: HeaderNodesParams) => {
 
     // 如果当前是隐藏节点, 给其父节点挂载相应信息 (兄弟节点, 当前哪个子节点隐藏了), 这样在 facet 层可以直接使用, 不用每次都去遍历
     const hiddenColumnsInfo = spreadsheet?.facet?.getHiddenColumnsInfo(node);
-
-    if (hiddenColumnsInfo && parentNode) {
-      // hiddenChildNodeInfo 属性在 S2 中没有用到，但是没删怕外部有使用，已标记为废弃
-      parentNode.hiddenChildNodeInfo = hiddenColumnsInfo;
-    }
 
     // omit the the whole column or row of the grandTotal or subTotals
     if (

--- a/packages/s2-react/__tests__/data/custom-tree-fields.ts
+++ b/packages/s2-react/__tests__/data/custom-tree-fields.ts
@@ -52,7 +52,7 @@ export const customTreeFields: S2DataConfig['fields'] = {
     },
     {
       field: 'measure-e',
-      title: '自定义节点A',
+      title: '自定义节点E',
       description: '指标E描述',
       children: [
         {

--- a/packages/s2-react/__tests__/unit/components/header/__snapshots__/index-spec.tsx.snap
+++ b/packages/s2-react/__tests__/unit/components/header/__snapshots__/index-spec.tsx.snap
@@ -3,56 +3,39 @@
 exports[`Header Component Tests should render component 1`] = `
 <DocumentFragment>
   <div
-    class="antv-s2-header test"
+    class="css-dev-only-do-not-override-p7e5j5 ant-app"
   >
     <div
-      class="antv-s2-header-heading"
+      class="antv-s2-header test"
     >
       <div
-        class="antv-s2-header-heading-left"
+        class="antv-s2-header-heading"
       >
         <div
-          class="antv-s2-header-heading-title"
+          class="antv-s2-header-heading-left"
         >
-          title
+          <div
+            class="antv-s2-header-heading-title"
+          >
+            title
+          </div>
         </div>
-      </div>
-      <div
-        class="antv-s2-header-heading-extra"
-      >
         <div
-          class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+          class="antv-s2-header-heading-extra"
         >
           <div
-            class="ant-space-item"
-          >
-            extra
-          </div>
-          <div
-            class="ant-space-item"
-          >
-            <button
-              class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
-              type="button"
-            >
-              <span
-                class="ant-btn-icon"
-              >
-                <div />
-              </span>
-              <span>
-                行列切换
-              </span>
-            </button>
-          </div>
-          <div
-            class="ant-space-item"
+            class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
           >
             <div
-              class="antv-s2-advanced-sort"
+              class="ant-space-item"
+            >
+              extra
+            </div>
+            <div
+              class="ant-space-item"
             >
               <button
-                class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
                 type="button"
               >
                 <span
@@ -61,27 +44,48 @@ exports[`Header Component Tests should render component 1`] = `
                   <div />
                 </span>
                 <span>
-                  高级排序
+                  行列切换
                 </span>
               </button>
             </div>
-          </div>
-          <div
-            class="ant-space-item"
-          >
-            <button
-              class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
-              type="button"
+            <div
+              class="ant-space-item"
             >
-              <div />
-            </button>
+              <div
+                class="antv-s2-advanced-sort"
+              >
+                <button
+                  class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                  type="button"
+                >
+                  <span
+                    class="ant-btn-icon"
+                  >
+                    <div />
+                  </span>
+                  <span>
+                    高级排序
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="ant-space-item"
+            >
+              <button
+                class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
+                type="button"
+              >
+                <div />
+              </button>
+            </div>
           </div>
         </div>
       </div>
+      <div
+        class="antv-s2-header-content"
+      />
     </div>
-    <div
-      class="antv-s2-header-content"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/packages/s2-react/__tests__/unit/components/sheets/__snapshots__/index-spec.tsx.snap
+++ b/packages/s2-react/__tests__/unit/components/sheets/__snapshots__/index-spec.tsx.snap
@@ -12,50 +12,33 @@ exports[`<SheetComponent/> Tests Render Tests should render editable sheet by sn
         class="antv-s2-wrapper"
       >
         <div
-          class="antv-s2-header"
-          style="width: 200px;"
+          class="css-dev-only-do-not-override-p7e5j5 ant-app"
         >
           <div
-            class="antv-s2-header-heading"
+            class="antv-s2-header"
+            style="width: 200px;"
           >
             <div
-              class="antv-s2-header-heading-left"
+              class="antv-s2-header-heading"
             >
               <div
-                class="antv-s2-header-heading-title"
-              />
-            </div>
-            <div
-              class="antv-s2-header-heading-extra"
-            >
-              <div
-                class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                class="antv-s2-header-heading-left"
               >
                 <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
-                    type="button"
-                  >
-                    <span
-                      class="ant-btn-icon"
-                    >
-                      <div />
-                    </span>
-                    <span>
-                      行列切换
-                    </span>
-                  </button>
-                </div>
+                  class="antv-s2-header-heading-title"
+                />
+              </div>
+              <div
+                class="antv-s2-header-heading-extra"
+              >
                 <div
-                  class="ant-space-item"
+                  class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                 >
                   <div
-                    class="antv-s2-advanced-sort"
+                    class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
                       type="button"
                     >
                       <span
@@ -64,27 +47,48 @@ exports[`<SheetComponent/> Tests Render Tests should render editable sheet by sn
                         <div />
                       </span>
                       <span>
-                        高级排序
+                        行列切换
                       </span>
                     </button>
                   </div>
-                </div>
-                <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
-                    type="button"
+                  <div
+                    class="ant-space-item"
                   >
-                    <div />
-                  </button>
+                    <div
+                      class="antv-s2-advanced-sort"
+                    >
+                      <button
+                        class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                        type="button"
+                      >
+                        <span
+                          class="ant-btn-icon"
+                        >
+                          <div />
+                        </span>
+                        <span>
+                          高级排序
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
+                      type="button"
+                    >
+                      <div />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              class="antv-s2-header-content"
+            />
           </div>
-          <div
-            class="antv-s2-header-content"
-          />
         </div>
         <div
           class="antv-s2-container"
@@ -276,50 +280,33 @@ exports[`<SheetComponent/> Tests Render Tests should render gridAnalysis sheet b
         class="antv-s2-wrapper"
       >
         <div
-          class="antv-s2-header"
-          style="width: 200px;"
+          class="css-dev-only-do-not-override-p7e5j5 ant-app"
         >
           <div
-            class="antv-s2-header-heading"
+            class="antv-s2-header"
+            style="width: 200px;"
           >
             <div
-              class="antv-s2-header-heading-left"
+              class="antv-s2-header-heading"
             >
               <div
-                class="antv-s2-header-heading-title"
-              />
-            </div>
-            <div
-              class="antv-s2-header-heading-extra"
-            >
-              <div
-                class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                class="antv-s2-header-heading-left"
               >
                 <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
-                    type="button"
-                  >
-                    <span
-                      class="ant-btn-icon"
-                    >
-                      <div />
-                    </span>
-                    <span>
-                      行列切换
-                    </span>
-                  </button>
-                </div>
+                  class="antv-s2-header-heading-title"
+                />
+              </div>
+              <div
+                class="antv-s2-header-heading-extra"
+              >
                 <div
-                  class="ant-space-item"
+                  class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                 >
                   <div
-                    class="antv-s2-advanced-sort"
+                    class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
                       type="button"
                     >
                       <span
@@ -328,27 +315,48 @@ exports[`<SheetComponent/> Tests Render Tests should render gridAnalysis sheet b
                         <div />
                       </span>
                       <span>
-                        高级排序
+                        行列切换
                       </span>
                     </button>
                   </div>
-                </div>
-                <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
-                    type="button"
+                  <div
+                    class="ant-space-item"
                   >
-                    <div />
-                  </button>
+                    <div
+                      class="antv-s2-advanced-sort"
+                    >
+                      <button
+                        class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                        type="button"
+                      >
+                        <span
+                          class="ant-btn-icon"
+                        >
+                          <div />
+                        </span>
+                        <span>
+                          高级排序
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
+                      type="button"
+                    >
+                      <div />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              class="antv-s2-header-content"
+            />
           </div>
-          <div
-            class="antv-s2-header-content"
-          />
         </div>
         <div
           class="antv-s2-container"
@@ -530,50 +538,33 @@ exports[`<SheetComponent/> Tests Render Tests should render pivot sheet by snaps
         class="antv-s2-wrapper"
       >
         <div
-          class="antv-s2-header"
-          style="width: 200px;"
+          class="css-dev-only-do-not-override-p7e5j5 ant-app"
         >
           <div
-            class="antv-s2-header-heading"
+            class="antv-s2-header"
+            style="width: 200px;"
           >
             <div
-              class="antv-s2-header-heading-left"
+              class="antv-s2-header-heading"
             >
               <div
-                class="antv-s2-header-heading-title"
-              />
-            </div>
-            <div
-              class="antv-s2-header-heading-extra"
-            >
-              <div
-                class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                class="antv-s2-header-heading-left"
               >
                 <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
-                    type="button"
-                  >
-                    <span
-                      class="ant-btn-icon"
-                    >
-                      <div />
-                    </span>
-                    <span>
-                      行列切换
-                    </span>
-                  </button>
-                </div>
+                  class="antv-s2-header-heading-title"
+                />
+              </div>
+              <div
+                class="antv-s2-header-heading-extra"
+              >
                 <div
-                  class="ant-space-item"
+                  class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                 >
                   <div
-                    class="antv-s2-advanced-sort"
+                    class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
                       type="button"
                     >
                       <span
@@ -582,27 +573,48 @@ exports[`<SheetComponent/> Tests Render Tests should render pivot sheet by snaps
                         <div />
                       </span>
                       <span>
-                        高级排序
+                        行列切换
                       </span>
                     </button>
                   </div>
-                </div>
-                <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
-                    type="button"
+                  <div
+                    class="ant-space-item"
                   >
-                    <div />
-                  </button>
+                    <div
+                      class="antv-s2-advanced-sort"
+                    >
+                      <button
+                        class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                        type="button"
+                      >
+                        <span
+                          class="ant-btn-icon"
+                        >
+                          <div />
+                        </span>
+                        <span>
+                          高级排序
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
+                      type="button"
+                    >
+                      <div />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              class="antv-s2-header-content"
+            />
           </div>
-          <div
-            class="antv-s2-header-content"
-          />
         </div>
         <div
           class="antv-s2-container"
@@ -784,50 +796,33 @@ exports[`<SheetComponent/> Tests Render Tests should render strategy sheet by sn
         class="antv-s2-wrapper"
       >
         <div
-          class="antv-s2-header"
-          style="width: 200px;"
+          class="css-dev-only-do-not-override-p7e5j5 ant-app"
         >
           <div
-            class="antv-s2-header-heading"
+            class="antv-s2-header"
+            style="width: 200px;"
           >
             <div
-              class="antv-s2-header-heading-left"
+              class="antv-s2-header-heading"
             >
               <div
-                class="antv-s2-header-heading-title"
-              />
-            </div>
-            <div
-              class="antv-s2-header-heading-extra"
-            >
-              <div
-                class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                class="antv-s2-header-heading-left"
               >
                 <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
-                    type="button"
-                  >
-                    <span
-                      class="ant-btn-icon"
-                    >
-                      <div />
-                    </span>
-                    <span>
-                      行列切换
-                    </span>
-                  </button>
-                </div>
+                  class="antv-s2-header-heading-title"
+                />
+              </div>
+              <div
+                class="antv-s2-header-heading-extra"
+              >
                 <div
-                  class="ant-space-item"
+                  class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                 >
                   <div
-                    class="antv-s2-advanced-sort"
+                    class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
                       type="button"
                     >
                       <span
@@ -836,27 +831,48 @@ exports[`<SheetComponent/> Tests Render Tests should render strategy sheet by sn
                         <div />
                       </span>
                       <span>
-                        高级排序
+                        行列切换
                       </span>
                     </button>
                   </div>
-                </div>
-                <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
-                    type="button"
+                  <div
+                    class="ant-space-item"
                   >
-                    <div />
-                  </button>
+                    <div
+                      class="antv-s2-advanced-sort"
+                    >
+                      <button
+                        class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                        type="button"
+                      >
+                        <span
+                          class="ant-btn-icon"
+                        >
+                          <div />
+                        </span>
+                        <span>
+                          高级排序
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
+                      type="button"
+                    >
+                      <div />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              class="antv-s2-header-content"
+            />
           </div>
-          <div
-            class="antv-s2-header-content"
-          />
         </div>
         <div
           class="antv-s2-container"
@@ -1038,50 +1054,33 @@ exports[`<SheetComponent/> Tests Render Tests should render table sheet by snaps
         class="antv-s2-wrapper"
       >
         <div
-          class="antv-s2-header"
-          style="width: 200px;"
+          class="css-dev-only-do-not-override-p7e5j5 ant-app"
         >
           <div
-            class="antv-s2-header-heading"
+            class="antv-s2-header"
+            style="width: 200px;"
           >
             <div
-              class="antv-s2-header-heading-left"
+              class="antv-s2-header-heading"
             >
               <div
-                class="antv-s2-header-heading-title"
-              />
-            </div>
-            <div
-              class="antv-s2-header-heading-extra"
-            >
-              <div
-                class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                class="antv-s2-header-heading-left"
               >
                 <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
-                    type="button"
-                  >
-                    <span
-                      class="ant-btn-icon"
-                    >
-                      <div />
-                    </span>
-                    <span>
-                      行列切换
-                    </span>
-                  </button>
-                </div>
+                  class="antv-s2-header-heading-title"
+                />
+              </div>
+              <div
+                class="antv-s2-header-heading-extra"
+              >
                 <div
-                  class="ant-space-item"
+                  class="ant-space css-dev-only-do-not-override-p7e5j5 ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
                 >
                   <div
-                    class="antv-s2-advanced-sort"
+                    class="ant-space-item"
                   >
                     <button
-                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-switcher-entry-button"
                       type="button"
                     >
                       <span
@@ -1090,27 +1089,48 @@ exports[`<SheetComponent/> Tests Render Tests should render table sheet by snaps
                         <div />
                       </span>
                       <span>
-                        高级排序
+                        行列切换
                       </span>
                     </button>
                   </div>
-                </div>
-                <div
-                  class="ant-space-item"
-                >
-                  <button
-                    class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
-                    type="button"
+                  <div
+                    class="ant-space-item"
                   >
-                    <div />
-                  </button>
+                    <div
+                      class="antv-s2-advanced-sort"
+                    >
+                      <button
+                        class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-default ant-btn-sm antv-s2-advanced-sort-btn"
+                        type="button"
+                      >
+                        <span
+                          class="ant-btn-icon"
+                        >
+                          <div />
+                        </span>
+                        <span>
+                          高级排序
+                        </span>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <button
+                      class="ant-btn css-dev-only-do-not-override-p7e5j5 ant-btn-text ant-dropdown-trigger antv-s2-export"
+                      type="button"
+                    >
+                      <div />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
+            <div
+              class="antv-s2-header-content"
+            />
           </div>
-          <div
-            class="antv-s2-header-content"
-          />
         </div>
         <div
           class="antv-s2-container"

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/index-spec.tsx
@@ -434,6 +434,8 @@ describe('<StrategySheet/> Tests', () => {
       renderStrategySheet(
         {
           ...StrategyOptions,
+          width: 800,
+          height: 800,
           interaction: {
             selectedCellsSpotlight: true,
           },
@@ -445,7 +447,8 @@ describe('<StrategySheet/> Tests', () => {
     // https://github.com/antvis/S2/issues/1960
     it('should selected cell and update spotlight style', async () => {
       await waitFor(() => {
-        const dataCellId = `root[&]自定义节点A[&]指标A-root[&]2022-11[&]["数值","环比","同比"]`;
+        const dataCellId =
+          'root[&]custom-node-1[&]measure-a-root[&]2022-11[&]["数值","环比","同比"]';
 
         const selectedDataCell = s2.facet.getCellById(dataCellId)!;
 

--- a/packages/s2-react/playground/components/CustomGrid.tsx
+++ b/packages/s2-react/playground/components/CustomGrid.tsx
@@ -86,6 +86,7 @@ type CustomGridProps = Partial<SheetComponentsProps>;
 export const CustomGrid = React.forwardRef<SpreadSheet, CustomGridProps>(
   (props, ref) => {
     const context = usePlaygroundContext();
+    const { logHandler } = context;
     const [customType, setCustomType] = React.useState<CustomType>(
       (localStorage.getItem('debugCustomType') as unknown as CustomType) ||
         CustomType.Row,
@@ -103,12 +104,6 @@ export const CustomGrid = React.forwardRef<SpreadSheet, CustomGridProps>(
     });
     const [sheetType, setSheetType] =
       React.useState<SheetComponentsProps['sheetType']>('pivot');
-
-    const logHandler =
-      (name: string) =>
-      (...args: unknown[]) => {
-        console.log(name, ...args);
-      };
 
     const dataCfg =
       customType === CustomType.Row

--- a/packages/s2-react/playground/components/CustomTree.tsx
+++ b/packages/s2-react/playground/components/CustomTree.tsx
@@ -10,16 +10,25 @@ import { customTreeData } from '../../__tests__/data/data-custom-trees';
 import { meta } from '../../__tests__/data/mock-dataset.json';
 import { usePlaygroundContext } from '../context/playground.context';
 
-export const customTreeDataCfg: S2DataConfig = {
+export const CustomTreeDataCfg: S2DataConfig = {
   meta,
   data: customTreeData,
   fields: customTreeFields,
 };
 
-export const customTreeOptions: SheetComponentOptions = {
+export const CustomTreeOptions: SheetComponentOptions = {
+  debug: true,
   width: 600,
   height: 480,
   hierarchyType: 'tree',
+  showDefaultHeaderActionIcon: false,
+  interaction: {
+    copy: {
+      enable: true,
+      withHeader: true,
+      withFormat: true,
+    },
+  },
   // cornerText: '指标',
 };
 
@@ -28,12 +37,20 @@ type CustomTreeProps = Partial<SheetComponentsProps>;
 export const CustomTree = React.forwardRef<SpreadSheet, CustomTreeProps>(
   (props, ref) => {
     const context = usePlaygroundContext();
+    const { logHandler } = context;
 
     return (
       <SheetComponent
-        dataCfg={customTreeDataCfg}
-        options={customTreeOptions}
+        dataCfg={CustomTreeDataCfg}
+        options={CustomTreeOptions}
         ref={ref}
+        onCopied={logHandler('onCopied')}
+        header={{
+          title: '自定义目录树',
+          export: {
+            open: true,
+          },
+        }}
         {...props}
         {...context}
       />

--- a/packages/s2-react/playground/components/CustomTree.tsx
+++ b/packages/s2-react/playground/components/CustomTree.tsx
@@ -1,5 +1,7 @@
 import type { S2DataConfig, SpreadSheet } from '@antv/s2';
 import React from 'react';
+import { Switch } from 'antd';
+import type { HierarchyType } from '@antv/s2';
 import {
   SheetComponent,
   type SheetComponentOptions,
@@ -11,7 +13,12 @@ import { meta } from '../../__tests__/data/mock-dataset.json';
 import { usePlaygroundContext } from '../context/playground.context';
 
 export const CustomTreeDataCfg: S2DataConfig = {
-  meta,
+  meta: [
+    ...meta,
+    // { field: 'a-1', name: '自定义 A' },
+    // { field: 'measure-a', name: '自定义 B' },
+    // { field: 'measure-b', name: '自定义 C' },
+  ],
   data: customTreeData,
   fields: customTreeFields,
 };
@@ -20,7 +27,7 @@ export const CustomTreeOptions: SheetComponentOptions = {
   debug: true,
   width: 600,
   height: 480,
-  hierarchyType: 'tree',
+  hierarchyType: 'grid',
   showDefaultHeaderActionIcon: false,
   interaction: {
     copy: {
@@ -37,12 +44,15 @@ type CustomTreeProps = Partial<SheetComponentsProps>;
 export const CustomTree = React.forwardRef<SpreadSheet, CustomTreeProps>(
   (props, ref) => {
     const context = usePlaygroundContext();
+    const [hierarchyType, setHierarchyType] = React.useState<HierarchyType>(
+      CustomTreeOptions.hierarchyType!,
+    );
     const { logHandler } = context;
 
     return (
       <SheetComponent
         dataCfg={CustomTreeDataCfg}
-        options={CustomTreeOptions}
+        options={{ ...CustomTreeOptions, hierarchyType }}
         ref={ref}
         onCopied={logHandler('onCopied')}
         header={{
@@ -50,6 +60,16 @@ export const CustomTree = React.forwardRef<SpreadSheet, CustomTreeProps>(
           export: {
             open: true,
           },
+          extra: (
+            <Switch
+              checked={hierarchyType === 'tree'}
+              checkedChildren="树状"
+              unCheckedChildren="平铺"
+              onChange={(checked) => {
+                setHierarchyType(checked ? 'tree' : 'grid');
+              }}
+            />
+          ),
         }}
         {...props}
         {...context}

--- a/packages/s2-react/playground/context/playground.context.ts
+++ b/packages/s2-react/playground/context/playground.context.ts
@@ -7,11 +7,16 @@ export const PlaygroundContext = React.createContext<
   Partial<SheetComponentsProps> & {
     ref?: React.MutableRefObject<SpreadSheet | null>;
     setThemeCfg: (theme: ThemeCfg) => void;
+    logHandler: (
+      name: string,
+      callback?: (...args: any[]) => void,
+    ) => (...args: any[]) => void;
   }
 >({
   onMounted: noop,
   themeCfg: { name: 'default' },
   setThemeCfg: () => {},
+  logHandler: () => () => {},
 });
 
 export function usePlaygroundContext() {

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -394,6 +394,7 @@ function MainLayout() {
           onDestroy: onSheetDestroy,
           themeCfg,
           setThemeCfg,
+          logHandler,
         }}
       >
         <div className="playground">

--- a/packages/s2-react/src/components/config-provider/index.tsx
+++ b/packages/s2-react/src/components/config-provider/index.tsx
@@ -1,5 +1,5 @@
 import { getLang, type ThemeName } from '@antv/s2';
-import { ConfigProvider as AntdConfigProvider, theme } from 'antd';
+import { ConfigProvider as AntdConfigProvider, App, theme } from 'antd';
 import enUS from 'antd/es/locale/en_US';
 import zhCN from 'antd/es/locale/zh_CN';
 import React from 'react';
@@ -21,7 +21,7 @@ export const ConfigProvider: React.FC<ConfigProviderProps> = (props) => {
         algorithm: isDarkTheme ? theme.darkAlgorithm : theme.defaultAlgorithm,
       }}
     >
-      {children}
+      <App>{children}</App>
     </AntdConfigProvider>
   );
 };

--- a/packages/s2-react/src/components/config-provider/index.tsx
+++ b/packages/s2-react/src/components/config-provider/index.tsx
@@ -1,5 +1,5 @@
 import { getLang, type ThemeName } from '@antv/s2';
-import { ConfigProvider as AntdConfigProvider, App, theme } from 'antd';
+import { ConfigProvider as AntdConfigProvider, theme } from 'antd';
 import enUS from 'antd/es/locale/en_US';
 import zhCN from 'antd/es/locale/zh_CN';
 import React from 'react';
@@ -21,7 +21,7 @@ export const ConfigProvider: React.FC<ConfigProviderProps> = (props) => {
         algorithm: isDarkTheme ? theme.darkAlgorithm : theme.defaultAlgorithm,
       }}
     >
-      <App>{children}</App>
+      {children}
     </AntdConfigProvider>
   );
 };

--- a/packages/s2-react/src/components/export/index.tsx
+++ b/packages/s2-react/src/components/export/index.tsx
@@ -56,6 +56,8 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
 
   const PRE_CLASS = `${S2_PREFIX_CLS}-export`;
 
+  const [messageApi, contextHolder] = message.useMessage();
+
   const copyData = async (isFormat: boolean) => {
     const params: CopyAllDataParams = {
       sheetInstance: sheet,
@@ -68,12 +70,12 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
 
     copyToClipboard(data, syncCopy)
       .then(() => {
-        message.success(successText);
+        messageApi.success(successText);
       })
       .catch((error) => {
         // eslint-disable-next-line no-console
         console.error('copy failed: ', error);
-        message.error(errorText);
+        messageApi.error(errorText);
       });
   };
 
@@ -86,55 +88,58 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
 
     try {
       download(data, fileName);
-      message.success(successText);
+      messageApi.success(successText);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('download failed: ', error);
-      message.error(errorText);
+      messageApi.error(errorText);
     }
   };
 
   return (
-    <Dropdown
-      menu={{
-        items: [
-          {
-            key: 'copyOriginal',
-            label: copyOriginalText,
-            onClick: () => {
-              copyData(false);
+    <>
+      {contextHolder}
+      <Dropdown
+        menu={{
+          items: [
+            {
+              key: 'copyOriginal',
+              label: copyOriginalText,
+              onClick: () => {
+                copyData(false);
+              },
             },
-          },
-          {
-            key: 'copyFormat',
-            label: copyFormatText,
-            onClick: () => {
-              copyData(true);
+            {
+              key: 'copyFormat',
+              label: copyFormatText,
+              onClick: () => {
+                copyData(true);
+              },
             },
-          },
-          {
-            key: 'downloadOriginal',
-            label: downloadOriginalText,
-            onClick: () => {
-              downloadData(false);
+            {
+              key: 'downloadOriginal',
+              label: downloadOriginalText,
+              onClick: () => {
+                downloadData(false);
+              },
             },
-          },
-          {
-            key: 'downloadFormat',
-            label: downloadFormatText,
-            onClick: () => {
-              downloadData(true);
+            {
+              key: 'downloadFormat',
+              label: downloadFormatText,
+              onClick: () => {
+                downloadData(true);
+              },
             },
-          },
-        ],
-      }}
-      trigger={['click']}
-      className={cx(PRE_CLASS, className)}
-      {...restProps}
-      {...dropdown}
-    >
-      <Button type="text">{icon || <DotIcon />}</Button>
-    </Dropdown>
+          ],
+        }}
+        trigger={['click']}
+        className={cx(PRE_CLASS, className)}
+        {...restProps}
+        {...dropdown}
+      >
+        <Button type="text">{icon || <DotIcon />}</Button>
+      </Dropdown>
+    </>
   );
 });
 

--- a/packages/s2-react/src/components/export/strategy-copy.ts
+++ b/packages/s2-react/src/components/export/strategy-copy.ts
@@ -1,9 +1,7 @@
 import {
-  CornerNodeType,
   PivotDataCellCopy,
   assembleMatrix,
   getHeaderList,
-  getMaxRowLen,
   getNodeFormatData,
   safeJsonParse,
   type CopyAllDataParams,
@@ -21,7 +19,6 @@ import {
   isNil,
   isObject,
   map,
-  sortBy,
 } from 'lodash';
 
 /**
@@ -104,29 +101,7 @@ class StrategyCopyData extends PivotDataCellCopy {
   };
 
   protected getCornerMatrix = (rowMatrix?: string[][]): string[][] => {
-    const { fields } = this.spreadsheet.dataCfg;
-    const { rows = [] } = fields;
-    const maxRowLen = this.spreadsheet.isHierarchyTreeType()
-      ? getMaxRowLen(rowMatrix ?? [])
-      : rows.length;
-    const cornerNodes = this.spreadsheet.facet.getCornerNodes();
-
-    // 对 cornerNodes 进行排序， cornerType === CornerNodeType.Col 的放在前面
-    const sortedCornerNodes = sortBy(cornerNodes, (node) => {
-      const { cornerType } = node;
-
-      return cornerType === CornerNodeType.Col ? 0 : 1;
-    });
-
-    // 角头需要根据行头的最大长度进行填充，最后一列的值为角头的值
-    return map(sortedCornerNodes, (node) => {
-      const { value } = node;
-      const result: string[] = new Array(maxRowLen).fill('');
-
-      result[maxRowLen - 1] = value;
-
-      return result;
-    });
+    return this.getCustomRowCornerMatrix(rowMatrix);
   };
 
   protected getDataMatrixByHeaderNode = () => {

--- a/packages/s2-react/src/components/header/index.tsx
+++ b/packages/s2-react/src/components/header/index.tsx
@@ -5,8 +5,8 @@ import { S2_PREFIX_CLS, type S2DataConfig, type SpreadSheet } from '@antv/s2';
 import { Export, type ExportBaseProps } from '../export';
 import { AdvancedSort, type AdvancedSortBaseProps } from '../advanced-sort';
 import { type SwitcherProps, SwitcherHeader } from '../switcher/header';
-import './index.less';
 import type { SheetComponentOptions } from '../sheets/interface';
+import './index.less';
 
 export interface HeaderBaseProps {
   style?: React.CSSProperties;

--- a/packages/s2-react/src/components/header/index.tsx
+++ b/packages/s2-react/src/components/header/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Space } from 'antd';
+import { App, Space } from 'antd';
 import cx from 'classnames';
 import { S2_PREFIX_CLS, type S2DataConfig, type SpreadSheet } from '@antv/s2';
 import { Export, type ExportBaseProps } from '../export';
@@ -59,15 +59,17 @@ export const Header: React.FC<HeaderProps> = React.memo(
     );
 
     return (
-      <div className={cx(PRE_CLASS, className)} style={style} {...restProps}>
-        <div className={`${PRE_CLASS}-heading`}>
-          <div className={`${PRE_CLASS}-heading-left`}>
-            <div className={`${PRE_CLASS}-heading-title`}>{title}</div>
+      <App>
+        <div className={cx(PRE_CLASS, className)} style={style} {...restProps}>
+          <div className={`${PRE_CLASS}-heading`}>
+            <div className={`${PRE_CLASS}-heading-left`}>
+              <div className={`${PRE_CLASS}-heading-title`}>{title}</div>
+            </div>
+            <div className={`${PRE_CLASS}-heading-extra`}>{renderExtra()}</div>
           </div>
-          <div className={`${PRE_CLASS}-heading-extra`}>{renderExtra()}</div>
+          <div className={`${PRE_CLASS}-content`}>{description}</div>
         </div>
-        <div className={`${PRE_CLASS}-content`}>{description}</div>
-      </div>
+      </App>
     );
   },
 );

--- a/s2-site/docs/api/basic-class/node.zh.md
+++ b/s2-site/docs/api/basic-class/node.zh.md
@@ -38,6 +38,5 @@ node.isTotals // false
 | width | 宽度 | `number` |
 | height | 高度 | `number` |
 | padding | 间距 | `number` |
-| hiddenChildNodeInfo | 隐藏的子节点信息 | [hiddenColumnsInfo](/api/basic-class/store#hiddencolumnsinfo) |
 | children | 子节点 | [Node[]](/docs/api/basic-class/node)  |
 | extra | 节点额外信息 | `Record<string, any>` |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2455


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

- 自定义行列头使用 field 生成 id, 解决同名节点引起的交互/折叠/复制等衍生问题.

```diff
- "root[&]自定义节点A"
+ "root[&]custom-node-1"
```

- 兼容刷选和复制导出, 并完善相关单测.
- 修复自定义行头 (平铺/树状) 复制的数据未包含角头的问题.

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->



| Before | After |
| ------ | ----- |
| ![Kapture 2024-02-19 at 19 05 29](https://github.com/antvis/S2/assets/21015895/425e8097-7565-4f2a-a1d9-d60a98ac66d5) | ![Kapture 2024-02-19 at 19 03 34](https://github.com/antvis/S2/assets/21015895/1d5719c1-c729-4e3b-b833-5c8fa7e1f54d) |
| ![image](https://github.com/antvis/S2/assets/21015895/deb9e2bc-0b8c-43df-a03e-cf15bb6ccd16) | ![image](https://github.com/antvis/S2/assets/21015895/070524dd-c30b-4a5f-bb8e-b3345ac6c724) |
| ![image](https://github.com/antvis/S2/assets/21015895/2bd88c89-ce2c-403a-a54a-b1cc831b5c7c) | ![image](https://github.com/antvis/S2/assets/21015895/75892fa2-5162-4e7a-bcd1-d79d393cf5be) |







### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
