### PR TITLE
fix: 调整换行高度自适应和自定义高度的优先级 close #2613

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
@@ -1323,7 +1323,815 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests PivotSheet should force adaptive adjust cell height if custom cell style less than actual text height 1`] = `
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 96,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "城市城市城市",
+      "城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 96,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 272,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 272,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 144,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 192,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 144,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省",
+      "浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 99,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "23672367236",
+      "1111",
+    ],
+    "originalText": "236723672361111",
+    "width": 96,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 96,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": "1723",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1822",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1822",
+    ],
+    "originalText": "1822",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1943",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1943",
+    ],
+    "originalText": "1943",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2330",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2330",
+    ],
+    "originalText": "2330",
+    "width": 96,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 96,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 96,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 96,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2451",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2451",
+    ],
+    "originalText": "2451",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2244",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2244",
+    ],
+    "originalText": "2244",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2333",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2333",
+    ],
+    "originalText": "2333",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2445",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2445",
+    ],
+    "originalText": "2445",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height() 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 96,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "城市城市城市",
+      "城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 96,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 272,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 272,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height() 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 144,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height() 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 192,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height() 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 144,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省",
+      "浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height() 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 99,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "23672367236",
+      "1111",
+    ],
+    "originalText": "236723672361111",
+    "width": 96,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 96,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": "1723",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1822",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1822",
+    ],
+    "originalText": "1822",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1943",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1943",
+    ],
+    "originalText": "1943",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2330",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2330",
+    ],
+    "originalText": "2330",
+    "width": 96,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 96,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 96,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 96,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2451",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2451",
+    ],
+    "originalText": "2451",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2244",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2244",
+    ],
+    "originalText": "2244",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2333",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2333",
+    ],
+    "originalText": "2333",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2445",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2445",
+    ],
+    "originalText": "2445",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by dataCell.height 1`] = `
 Array [
   Object {
     "actualText": "序号",
@@ -1384,13 +2192,13 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests PivotSheet should force adaptive adjust cell height if custom cell style less than actual text height 2`] = `
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by dataCell.height 2`] = `
 Array [
   Object {
     "actualText": "1",
     "actualTextHeight": 15,
     "actualTextWidth": 7,
-    "height": 137,
+    "height": 134,
     "multiLineActualTexts": Array [
       "1",
     ],
@@ -1422,7 +2230,7 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests PivotSheet should force adaptive adjust cell height if custom cell style less than actual text height 3`] = `
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by dataCell.height 3`] = `
 Array [
   Object {
     "actualText": "家具",
@@ -1484,13 +2292,13 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests PivotSheet should force adaptive adjust cell height if custom cell style less than actual text height 4`] = `
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by dataCell.height 4`] = `
 Array [
   Object {
     "actualText": "浙江省",
     "actualTextHeight": 16,
     "actualTextWidth": 37,
-    "height": 137,
+    "height": 134,
     "multiLineActualTexts": Array [
       "浙江省",
     ],
@@ -1523,13 +2331,13 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests PivotSheet should force adaptive adjust cell height if custom cell style less than actual text height 5`] = `
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by dataCell.height 5`] = `
 Array [
   Object {
     "actualText": "236723672361111",
     "actualTextHeight": 30,
     "actualTextWidth": 99,
-    "height": 23,
+    "height": 20,
     "multiLineActualTexts": Array [
       "23672367236",
       "1111",
@@ -1618,7 +2426,771 @@ Array [
     "actualText": "632",
     "actualTextHeight": 15,
     "actualTextWidth": 21,
-    "height": 23,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 96,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 96,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 96,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2451",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2451",
+    ],
+    "originalText": "2451",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2244",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2244",
+    ],
+    "originalText": "2244",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2333",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2333",
+    ],
+    "originalText": "2333",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 96,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "城市城市城市",
+      "城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 96,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 272,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 272,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 134,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 192,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 134,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省",
+      "浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 99,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "23672367236",
+      "1111",
+    ],
+    "originalText": "236723672361111",
+    "width": 96,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 96,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": "1723",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1822",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1822",
+    ],
+    "originalText": "1822",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1943",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1943",
+    ],
+    "originalText": "1943",
+    "width": 96,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 96,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 96,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 96,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2451",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2451",
+    ],
+    "originalText": "2451",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2244",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2244",
+    ],
+    "originalText": "2244",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2333",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "2333",
+    ],
+    "originalText": "2333",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height() 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 96,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "城市城市城市",
+      "城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 96,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 272,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 272,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height() 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 134,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height() 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 192,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height() 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 134,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省",
+      "浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 152,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by rowCell.height() 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 99,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "23672367236",
+      "1111",
+    ],
+    "originalText": "236723672361111",
+    "width": 96,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 96,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": "1723",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1822",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1822",
+    ],
+    "originalText": "1822",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1943",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "1943",
+    ],
+    "originalText": "1943",
+    "width": 96,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
     "multiLineActualTexts": Array [
       "632",
     ],
@@ -1864,6 +3436,643 @@ Array [
       "834",
     ],
     "originalText": "834",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 96,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "actualTextHeight": 64,
+    "actualTextWidth": 292,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "城市城市城市",
+      "城市城市城市",
+      "城市城市城市",
+      "城市城市城市",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 96,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 50,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 272,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 272,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 189,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 50,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 192,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 60,
+    "actualTextWidth": 268,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数量",
+      "数量数量数量",
+      "数量数量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 60,
+    "actualTextWidth": 268,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数量",
+      "数量数量数量",
+      "数量数量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 189,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 99,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "23672367236",
+      "1111",
+    ],
+    "originalText": "236723672361111",
+    "width": 96,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 53,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 96,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 53,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 53,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 96,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 53,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 96,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 53,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 96,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 53,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by rowCell.heightByField 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 96,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "城市城市城市",
+      "城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 96,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 272,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 272,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by rowCell.heightByField 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 140,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 155,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by rowCell.heightByField 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 192,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 96,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 144,
+    "height": 38,
+    "multiLineActualTexts": Array [
+      "数量数量数量",
+      "数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by rowCell.heightByField 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 140,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 144,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省",
+      "浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 96,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 155,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 96,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by rowCell.heightByField 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 99,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "23672367236",
+      "1111",
+    ],
+    "originalText": "236723672361111",
+    "width": 96,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 96,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 50,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": "1723",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1822",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "1822",
+    ],
+    "originalText": "1822",
+    "width": 96,
+  },
+  Object {
+    "actualText": "1943",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "1943",
+    ],
+    "originalText": "1943",
+    "width": 96,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 96,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 96,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 96,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 96,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2451",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 50,
+    "multiLineActualTexts": Array [
+      "2451",
+    ],
+    "originalText": "2451",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2244",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "2244",
+    ],
+    "originalText": "2244",
+    "width": 96,
+  },
+  Object {
+    "actualText": "2333",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 35,
+    "multiLineActualTexts": Array [
+      "2333",
+    ],
+    "originalText": "2333",
     "width": 96,
   },
 ]
@@ -8683,1194 +10892,7 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust cell height if custom cell style less than actual text height 1`] = `
-Array [
-  Object {
-    "actualText": "序号",
-    "actualTextHeight": 16,
-    "actualTextWidth": 25,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "序号",
-    ],
-    "originalText": "序号",
-    "width": 80,
-  },
-]
-`;
-
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust cell height if custom cell style less than actual text height 2`] = `
-Array [
-  Object {
-    "actualText": "1",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "1",
-    ],
-    "originalText": "1",
-    "width": 80,
-  },
-  Object {
-    "actualText": "2",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "2",
-    ],
-    "originalText": "2",
-    "width": 80,
-  },
-  Object {
-    "actualText": "3",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "3",
-    ],
-    "originalText": "3",
-    "width": 80,
-  },
-  Object {
-    "actualText": "4",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "4",
-    ],
-    "originalText": "4",
-    "width": 80,
-  },
-  Object {
-    "actualText": "5",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "5",
-    ],
-    "originalText": "5",
-    "width": 80,
-  },
-  Object {
-    "actualText": "6",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "6",
-    ],
-    "originalText": "6",
-    "width": 80,
-  },
-  Object {
-    "actualText": "7",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "7",
-    ],
-    "originalText": "7",
-    "width": 80,
-  },
-  Object {
-    "actualText": "8",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "8",
-    ],
-    "originalText": "8",
-    "width": 80,
-  },
-  Object {
-    "actualText": "9",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "9",
-    ],
-    "originalText": "9",
-    "width": 80,
-  },
-  Object {
-    "actualText": "10",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "10",
-    ],
-    "originalText": "10",
-    "width": 80,
-  },
-  Object {
-    "actualText": "11",
-    "actualTextHeight": 15,
-    "actualTextWidth": 13,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "11",
-    ],
-    "originalText": "11",
-    "width": 80,
-  },
-  Object {
-    "actualText": "12",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "12",
-    ],
-    "originalText": "12",
-    "width": 80,
-  },
-  Object {
-    "actualText": "13",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "13",
-    ],
-    "originalText": "13",
-    "width": 80,
-  },
-  Object {
-    "actualText": "14",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "14",
-    ],
-    "originalText": "14",
-    "width": 80,
-  },
-]
-`;
-
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust cell height if custom cell style less than actual text height 3`] = `
-Array [
-  Object {
-    "actualText": "序号",
-    "actualTextHeight": 16,
-    "actualTextWidth": 25,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "序号",
-    ],
-    "originalText": "序号",
-    "width": 80,
-  },
-  Object {
-    "actualText": "省份",
-    "actualTextHeight": 16,
-    "actualTextWidth": 25,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "省份",
-    ],
-    "originalText": "省份",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "城市城市城市城市城市城市城...",
-    "actualTextHeight": 32,
-    "actualTextWidth": 168,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "城市城市城市城",
-      "市城市城市城...",
-    ],
-    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "类别类别类别类别类别类别类...",
-    "actualTextHeight": 32,
-    "actualTextWidth": 168,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "类别类别类别类",
-      "别类别类别类...",
-    ],
-    "originalText": "类别类别类别类别类别类别类别类别类别类别",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "子类别",
-    "actualTextHeight": 16,
-    "actualTextWidth": 37,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "子类别",
-    ],
-    "originalText": "子类别",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "数量数量数量数量数量数量数...",
-    "actualTextHeight": 32,
-    "actualTextWidth": 168,
-    "height": 40,
-    "multiLineActualTexts": Array [
-      "数量数量数量数",
-      "量数量数量数...",
-    ],
-    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
-    "width": 103.8,
-  },
-]
-`;
-
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust cell height if custom cell style less than actual text height 4`] = `Array []`;
-
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust cell height if custom cell style less than actual text height 5`] = `
-Array [
-  Object {
-    "actualText": "1",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "1",
-    ],
-    "originalText": "1",
-    "width": 80,
-  },
-  Object {
-    "actualText": "2",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "2",
-    ],
-    "originalText": "2",
-    "width": 80,
-  },
-  Object {
-    "actualText": "3",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "3",
-    ],
-    "originalText": "3",
-    "width": 80,
-  },
-  Object {
-    "actualText": "4",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "4",
-    ],
-    "originalText": "4",
-    "width": 80,
-  },
-  Object {
-    "actualText": "5",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "5",
-    ],
-    "originalText": "5",
-    "width": 80,
-  },
-  Object {
-    "actualText": "6",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "6",
-    ],
-    "originalText": "6",
-    "width": 80,
-  },
-  Object {
-    "actualText": "7",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "7",
-    ],
-    "originalText": "7",
-    "width": 80,
-  },
-  Object {
-    "actualText": "8",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "8",
-    ],
-    "originalText": "8",
-    "width": 80,
-  },
-  Object {
-    "actualText": "9",
-    "actualTextHeight": 15,
-    "actualTextWidth": 7,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "9",
-    ],
-    "originalText": "9",
-    "width": 80,
-  },
-  Object {
-    "actualText": "10",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "10",
-    ],
-    "originalText": "10",
-    "width": 80,
-  },
-  Object {
-    "actualText": "11",
-    "actualTextHeight": 15,
-    "actualTextWidth": 13,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "11",
-    ],
-    "originalText": "11",
-    "width": 80,
-  },
-  Object {
-    "actualText": "12",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "12",
-    ],
-    "originalText": "12",
-    "width": 80,
-  },
-  Object {
-    "actualText": "13",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "13",
-    ],
-    "originalText": "13",
-    "width": 80,
-  },
-  Object {
-    "actualText": "14",
-    "actualTextHeight": 15,
-    "actualTextWidth": 14,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "14",
-    ],
-    "originalText": "14",
-    "width": 80,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省浙江省浙江省浙江省浙...",
-    "actualTextHeight": 30,
-    "actualTextWidth": 168,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "浙江省浙江省浙",
-      "江省浙江省浙...",
-    ],
-    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "浙江省",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "浙江省",
-    ],
-    "originalText": "浙江省",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "绍兴市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "绍兴市",
-    ],
-    "originalText": "绍兴市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "杭州市杭州市杭州市杭州市杭...",
-    "actualTextHeight": 30,
-    "actualTextWidth": 168,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "杭州市杭州市杭",
-      "州市杭州市杭...",
-    ],
-    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "绍兴市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "绍兴市",
-    ],
-    "originalText": "绍兴市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "宁波市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "宁波市",
-    ],
-    "originalText": "宁波市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "舟山市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "舟山市",
-    ],
-    "originalText": "舟山市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "杭州市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "杭州市",
-    ],
-    "originalText": "杭州市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "绍兴市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "绍兴市",
-    ],
-    "originalText": "绍兴市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "宁波市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "宁波市",
-    ],
-    "originalText": "宁波市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "舟山市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "舟山市",
-    ],
-    "originalText": "舟山市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "杭州市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "杭州市",
-    ],
-    "originalText": "杭州市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "绍兴市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "绍兴市",
-    ],
-    "originalText": "绍兴市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "宁波市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "宁波市",
-    ],
-    "originalText": "宁波市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "舟山市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "舟山市",
-    ],
-    "originalText": "舟山市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "杭州市",
-    "actualTextHeight": 15,
-    "actualTextWidth": 37,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "杭州市",
-    ],
-    "originalText": "杭州市",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具家具家具家具家具家具家...",
-    "actualTextHeight": 30,
-    "actualTextWidth": 168,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "家具家具家具家",
-      "具家具家具家...",
-    ],
-    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "家具",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "家具",
-    ],
-    "originalText": "家具",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "办公用品",
-    "actualTextHeight": 15,
-    "actualTextWidth": 49,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "办公用品",
-    ],
-    "originalText": "办公用品",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "办公用品",
-    "actualTextHeight": 15,
-    "actualTextWidth": 49,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "办公用品",
-    ],
-    "originalText": "办公用品",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "办公用品",
-    "actualTextHeight": 15,
-    "actualTextWidth": 49,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "办公用品",
-    ],
-    "originalText": "办公用品",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "办公用品",
-    "actualTextHeight": 15,
-    "actualTextWidth": 49,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "办公用品",
-    ],
-    "originalText": "办公用品",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "办公用品",
-    "actualTextHeight": 15,
-    "actualTextWidth": 49,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "办公用品",
-    ],
-    "originalText": "办公用品",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "桌子",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "桌子",
-    ],
-    "originalText": "桌子",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "桌子桌子桌子桌子桌子桌子桌...",
-    "actualTextHeight": 30,
-    "actualTextWidth": 168,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "桌子桌子桌子桌",
-      "子桌子桌子桌...",
-    ],
-    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "桌子",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "桌子",
-    ],
-    "originalText": "桌子",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "桌子",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "桌子",
-    ],
-    "originalText": "桌子",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "桌子",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "桌子",
-    ],
-    "originalText": "桌子",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "沙发",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "沙发",
-    ],
-    "originalText": "沙发",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "沙发",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "沙发",
-    ],
-    "originalText": "沙发",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "沙发",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "沙发",
-    ],
-    "originalText": "沙发",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "沙发",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "沙发",
-    ],
-    "originalText": "沙发",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "笔",
-    "actualTextHeight": 15,
-    "actualTextWidth": 13,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "笔",
-    ],
-    "originalText": "笔",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "笔",
-    "actualTextHeight": 15,
-    "actualTextWidth": 13,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "笔",
-    ],
-    "originalText": "笔",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "笔",
-    "actualTextHeight": 15,
-    "actualTextWidth": 13,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "笔",
-    ],
-    "originalText": "笔",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "笔",
-    "actualTextHeight": 15,
-    "actualTextWidth": 13,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "笔",
-    ],
-    "originalText": "笔",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "纸张",
-    "actualTextHeight": 15,
-    "actualTextWidth": 25,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "纸张",
-    ],
-    "originalText": "纸张",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
-    ],
-    "originalText": "236723672361111",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "778977897789778977897789...",
-    "actualTextHeight": 30,
-    "actualTextWidth": 172,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "7789778977897",
-      "78977897789...",
-    ],
-    "originalText": "7789778977897789778977897789",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
-    "height": 46,
-    "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
-    ],
-    "originalText": "236723672361111",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "3877",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "3877",
-    ],
-    "originalText": "3877",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "4342",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "4342",
-    ],
-    "originalText": "4342",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "5343",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "5343",
-    ],
-    "originalText": "5343",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "632",
-    "actualTextHeight": 15,
-    "actualTextWidth": 21,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "632",
-    ],
-    "originalText": "632",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "7234",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "7234",
-    ],
-    "originalText": "7234",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "834",
-    "actualTextHeight": 15,
-    "actualTextWidth": 21,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "834",
-    ],
-    "originalText": "834",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "945",
-    "actualTextHeight": 15,
-    "actualTextWidth": 21,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "945",
-    ],
-    "originalText": "945",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "1304",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "1304",
-    ],
-    "originalText": "1304",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "1145",
-    "actualTextHeight": 15,
-    "actualTextWidth": 26,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "1145",
-    ],
-    "originalText": "1145",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "1432",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "1432",
-    ],
-    "originalText": "1432",
-    "width": 103.8,
-  },
-  Object {
-    "actualText": "1343",
-    "actualTextHeight": 15,
-    "actualTextWidth": 27,
-    "height": 20,
-    "multiLineActualTexts": Array [
-      "1343",
-    ],
-    "originalText": "1343",
-    "width": 103.8,
-  },
-]
-`;
-
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style less than actual text height 1`] = `
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 1`] = `
 Array [
   Object {
     "actualText": "序号",
@@ -9886,7 +10908,7 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style less than actual text height 2`] = `
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 2`] = `
 Array [
   Object {
     "actualText": "1",
@@ -10001,7 +11023,7 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style less than actual text height 3`] = `
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 3`] = `
 Array [
   Object {
     "actualText": "序号",
@@ -10078,9 +11100,9 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style less than actual text height 4`] = `Array []`;
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 4`] = `Array []`;
 
-exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style less than actual text height 5`] = `
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 5`] = `
 Array [
   Object {
     "actualText": "1",
@@ -10757,6 +11779,2495 @@ Array [
 ]
 `;
 
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 61,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text not wrap 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text not wrap 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text not wrap 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "province",
+    "actualTextHeight": 16,
+    "actualTextWidth": 51,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "province",
+    ],
+    "originalText": "province",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "city",
+    "actualTextHeight": 16,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "city",
+    ],
+    "originalText": "city",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "type",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "type",
+    ],
+    "originalText": "type",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "sub_type",
+    "actualTextHeight": 16,
+    "actualTextWidth": 53,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "sub_type",
+    ],
+    "originalText": "sub_type",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "number",
+    "actualTextHeight": 16,
+    "actualTextWidth": 45,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "number",
+    ],
+    "originalText": "number",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text not wrap 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text not wrap 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1304",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1304",
+    ],
+    "originalText": "1304",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1145",
+    "actualTextHeight": 15,
+    "actualTextWidth": 26,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1145",
+    ],
+    "originalText": "1145",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1432",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1432",
+    ],
+    "originalText": "1432",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1343",
+    ],
+    "originalText": "1343",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text wrap 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text wrap 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text wrap 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text wrap 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should get correctly cell height priority if actual text wrap 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 70,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+]
+`;
+
 exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust cell height if custom cell style more than actual text height 1`] = `
 Array [
   Object {
@@ -10826,6 +14337,9053 @@ Array [
       "量数量数量数...",
     ],
     "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "actualTextHeight": 64,
+    "actualTextWidth": 292,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市城",
+      "市城市",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 50,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 64,
+    "actualTextWidth": 268,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量数",
+      "量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省...",
+    "actualTextHeight": 60,
+    "actualTextWidth": 338,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江省",
+      "浙江省浙江省...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市...",
+    "actualTextHeight": 60,
+    "actualTextWidth": 338,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州市",
+      "杭州市杭州市...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "actualTextHeight": 60,
+    "actualTextWidth": 340,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具家",
+      "具家具家具家具",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌...",
+    "actualTextHeight": 60,
+    "actualTextWidth": 338,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子桌",
+      "子桌子桌子桌...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 76,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style less than actual text height by dataCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style less than actual text height by dataCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+  Object {
+    "actualText": "14",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "14",
+    ],
+    "originalText": "14",
+    "width": 80,
+  },
+  Object {
+    "actualText": "15",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "15",
+    ],
+    "originalText": "15",
+    "width": 80,
+  },
+  Object {
+    "actualText": "16",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "16",
+    ],
+    "originalText": "16",
+    "width": 80,
+  },
+  Object {
+    "actualText": "17",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "17",
+    ],
+    "originalText": "17",
+    "width": 80,
+  },
+  Object {
+    "actualText": "18",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "18",
+    ],
+    "originalText": "18",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style less than actual text height by dataCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类...",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style less than actual text height by dataCell.height 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style less than actual text height by dataCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+  Object {
+    "actualText": "14",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "14",
+    ],
+    "originalText": "14",
+    "width": 80,
+  },
+  Object {
+    "actualText": "15",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "15",
+    ],
+    "originalText": "15",
+    "width": 80,
+  },
+  Object {
+    "actualText": "16",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "16",
+    ],
+    "originalText": "16",
+    "width": 80,
+  },
+  Object {
+    "actualText": "17",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "17",
+    ],
+    "originalText": "17",
+    "width": 80,
+  },
+  Object {
+    "actualText": "18",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "18",
+    ],
+    "originalText": "18",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "成都市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "成都市",
+    ],
+    "originalText": "成都市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "778977897789778977897789...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 172,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "78977897789...",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1304",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1304",
+    ],
+    "originalText": "1304",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1145",
+    "actualTextHeight": 15,
+    "actualTextWidth": 26,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1145",
+    ],
+    "originalText": "1145",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1432",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1432",
+    ],
+    "originalText": "1432",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1343",
+    ],
+    "originalText": "1343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1354",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1354",
+    ],
+    "originalText": "1354",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1523",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1523",
+    ],
+    "originalText": "1523",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1634",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1634",
+    ],
+    "originalText": "1634",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": "1723",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style more than actual text height by dataCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style more than actual text height by dataCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style more than actual text height by dataCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类...",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 40,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style more than actual text height by dataCell.height 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not adaptive adjust data cell height if custom cell style more than actual text height by dataCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "778977897789778977897789...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 172,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "78977897789...",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust cell height if custom cell style less than actual text height by colCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust cell height if custom cell style less than actual text height by colCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust cell height if custom cell style less than actual text height by colCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类...",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数...",
+    "actualTextHeight": 32,
+    "actualTextWidth": 168,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust cell height if custom cell style less than actual text height by colCell.height 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust cell height if custom cell style less than actual text height by colCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 168,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "778977897789778977897789...",
+    "actualTextHeight": 30,
+    "actualTextWidth": 172,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "78977897789...",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1304",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1304",
+    ],
+    "originalText": "1304",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+  Object {
+    "actualText": "14",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "14",
+    ],
+    "originalText": "14",
+    "width": 80,
+  },
+  Object {
+    "actualText": "15",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "15",
+    ],
+    "originalText": "15",
+    "width": 80,
+  },
+  Object {
+    "actualText": "16",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "16",
+    ],
+    "originalText": "16",
+    "width": 80,
+  },
+  Object {
+    "actualText": "17",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "17",
+    ],
+    "originalText": "17",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.height 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+  Object {
+    "actualText": "14",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "14",
+    ],
+    "originalText": "14",
+    "width": 80,
+  },
+  Object {
+    "actualText": "15",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "15",
+    ],
+    "originalText": "15",
+    "width": 80,
+  },
+  Object {
+    "actualText": "16",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "16",
+    ],
+    "originalText": "16",
+    "width": 80,
+  },
+  Object {
+    "actualText": "17",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "17",
+    ],
+    "originalText": "17",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "纸张",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "纸张",
+    ],
+    "originalText": "纸张",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1304",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1304",
+    ],
+    "originalText": "1304",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1145",
+    "actualTextHeight": 15,
+    "actualTextWidth": 26,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1145",
+    ],
+    "originalText": "1145",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1432",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1432",
+    ],
+    "originalText": "1432",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1343",
+    ],
+    "originalText": "1343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1354",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1354",
+    ],
+    "originalText": "1354",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1523",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1523",
+    ],
+    "originalText": "1523",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1634",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "1634",
+    ],
+    "originalText": "1634",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.heightByField 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.heightByField 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.heightByField 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.heightByField 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style less than actual text height by rowCell.heightByField 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 20,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.height 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "城市城市城市城",
+      "市城市城市城市",
+      "城市城市城市...",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 48,
+    "actualTextWidth": 243,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "类别类别类别类",
+      "别类别类别类别",
+      "类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量...",
+    "actualTextHeight": 48,
+    "actualTextWidth": 253,
+    "height": 56,
+    "multiLineActualTexts": Array [
+      "数量数量数量数",
+      "量数量数量数量",
+      "数量数量数量...",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not force adaptive adjust row height if custom cell style more than actual text height by rowCell.heightByField 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙",
+      "江省浙江省浙江",
+      "省浙江省浙江...",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭",
+      "州市杭州市杭州",
+      "市杭州市杭州...",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "家具家具家具家",
+      "具家具家具家具",
+      "家具家具家具...",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
+    "actualTextHeight": 45,
+    "actualTextWidth": 253,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌",
+      "子桌子桌子桌子",
+      "桌子桌子桌子...",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 45,
+    "actualTextWidth": 189,
+    "height": 100,
+    "multiLineActualTexts": Array [
+      "7789778977897",
+      "7897789778977",
+      "89",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 30,
+    "actualTextWidth": 100,
+    "height": 46,
+    "multiLineActualTexts": Array [
+      "2367236723611",
+      "11",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not render word wrap text 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not render word wrap text 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not render word wrap text 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "actualTextHeight": 16,
+    "actualTextWidth": 289,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "城市城市城市城市城市城市城市城市城市城市城市城市",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 16,
+    "actualTextWidth": 265,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "数量数量数量数量数量数量数量数量数量数量数量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not render word wrap text 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should not render word wrap text 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 361,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 361,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 337,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 361,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 15,
+    "actualTextWidth": 98,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "236723672361111",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778977897789778977897789",
+    "actualTextHeight": 15,
+    "actualTextWidth": 187,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7789778977897789778977897789",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 15,
+    "actualTextWidth": 98,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "236723672361111",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1304",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1304",
+    ],
+    "originalText": "1304",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1145",
+    "actualTextHeight": 15,
+    "actualTextWidth": 26,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1145",
+    ],
+    "originalText": "1145",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1432",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1432",
+    ],
+    "originalText": "1432",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should render custom text overflow text 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should render custom text overflow text 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should render custom text overflow text 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "城市城市@@@",
+    "actualTextHeight": 16,
+    "actualTextWidth": 84,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "城市城市@@@",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "类别类别@@@",
+    "actualTextHeight": 16,
+    "actualTextWidth": 84,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "类别类别@@@",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "数量数量@@@",
+    "actualTextHeight": 16,
+    "actualTextWidth": 84,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "数量数量@@@",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 103.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should render custom text overflow text 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should render custom text overflow text 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+  Object {
+    "actualText": "4",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4",
+    ],
+    "originalText": "4",
+    "width": 80,
+  },
+  Object {
+    "actualText": "5",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5",
+    ],
+    "originalText": "5",
+    "width": 80,
+  },
+  Object {
+    "actualText": "6",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "6",
+    ],
+    "originalText": "6",
+    "width": 80,
+  },
+  Object {
+    "actualText": "7",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7",
+    ],
+    "originalText": "7",
+    "width": 80,
+  },
+  Object {
+    "actualText": "8",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "8",
+    ],
+    "originalText": "8",
+    "width": 80,
+  },
+  Object {
+    "actualText": "9",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "9",
+    ],
+    "originalText": "9",
+    "width": 80,
+  },
+  Object {
+    "actualText": "10",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "10",
+    ],
+    "originalText": "10",
+    "width": 80,
+  },
+  Object {
+    "actualText": "11",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "11",
+    ],
+    "originalText": "11",
+    "width": 80,
+  },
+  Object {
+    "actualText": "12",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "12",
+    ],
+    "originalText": "12",
+    "width": 80,
+  },
+  Object {
+    "actualText": "13",
+    "actualTextHeight": 15,
+    "actualTextWidth": 14,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "13",
+    ],
+    "originalText": "13",
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省浙@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 85,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省浙@@@",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市杭@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 85,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市杭@@@",
+    ],
+    "originalText": "杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "杭州市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州市",
+    ],
+    "originalText": "杭州市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "绍兴市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "绍兴市",
+    ],
+    "originalText": "绍兴市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "宁波市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "宁波市",
+    ],
+    "originalText": "宁波市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "舟山市",
+    "actualTextHeight": 15,
+    "actualTextWidth": 37,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "舟山市",
+    ],
+    "originalText": "舟山市",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具家具@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 85,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具家具@@@",
+    ],
+    "originalText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "办公用品",
+    "actualTextHeight": 15,
+    "actualTextWidth": 49,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "办公用品",
+    ],
+    "originalText": "办公用品",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子桌子@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 85,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子桌子@@@",
+    ],
+    "originalText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "2367236@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2367236@@@",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7789778@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7789778@@@",
+    ],
+    "originalText": "7789778977897789778977897789",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "2367236@@@",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2367236@@@",
+    ],
+    "originalText": "236723672361111",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": "3877",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": "4342",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": "5343",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": "632",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": "7234",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": "834",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "945",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "945",
+    ],
+    "originalText": "945",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1304",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1304",
+    ],
+    "originalText": "1304",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1145",
+    "actualTextHeight": 15,
+    "actualTextWidth": 26,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1145",
+    ],
+    "originalText": "1145",
+    "width": 103.8,
+  },
+  Object {
+    "actualText": "1432",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1432",
+    ],
+    "originalText": "1432",
     "width": 103.8,
   },
 ]

--- a/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
+++ b/packages/s2-core/__tests__/unit/facet/table-facet-spec.ts
@@ -103,6 +103,7 @@ jest.mock('@/data-set/table-data-set', () => {
         getDisplayDataSet: jest.fn(() => data),
         getCellData: () => 1,
         getFieldMeta: jest.fn(),
+        getField: jest.fn(),
         getFieldFormatter: actualDataSet.prototype.getFieldFormatter,
         isEmpty: jest.fn(),
       };

--- a/packages/s2-core/src/common/constant/options.ts
+++ b/packages/s2-core/src/common/constant/options.ts
@@ -88,7 +88,9 @@ export const DEFAULT_OPTIONS: S2Options = {
     hiddenColumnFields: [],
     selectedCellsSpotlight: false,
     hoverHighlight: true,
-    hoverFocus: { duration: HOVER_FOCUS_DURATION },
+    hoverFocus: {
+      duration: HOVER_FOCUS_DURATION,
+    },
     scrollSpeedRatio: {
       horizontal: 1,
       vertical: 1,

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -313,6 +313,10 @@ export abstract class BaseFacet {
   }
 
   protected getColNodeHeight(colNode: Node, colsHierarchy: Hierarchy) {
+    if (!colNode) {
+      return 0;
+    }
+
     const { colCell: colCellStyle } = this.spreadsheet.options.style!;
     // 优先级: 列头拖拽 > 列头自定义高度 > 多行文本自适应高度 > 通用单元格高度
     const height =
@@ -339,6 +343,10 @@ export abstract class BaseFacet {
     colNode: Node,
     colsHierarchy: Hierarchy,
   ): number {
+    if (!colNode) {
+      return 0;
+    }
+
     const { colCell } = this.spreadsheet.options.style!;
 
     // 当前层级高度最大的单元格

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -16,7 +16,7 @@ import {
   size,
   sumBy,
 } from 'lodash';
-import { ColCell, RowCell, SeriesNumberCell } from '../cell';
+import { RowCell, SeriesNumberCell } from '../cell';
 import {
   DEFAULT_TREE_ROW_CELL_WIDTH,
   FRONT_GROUND_GROUP_FROZEN_Z_INDEX,
@@ -36,11 +36,11 @@ import type { PivotDataSet } from '../data-set/pivot-data-set';
 import { renderLine, safeJsonParse } from '../utils';
 import { getDataCellId } from '../utils/cell/data-cell';
 import { getActionIconConfig } from '../utils/cell/header-cell';
+import { getHeaderTotalStatus } from '../utils/dataset/pivot-data-set';
 import { getIndexRangeWithOffsets } from '../utils/facet';
 import { getRowsForGrid } from '../utils/grid';
 import { floor } from '../utils/math';
 import { getCellWidth } from '../utils/text';
-import { getHeaderTotalStatus } from '../utils/dataset/pivot-data-set';
 import { FrozenFacet } from './frozen-facet';
 import { Frame } from './header';
 import { buildHeaderHierarchy } from './layout/build-header-hierarchy';
@@ -402,20 +402,6 @@ export class PivotFacet extends FrozenFacet {
     const defaultHeight = this.getRowCellHeight(rowNode);
 
     return this.getCellAdaptiveHeight(rowCell, defaultHeight);
-  }
-
-  protected getColNodeHeight(colNode: Node, colsHierarchy: Hierarchy): number {
-    if (!colNode) {
-      return 0;
-    }
-
-    const colCell = new ColCell(colNode, this.spreadsheet, {
-      shallowRender: true,
-    });
-
-    const defaultHeight = this.getDefaultColNodeHeight(colNode, colsHierarchy);
-
-    return this.getCellAdaptiveHeight(colCell, defaultHeight);
   }
 
   /**

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -396,6 +396,10 @@ export class PivotFacet extends FrozenFacet {
   }
 
   private getRowNodeHeight(rowNode: Node): number {
+    if (!rowNode) {
+      return 0;
+    }
+
     const rowCell = new RowCell(rowNode, this.spreadsheet, {
       shallowRender: true,
     });

--- a/s2-site/docs/manual/advanced/custom/cell-size.zh.md
+++ b/s2-site/docs/manual/advanced/custom/cell-size.zh.md
@@ -8,7 +8,7 @@ S2 可以手动拖拽动态改变单元格的宽高，同时内置了 `行列等
 
 我们可以通过 [主题](/docs/manual/basic/theme/) 修改单元格的背景色，字体大小等配置，如果想自定义单元格的宽高，可以通过 `s2Options` 的 [style](/docs/api/general/S2Options#style) 配置来实现
 
-<Playground path='layout/custom/demo/custom-pivot-size.ts' rid='container' height='400'></playground>
+<Playground path='layout/custom/demo/custom-pivot-size.ts' rid='custom-pivot-size' height='400'></playground>
 
 <br/>
 
@@ -81,7 +81,7 @@ const s2Options = {
       },
       height: (rowNode) => {
         // 例：偶数行高度 300pox, 奇数行默认高度
-        return rowNode.level % 2 === 0 ? 300 : null,
+        return rowNode.level % 2 === 0 ? 300 : null
       }
     },
   },
@@ -126,30 +126,6 @@ const s2Options = {
 ```
 
 <img src="https://gw.alipayobjects.com/zos/antfincdn/oaGLPvya5/bf8b9dfe-1873-4567-9c4b-400632cebbe3.png" alt="preview" width="600" />
-
-:::info{title="提示"}
-
-明细表有一点特殊，由于只有列头，如果想给**特定行**设置不同的高度，则可以根据**行序号**调整 （从 `0` 开始）
-
-:::
-
-```ts
-const s2Options = {
-  style: {
-    rowCell: {
-      // 给第一行和第三行设置不同的高度
-      heightByField: {
-        '0': 130,
-        '2': 60,
-      },
-    },
-  },
-}
-```
-
-<br/>
-
-<Playground path='layout/custom/demo/custom-table-size.ts' rid='container' height='400'></playground>
 
 ## 调整树状模式下行头宽度
 
@@ -242,6 +218,37 @@ const s2Options = {
 ```
 
 <img src="https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*lcRNQpDF2eMAAAAAAAAAAAAADmJ7AQ/original" alt="preview" width="600"/>
+
+## 调整明细表行高
+
+:::info{title="提示"}
+
+明细表有一点特殊，由于只有列头
+
+1. 如果想给**所有行**设置固定的行高，则可以通过 `rowCell.height` 调整
+2. 如果想给**特定行**设置不同的行高，则可以通过 `rowCell.heightByField` 根据**行索引**调整 （从 `0` 开始）
+
+:::
+
+```ts
+const s2Options = {
+  style: {
+    rowCell: {
+      // 设置行高
+      height: 40,
+      // 给第一行和第三行设置不同的高度
+      heightByField: {
+        '0': 130,
+        '2': 60,
+      },
+    },
+  },
+}
+```
+
+<br/>
+
+<Playground path='layout/custom/demo/custom-table-size.ts' rid='custom-table-size' height='400'></playground>
 
 ## 隐藏列头
 

--- a/s2-site/docs/manual/basic/multi-line-text.zh.md
+++ b/s2-site/docs/manual/basic/multi-line-text.zh.md
@@ -22,7 +22,7 @@ S2 内部适配了 `AntV/G 5.0` 的 [多行布局能力](https://g.antv.antgroup
 
 具体参数请跳转 `AntV/G` [官网查看](https://g.antv.antgroup.com/api/basic/text#%E5%A4%9A%E8%A1%8C%E5%B8%83%E5%B1%80).
 
-- `maxLines`: 最大行数，一个具体的整数，文本超出后将被截断 （默认值为 `1`)。
+- `maxLines`: 最大行数，一个具体的正整数，文本超出后将被截断 （默认值为 `1`)。
 - `wordWrap`: 是否开启自动折行，（默认值为 `false`).
 - `textOverflow`:
   - 'clip': 直接截断文本。
@@ -59,6 +59,14 @@ const s2Options = {
 };
 
 ```
+
+## 高度优先级
+
+:::info{title="提示"}
+
+开启文本自动换行后，默认会根据**文本实际的高度**调整对应单元格的高度。如果配置了 [自定义单元格宽高](/manual/advanced/custom/cell-size), 则高度自适应失效，以自定义的宽高为准。
+
+:::
 
 ## 效果
 

--- a/s2-site/examples/layout/custom/demo/custom-table-size.ts
+++ b/s2-site/examples/layout/custom/demo/custom-table-size.ts
@@ -44,6 +44,7 @@ fetch('https://render.alipay.com/p/yuyan/180020010001215413/s2/basic.json')
           height: 50,
         },
         colCell: {
+          width: 200,
           height: 50,
           widthByField: {
             // 特定维度 (如: 城市)
@@ -52,8 +53,10 @@ fetch('https://render.alipay.com/p/yuyan/180020010001215413/s2/basic.json')
             'root[&]province': 80,
           },
         },
-        // 明细表每一行根据行序号单独设置 (从 0 开始)
         rowCell: {
+          // 设置行高
+          height: 40,
+          // 明细表每一行根据行索引单独设置 (从 0 开始)
           heightByField: {
             '0': 40,
             '1': 130,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2613 

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

```ts
  s2.setOptions({
    style: {
      colCell: {
        height: 70,
      },
      rowCell: {
        heightByField: {
          0: 70,
          1: 100,
       	  2: 150,
        },
      },
    },
  });
```

1. 修复开启换行时, 且不存在换行文本时自定义单元格高度失效的问题, 现在自定义单元格宽高的优先级最高.
2. 完善相关单测和文档

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/e5384668-6b9a-4ef8-8b8d-fe4936d4c89f) | ![image](https://github.com/antvis/S2/assets/21015895/e5066769-b29a-426c-b615-8a1f6c1222e4) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
