### PR TITLE
fix: 修复数值单元格内的自定义 icon 点击时会选中单元格的问题 close #2333

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-1520-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-1520-spec.ts
@@ -6,9 +6,9 @@
 import { getContainer } from '../util/helpers';
 import * as mockDataConfig from '../data/data-issue-1520.json';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
-import { GuiIcon } from '@/common';
+import { GuiIcon, type S2Options } from '@/common';
 
-const s2Options = {
+const s2Options: S2Options = {
   width: 800,
   height: 600,
   conditions: {

--- a/packages/s2-core/__tests__/bugs/issue-292-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-292-spec.ts
@@ -6,9 +6,10 @@
  */
 import { getContainer } from '../util/helpers';
 import * as mockDataConfig from '../data/data-issue-292.json';
+import type { S2Options } from '../../src';
 import { PivotSheet } from '@/sheet-type';
 
-const s2Options = {
+const s2Options: S2Options = {
   width: 800,
   height: 600,
 };

--- a/packages/s2-core/__tests__/bugs/issue-368-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-368-spec.ts
@@ -4,11 +4,12 @@
  * Wrong style when show the totals in multi-value mode
  *
  */
+import type { S2Options } from '../../src';
 import * as mockDataConfig from '../data/data-issue-368.json';
 import { getContainer } from '../util/helpers';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
 
-const s2Options = {
+const s2Options: S2Options = {
   width: 800,
   height: 600,
   totals: {
@@ -32,7 +33,7 @@ const s2Options = {
 describe('Total Cells Rendering Test', () => {
   let s2: SpreadSheet;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
 
     await s2.render();
@@ -66,7 +67,7 @@ describe('Total Cells Rendering Test', () => {
       totals: {
         ...s2Options.totals,
         row: {
-          ...s2Options.totals.row,
+          ...s2Options.totals!.row,
           subTotalsDimensions: ['row0'],
         },
       },

--- a/packages/s2-core/__tests__/bugs/issue-446-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-446-spec.ts
@@ -6,10 +6,11 @@
  */
 import { getContainer } from '../util/helpers';
 import * as mockDataConfig from '../data/data-issue-446.json';
+import type { S2Options } from '../../src';
 import { TableSheet } from '@/sheet-type';
 import { asyncGetAllPlainData } from '@/utils';
 
-const s2Options = {
+const s2Options: S2Options = {
   width: 800,
   height: 600,
   seriesNumber: {

--- a/packages/s2-core/__tests__/bugs/issue-507-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-507-spec.ts
@@ -57,15 +57,15 @@ describe('Spreadsheet Empty Test', () => {
   });
 
   test('should render skeleton when tree sheet in the valueInCols mode', async () => {
-    const valueInColstreeS2 = new PivotSheet(
+    const valueInColsTreeS2 = new PivotSheet(
       getContainer(),
       valueInCols,
       treeOptions,
     );
 
-    await valueInColstreeS2.render();
+    await valueInColsTreeS2.render();
 
-    const layoutResult = valueInColstreeS2.facet.getLayoutResult();
+    const layoutResult = valueInColsTreeS2.facet.getLayoutResult();
 
     expect(layoutResult.colNodes).toHaveLength(5);
     expect(layoutResult.rowNodes).toBeEmpty();

--- a/packages/s2-core/__tests__/bugs/issue-511-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-511-spec.ts
@@ -5,9 +5,10 @@
  */
 import { getContainer } from '../util/helpers';
 import * as mockDataConfig from '../data/data-issue-511.json';
+import type { S2Options } from '../../src';
 import { PivotSheet } from '@/sheet-type';
 
-const s2Options = {
+const s2Options: S2Options = {
   width: 800,
   height: 600,
 };

--- a/packages/s2-core/__tests__/bugs/issue-868-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-868-spec.ts
@@ -6,9 +6,10 @@
 
 import { getContainer } from '../util/helpers';
 import * as mockDataConfig from '../data/data-issue-868.json';
+import type { S2Options } from '../../src';
 import { PivotSheet } from '@/sheet-type';
 
-const s2Options = {
+const s2Options: S2Options = {
   width: 800,
   height: 600,
 };

--- a/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
+++ b/packages/s2-core/__tests__/unit/cell/data-cell-spec.ts
@@ -111,6 +111,7 @@ describe('Data Cell Tests', () => {
         getRowLeafNodes: () => [],
         getRowLeafNodeByIndex: jest.fn(),
         getCells: () => [],
+        destroy: jest.fn(),
       } as unknown as PivotFacet;
 
       await s2.render();
@@ -222,6 +223,7 @@ describe('Data Cell Tests', () => {
         getRowLeafNodes: () => [],
         getRowLeafNodeByIndex: jest.fn(),
         getCells: () => [],
+        destroy: jest.fn(),
       } as unknown as PivotFacet;
 
       await s2.render();

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -148,6 +148,7 @@ export const createFakeSpreadSheet = (config?: {
       [FrozenGroupType.FROZEN_TRAILING_COL]: {},
     },
     cornerBBox: {},
+    destroy: jest.fn(),
   } as unknown as BaseFacet;
   s2.container.render = jest.fn();
   s2.store = new Store();

--- a/packages/s2-core/src/common/constant/events/basic.ts
+++ b/packages/s2-core/src/common/constant/events/basic.ts
@@ -56,7 +56,7 @@ export enum S2Event {
   MERGED_CELLS_HOVER = 'merged-cells:hover',
   MERGED_CELLS_CLICK = 'merged-cells:click',
   MERGED_CELLS_DOUBLE_CLICK = 'merged-cells:double-click',
-  MERGED_CELLS_CONTEXT_MENU = 'merged-cell:context-menu',
+  MERGED_CELLS_CONTEXT_MENU = 'merged-cells:context-menu',
   MERGED_CELLS_MOUSE_DOWN = 'merged-cells:mouse-down',
   MERGED_CELLS_MOUSE_UP = 'merged-cells:mouse-up',
   MERGED_CELLS_MOUSE_MOVE = 'merged-cells:mouse-move',

--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -56,7 +56,6 @@ export class GuiIcon extends Group {
 
       const img = new Image();
 
-      // 成功
       img.onload = () => {
         ImageCache[cacheKey] = img;
         resolve(img);


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

🐛 Bugfix

- [x] Solve the issue and close #2333 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

![image](https://github.com/antvis/S2/assets/21015895/50a65f5c-c770-4e41-8694-304b87d47685)

默认单元格内的 icon 点击时会进行拦截, 不会触发单元格的点击事件, 避免触发选中, 但是 dataCell 没有做处理, 如果通过自定义 dataCell 的方式, 绘制自定义 icon, 这个时候应该拦截

相关 issue #2333 , 在 1.x 考虑到影响面未做修改, 2.0 中修改拦截的规则, 对所有单元格生效 (字段标记生成的 icon 除外)

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![Kapture 2024-02-28 at 19 11 56](https://github.com/antvis/S2/assets/21015895/2c641100-70e0-46d4-8a15-ce8dd81bbe9b) | ![Kapture 2024-02-28 at 19 09 47](https://github.com/antvis/S2/assets/21015895/c3f26b83-8522-45a1-9b61-53065cfb3772) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
