### PR TITLE
fix: 修复父容器存在 transform 缩放时单元格刷选偏移 close #2553

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/base-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/base-brush-selection-spec.ts
@@ -13,6 +13,7 @@ import {
   type OriginalEvent,
   type S2DataConfig,
   type ViewMeta,
+  EventController,
 } from '@/index';
 import { RootInteraction } from '@/interaction/root';
 
@@ -61,6 +62,13 @@ describe('Interaction Base Cell Brush Selection Tests', () => {
     await s2.render();
 
     mockRootInteraction = new MockRootInteraction(s2);
+    mockRootInteraction.eventController = new EventController(s2);
+    mockRootInteraction.eventController.getViewportPoint = (event) => {
+      return s2.container.client2Viewport({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
     mockRootInteraction.getBrushSelection = () => {
       return {
         dataCell: true,

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/col-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/col-brush-selection-spec.ts
@@ -11,6 +11,7 @@ import {
   SpreadSheet,
   type OriginalEvent,
   type S2DataConfig,
+  EventController,
 } from '@/index';
 
 jest.mock('@/interaction/event-controller');
@@ -72,6 +73,13 @@ describe('Interaction Col Cell Brush Selection Tests', () => {
 
     s2.showTooltipWithInfo = jest.fn();
     mockRootInteraction = new MockRootInteraction(s2);
+    mockRootInteraction.eventController = new EventController(s2);
+    mockRootInteraction.eventController.getViewportPoint = (event) => {
+      return s2.container.client2Viewport({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
     s2.getCell = jest.fn(() => startBrushColCell) as any;
     mockRootInteraction.getBrushSelection = () => {
       return {
@@ -212,7 +220,7 @@ describe('Interaction Col Cell Brush Selection Tests', () => {
     expect(brushSelectionFn).toHaveBeenCalledTimes(1);
   });
 
-  test('should not emit brush secletion event', () => {
+  test('should not emit brush selection event', () => {
     mockRootInteraction.getBrushSelection = () => ({
       dataCell: true,
       rowCell: true,

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/data-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/data-brush-selection-spec.ts
@@ -7,19 +7,20 @@ import {
   CellType,
   DataCellBrushSelection,
   FrozenGroupType,
-  getScrollOffsetForCol,
-  getScrollOffsetForRow,
   InteractionBrushSelectionStage,
   Node,
   PivotSheet,
   S2Event,
   ScrollDirection,
   SpreadSheet,
+  getScrollOffsetForCol,
+  getScrollOffsetForRow,
   type LayoutResult,
   type OriginalEvent,
   type S2DataConfig,
   type S2Options,
   type ViewMeta,
+  EventController,
 } from '@/index';
 import { RootInteraction } from '@/interaction/root';
 
@@ -118,6 +119,13 @@ describe('Interaction Data Cell Brush Selection Tests', () => {
     await s2.render();
 
     mockRootInteraction = new MockRootInteraction(s2);
+    mockRootInteraction.eventController = new EventController(s2);
+    mockRootInteraction.eventController.getViewportPoint = (event) => {
+      return s2.container.client2Viewport({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
     s2.getCell = jest.fn(() => startBrushDataCell) as any;
     s2.showTooltipWithInfo = jest.fn();
     mockRootInteraction.getSelectedCellHighlight = () => {

--- a/packages/s2-core/__tests__/unit/interaction/brush-selection/row-brush-selection-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/brush-selection/row-brush-selection-spec.ts
@@ -11,6 +11,7 @@ import {
   SpreadSheet,
   type OriginalEvent,
   type S2DataConfig,
+  EventController,
 } from '@/index';
 
 jest.mock('@/interaction/event-controller');
@@ -73,6 +74,13 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
     s2.showTooltipWithInfo = jest.fn();
     s2.getCell = jest.fn(() => startBrushRowCell) as any;
     mockRootInteraction = new MockRootInteraction(s2);
+    mockRootInteraction.eventController = new EventController(s2);
+    mockRootInteraction.eventController.getViewportPoint = (event) => {
+      return s2.container.client2Viewport({
+        x: event.clientX,
+        y: event.clientY,
+      });
+    };
     mockRootInteraction.getBrushSelection = () => {
       return {
         dataCell: true,
@@ -259,7 +267,7 @@ describe('Interaction Row Cell Brush Selection Tests', () => {
     expect(brushSelectionInstance.brushRangeCells.length).toEqual(8);
   });
 
-  test('should not emit brush secletion event', () => {
+  test('should not emit brush selection event', () => {
     mockRootInteraction.getBrushSelection = () => ({
       dataCell: true,
       rowCell: false,

--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -1004,9 +1004,9 @@ describe('Interaction Event Controller Tests', () => {
     spreadsheet.on(S2Event.GLOBAL_RESET, reset);
 
     const pointInCanvas = getClientPointOnCanvas(spreadsheet.container, 10, 10);
-    const evt = new window.CustomEvent('click');
+    const event = new window.CustomEvent('click');
 
-    Object.defineProperties(evt, {
+    Object.defineProperties(event, {
       clientX: {
         value: pointInCanvas.clientX,
       },
@@ -1014,10 +1014,41 @@ describe('Interaction Event Controller Tests', () => {
         value: pointInCanvas.clientY,
       },
     });
-    spreadsheet.getCanvasElement().dispatchEvent(evt);
+    spreadsheet.getCanvasElement().dispatchEvent(event);
 
     expect(eventController.isCanvasEffect).toBe(true);
     expect(reset).not.toHaveBeenCalled();
     expect(spreadsheet.interaction.reset).not.toHaveBeenCalled();
+  });
+
+  // https://github.com/antvis/S2/issues/2553
+  test('should use offset point if enable supportsCSSTransform', () => {
+    jest.spyOn(spreadsheet, 'getCanvasConfig').mockImplementationOnce(() => {
+      return {
+        supportsCSSTransform: true,
+      };
+    });
+
+    const event = new MouseEvent('click');
+
+    Object.defineProperties(event, {
+      offsetX: {
+        value: 100,
+      },
+      offsetY: {
+        value: 200,
+      },
+      clientX: {
+        value: 300,
+      },
+      clientY: {
+        value: 400,
+      },
+    });
+
+    expect(eventController.getViewportPoint(event)).toStrictEqual({
+      x: 100,
+      y: 200,
+    });
   });
 });

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -173,6 +173,7 @@ export const createFakeSpreadSheet = (config?: {
   s2.facet.getCells = jest.fn().mockReturnValue([]);
   s2.getCanvasElement = () =>
     s2.container.getContextService().getDomElement() as HTMLCanvasElement;
+  s2.getCanvasConfig = () => s2.container.getConfig();
   s2.isCustomHeaderFields = jest.fn(() => false);
   s2.isCustomRowFields = jest.fn(() => false);
   s2.isCustomColumnFields = jest.fn(() => false);

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -154,6 +154,7 @@ export const createFakeSpreadSheet = (config?: {
       [FrozenGroupType.FROZEN_TRAILING_COL]: {},
     },
     cornerBBox: {},
+    destroy: jest.fn(),
   } as unknown as BaseFacet;
   s2.container.render = jest.fn();
   s2.store = new Store();

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -14,7 +14,13 @@ import { omit } from 'lodash';
 import * as simpleDataConfig from 'tests/data/simple-data.json';
 import * as dataConfig from 'tests/data/mock-dataset.json';
 import { Renderer } from '@antv/g-canvas';
-import { getTheme, type BaseDataSet, type Node, Hierarchy } from '../../src';
+import {
+  getTheme,
+  type BaseDataSet,
+  type Node,
+  Hierarchy,
+  EventController,
+} from '../../src';
 
 import { assembleOptions, assembleDataCfg } from '.';
 import { RootInteraction } from '@/interaction/root';
@@ -194,6 +200,7 @@ export const createFakeSpreadSheet = (config?: {
   const interaction = new RootInteraction(s2 as unknown as SpreadSheet);
 
   s2.interaction = interaction;
+  s2.interaction.eventController = new EventController(s2);
 
   return s2;
 };

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -1,4 +1,4 @@
-import type { FederatedPointerEvent as Event } from '@antv/g';
+import type { FederatedPointerEvent as Event, PointLike } from '@antv/g';
 import type { DataCell, MergedCell } from '../../cell';
 import type {
   CustomTreeNode,
@@ -507,9 +507,6 @@ export interface GridInfo {
   rows: number[];
 }
 
-export interface Point {
-  x: number;
-  y: number;
-}
+export interface Point extends PointLike {}
 
 export type RowData = Data | CellData[];

--- a/packages/s2-core/src/common/interface/tooltip.ts
+++ b/packages/s2-core/src/common/interface/tooltip.ts
@@ -1,6 +1,6 @@
-import type { FederatedPointerEvent as CanvasEvent } from '@antv/g';
+import type { FederatedPointerEvent as CanvasEvent, PointLike } from '@antv/g';
 import type * as CSS from 'csstype';
-import type { Point, S2CellType, ViewMetaData } from '../../common/interface';
+import type { S2CellType, ViewMetaData } from '../../common/interface';
 import type { SpreadSheet } from '../../sheet-type';
 import type { BaseTooltip } from '../../ui/tooltip';
 
@@ -66,7 +66,7 @@ export interface TooltipOperatorOptions<Menu = BaseTooltipOperatorMenuOptions> {
   menu?: Menu;
 }
 
-export type TooltipPosition = Point;
+export type TooltipPosition = PointLike;
 
 export type TooltipDetailListItem = {
   name: string;

--- a/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/base-brush-selection.ts
@@ -115,7 +115,10 @@ export class BaseBrushSelection
     const { minX, minY } = this.spreadsheet.facet.panelBBox;
 
     return (
-      point.x > minX && point.x < width && point.y > minY && point.y < height
+      point?.x > minX &&
+      point?.x < width &&
+      point?.y > minY &&
+      point?.y < height
     );
   }
 

--- a/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
@@ -1,4 +1,4 @@
-import type { FederatedPointerEvent as CanvasEvent } from '@antv/g';
+import type { FederatedPointerEvent as CanvasEvent, PointLike } from '@antv/g';
 import { isEmpty, map } from 'lodash';
 import type { ColCell } from '../../cell/col-cell';
 import { InterceptType, S2Event } from '../../common/constant';
@@ -34,7 +34,7 @@ export class ColCellBrushSelection extends BaseBrushSelection {
     });
   }
 
-  protected isPointInCanvas(point: { x: number; y: number }) {
+  protected isPointInCanvas(point: PointLike) {
     // 获取列头的区域范围
     const { width: maxX } = this.spreadsheet.facet.getCanvasSize();
     const { width: minX, minY, maxY } = this.spreadsheet.facet.cornerBBox;
@@ -55,7 +55,7 @@ export class ColCellBrushSelection extends BaseBrushSelection {
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
 
       const pointInCanvas =
-        this.spreadsheet.interaction.eventController.getViewportPoint(event);
+        this.spreadsheet.interaction.eventController?.getViewportPoint(event);
 
       if (!this.isPointInCanvas(pointInCanvas)) {
         return;

--- a/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/col-brush-selection.ts
@@ -54,10 +54,8 @@ export class ColCellBrushSelection extends BaseBrushSelection {
 
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
 
-      const pointInCanvas = this.spreadsheet.container.client2Viewport({
-        x: event.clientX,
-        y: event.clientY,
-      });
+      const pointInCanvas =
+        this.spreadsheet.interaction.eventController.getViewportPoint(event);
 
       if (!this.isPointInCanvas(pointInCanvas)) {
         return;

--- a/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
@@ -1,3 +1,4 @@
+import type { PointLike } from '@antv/g';
 import { isEmpty, range } from 'lodash';
 import type { DataCell } from '../../cell/data-cell';
 import { S2Event } from '../../common/constant';
@@ -6,12 +7,7 @@ import {
   InteractionBrushSelectionStage,
   InteractionStateName,
 } from '../../common/constant/interaction';
-import type {
-  BrushRange,
-  CellMeta,
-  Point,
-  ViewMeta,
-} from '../../common/interface';
+import type { BrushRange, CellMeta, ViewMeta } from '../../common/interface';
 import { afterSelectDataCells } from '../../utils/interaction/select-event';
 import { BaseBrushSelection } from './base-brush-selection';
 
@@ -148,7 +144,7 @@ export class DataCellBrushSelection extends BaseBrushSelection {
     super.bindMouseUp(true);
   }
 
-  protected getPrepareSelectMaskPosition(brushRange: BrushRange): Point {
+  protected getPrepareSelectMaskPosition(brushRange: BrushRange): PointLike {
     const { minX, minY } = this.spreadsheet.facet.panelBBox;
     const x = Math.max(brushRange.start.x, minX);
     const y = Math.max(brushRange.start.y, minY);

--- a/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/data-cell-brush-selection.ts
@@ -40,10 +40,8 @@ export class DataCellBrushSelection extends BaseBrushSelection {
       }
 
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
-      const pointInCanvas = this.spreadsheet.container.client2Viewport({
-        x: event.clientX,
-        y: event.clientY,
-      });
+      const pointInCanvas =
+        this.spreadsheet.interaction.eventController.getViewportPoint(event);
 
       if (this.autoBrushScroll(pointInCanvas)) {
         return;

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -1,3 +1,4 @@
+import type { PointLike } from '@antv/g';
 import { isNil, last, map } from 'lodash';
 import { RowCell } from '../../cell';
 import { InterceptType, S2Event } from '../../common/constant';
@@ -9,7 +10,6 @@ import {
 import type {
   BrushRange,
   OnUpdateCells,
-  Point,
   ViewMeta,
 } from '../../common/interface';
 import type { BBox } from '../../engine';
@@ -32,7 +32,7 @@ export class RowCellBrushSelection extends BaseBrushSelection {
     });
   }
 
-  protected isPointInCanvas(point: Point) {
+  protected isPointInCanvas(point: PointLike) {
     // 获取行头的区域范围
     const { height: maxY } = this.spreadsheet.facet.getCanvasSize();
     const { minX, height: minY, maxX } = this.spreadsheet.facet.cornerBBox;
@@ -180,7 +180,7 @@ export class RowCellBrushSelection extends BaseBrushSelection {
     return this.validateYIndex(nextRowIndex);
   };
 
-  protected getPrepareSelectMaskPosition(brushRange: BrushRange): Point {
+  protected getPrepareSelectMaskPosition(brushRange: BrushRange): PointLike {
     const { minY } = this.spreadsheet.facet.panelBBox;
     const x = brushRange.start.x;
     const y = Math.max(brushRange.start.y, minY);

--- a/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
+++ b/packages/s2-core/src/interaction/brush-selection/row-brush-selection.ts
@@ -52,10 +52,8 @@ export class RowCellBrushSelection extends BaseBrushSelection {
 
       this.setBrushSelectionStage(InteractionBrushSelectionStage.DRAGGED);
 
-      const pointInCanvas = this.spreadsheet.container.client2Viewport({
-        x: event.clientX,
-        y: event.clientY,
-      });
+      const pointInCanvas =
+        this.spreadsheet.interaction.eventController.getViewportPoint(event);
 
       if (this.autoBrushScroll(pointInCanvas, true)) {
         return;

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -3,6 +3,7 @@ import {
   DisplayObject,
   type FederatedPointerEvent as CanvasEvent,
   type Group,
+  type PointLike,
 } from '@antv/g';
 import { each, get, hasIn, isEmpty, isNil } from 'lodash';
 import { GuiIcon } from '../common';
@@ -700,5 +701,28 @@ export class EventController {
     this.canvasEventHandlers = [];
     this.s2EventHandlers = [];
     this.domEventListeners = [];
+  }
+
+  public getViewportPoint(
+    event: MouseEvent | PointerEvent | CanvasEvent,
+  ): PointLike {
+    const config = this.spreadsheet.getCanvasConfig();
+
+    // https://github.com/antvis/G/blob/a43c19a662684945d0bf9dc1876af43ac26b1243/packages/g-lite/src/plugins/EventPlugin.ts#L216
+    if (
+      config.supportsCSSTransform &&
+      !isNil(event.offsetX) &&
+      !isNil(event.offsetY)
+    ) {
+      return {
+        x: event.offsetX,
+        y: event.offsetY,
+      };
+    }
+
+    return this.spreadsheet.container.client2Viewport({
+      x: event.clientX,
+      y: event.clientY,
+    });
   }
 }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -599,9 +599,18 @@ export abstract class SpreadSheet extends EE {
 
   /**
    * 获取 G Canvas 实例
+   * @see https://g.antv.antgroup.com/api/renderer/canvas
    */
   public getCanvas(): Canvas {
     return this.container;
+  }
+
+  /**
+   * 获取 G Canvas 配置
+   * @see https://g.antv.antgroup.com/api/canvas/options
+   */
+  public getCanvasConfig(): Partial<CanvasConfig> {
+    return this.getCanvas().getConfig();
   }
 
   /**

--- a/packages/s2-react/playground/components/CustomTree.tsx
+++ b/packages/s2-react/playground/components/CustomTree.tsx
@@ -28,6 +28,11 @@ export const CustomTreeOptions: SheetComponentOptions = {
   width: 600,
   height: 480,
   hierarchyType: 'tree',
+  transformCanvasConfig() {
+    return {
+      supportsCSSTransform: true,
+    };
+  },
   showDefaultHeaderActionIcon: false,
   interaction: {
     copy: {

--- a/s2-site/docs/api/basic-class/interaction.zh.md
+++ b/s2-site/docs/api/basic-class/interaction.zh.md
@@ -14,7 +14,8 @@ s2.interaction.reset()
 | --- |--------------------------------------------------| --- |
 | spreadsheet | 表格实例                                             | [SpreadSheet](/docs/api/basic-class/spreadsheet) |
 | interactions | 当前已注册的交互                                         | `Map<string, BaseEvent>` |
-| intercept | 当前拦截的交互，防止不同交互之间冲突                               | `Set<Intercept>` |
+| intercepts | 当前拦截的交互，防止不同交互之间冲突 ([查看示例](/examples/interaction/advanced/#intercepts))                              | `Set<Intercept>` |
+| eventController | 事件控制器                              | [EventController](#eventcontroller) |
 | destroy | 卸载所有交互实例，并重置为初始状态                                | `() => void` |
 | reset | 重置所有交互                                           | `() => void` |
 | setState | 设置状态                                             | (data: [InteractionStateInfo](#interactionstateinfo)) => void |
@@ -25,7 +26,7 @@ s2.interaction.reset()
 | setInteractedCells | 设置当前发生改变的单元格                                     | (cell: [S2CellType](#s2celltype)) => void |
 | getInteractedCells | 获取当前发生改变的单元格                                     | () => [S2CellType](#s2celltype)[] |
 | getCurrentStateName | 获取当前状态名                                          | `() => void` |
-| isEqualStateName | 是否是相同的状态名                                        | `(name: InteractionStateName) => void` |
+| isEqualStateName | 是否是相同的状态名                                        | (name: [InteractionStateName](#interactionstatename)) => void |
 | isSelectedState | 是否是选中状态                                          | `() => void` |
 | isHoverState | 是否是悬停状态                                          | `() => void` |
 | isHoverFocusState | 是否是悬停聚焦状态 （悬停在单元格 `focusTime`: 默认 800ms 后）       | `() => void` |
@@ -121,6 +122,48 @@ interface MergedCellInfo {
 }
 ```
 
+### CellType
+
+```ts
+enum CellType {
+  DATA_CELL = 'dataCell',
+  ROW_CELL = 'rowCell',
+  COL_CELL = 'colCell',
+  SERIES_NUMBER_CELL = 'seriesNumberCell',
+  CORNER_CELL = 'cornerCell',
+  MERGED_CELL = 'mergedCell',
+}
+```
+
+### CellMeta
+
+```ts
+interface CellMeta {
+  id: string;
+  colIndex: number;
+  rowIndex: number;
+  type: CellType;
+  rowQuery?: Record<string, any>;
+  [key: string]: unknown;
+}
+```
+
+### InteractionStateName
+
+```ts
+enum InteractionStateName {
+  ALL_SELECTED = 'allSelected',
+  SELECTED = 'selected',
+  BRUSH_SELECTED = 'brushSelected',
+  UNSELECTED = 'unselected',
+  HOVER = 'hover',
+  HOVER_FOCUS = 'hoverFocus',
+  HIGHLIGHT = 'highlight',
+  SEARCH_RESULT = 'searchResult',
+  PREPARE_SELECT = 'prepareSelect',
+}
+```
+
 ### InteractionStateInfo
 
 ```ts
@@ -130,6 +173,51 @@ interface InteractionStateInfo {
   interactedCells?: S2CellType[];
   nodes?: Node[];
   force?: boolean;
+}
+```
+
+### EventController
+
+| 参数 | 说明    | 类型 |
+| --- |--------| --- |
+| spreadsheet | 表格实例 | [SpreadSheet](/docs/api/basic-class/spreadsheet) |
+| canvasEventHandlers | 当前已注册的交互            | [EventHandler](#eventhandler)[] |
+| s2EventHandlers | 当前已注册的交互            | [S2EventHandler](#s2eventhandler)[] |
+| domEventListeners | 当前已注册的交互            | [EventHandler](#eventhandler)[] |
+| isCanvasEffect | 是否是图表内部引起的事件            | boolean |
+| canvasMousemoveEvent | 表格鼠标移动事件            | CanvasEvent |
+| isMatchElement | 是否是表格内部的元素            | (event: MouseEvent) => void |
+| isMatchPoint | 是否是表格内部的坐标            | (event: MouseEvent) => void |
+| bindEvents | 绑定交互事件            | `() => void`) |
+| clear | 清空交互事件            | `() => void`) |
+| getViewportPoint | 获取表格内的鼠标坐标 （兼容 `supportsCSSTransform`)  | `(event: MouseEvent \| PointerEvent \| WheelEvent) => PointLike` |
+
+### EventListener
+
+```ts
+interface EventListener {
+  target: EventTarget;
+  type: string;
+  handler: EventListenerOrEventListenerObject;
+  options?: AddEventListenerOptions | boolean;
+}
+```
+
+### S2EventHandler
+
+```ts
+interface S2EventHandler {
+  type: keyof EmitterType;
+  handler: EmitterType[keyof EmitterType];
+}
+```
+
+### EventHandler
+
+```ts
+interface EventHandler {
+  type: string;
+  handler: (event: CanvasEvent) => void;
 }
 ```
 

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -60,6 +60,7 @@ s2.isPivotMode()
 | getInitColLeafNodes | 获取初次渲染的列头叶子节点 （比如：隐藏列头前）                                                                                               | () => [Node[]](/docs/api/basic-class/node/) |    |
 | getCanvasElement | 获取表格对应的 `<canvas/>` HTML 元素                                                                                            | () => [HTMLCanvasElement](https://developer.mozilla.org/zh-CN/docs/Web/API/HTMLCanvasElement) |    |
 | getCanvas | 获取 G Canvas 实例                                                                                           | () => [Canvas](https://g.antv.antgroup.com/api/renderer/canvas) |    |
+| getCanvasConfig | 获取 G Canvas 配置                                                                                           | () => Partial<[CanvasConfig](https://g.antv.antgroup.com/api/canvas/options)> |    |
 | clearInitColLeafNodes | 清空存储在 store 中的初始叶子节点                                                                                                   | () => void |    |
 | updateSortMethodMap | 更新存储在 store 中的节点排序方式 map, replace 为是否覆盖上一次的值                                                                           | (nodeId: string, sortMethod: string, replace?: boolean) => void |    |
 | getMenuDefaultSelectedKeys | 获取 tooltip 中选中的菜单项 key 值 | `(nodeId: string) => string[]` |    |


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2553 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

1. 父容器存在 `transform: scale() ` 时, 刷选坐标拿的有问题, 应该使用 `offsetX/offsetY` 而不是 `clientX/clientY`, 参考 G 的 supportsCSSTransform 处理方式.

https://github.com/antvis/G/blob/a43c19a662684945d0bf9dc1876af43ac26b1243/packages/g-lite/src/plugins/EventPlugin.ts#L215-L229

2. 增加遗漏的 eventController 文档

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![Kapture 2024-02-27 at 17 17 37](https://github.com/antvis/S2/assets/21015895/5c70847b-f709-4619-a57f-3591dc377e38) | ![Kapture 2024-02-27 at 17 13 40](https://github.com/antvis/S2/assets/21015895/22893d9c-bacc-42d5-9380-bf778575a994) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
