### PR TITLE
fix: 修复紧凑模式下数值单元格错误的展示了省略号

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2385-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2385-spec.ts
@@ -5,7 +5,7 @@
 import { LayoutWidthType, type S2Options } from '../../src';
 import * as mockDataConfig from '../data/data-issue-2385.json';
 import { getContainer } from '../util/helpers';
-import { PivotSheet, TableSheet } from '@/sheet-type';
+import { PivotSheet, SpreadSheet, TableSheet } from '@/sheet-type';
 
 const s2Options: S2Options = {
   width: 800,
@@ -19,6 +19,12 @@ const s2Options: S2Options = {
 };
 
 describe('Compare Layout Tests', () => {
+  const expectTextOverflowing = (s2: SpreadSheet) => {
+    [...s2.facet.getColCells(), ...s2.facet.getDataCells()].forEach((cell) => {
+      expect(cell.getTextShape().isOverflowing()).toBeFalsy();
+    });
+  };
+
   test('should get max col width for pivot sheet', async () => {
     const s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
 
@@ -35,6 +41,7 @@ describe('Compare Layout Tests', () => {
 
     expect(Math.floor(colLeafNodes[0].width)).toBeCloseTo(189);
     expect(Math.floor(colLeafNodes[1].width)).toEqual(90);
+    expectTextOverflowing(s2);
   });
 
   test('should get max col width for table sheet', async () => {
@@ -58,5 +65,6 @@ describe('Compare Layout Tests', () => {
     const colLeafNodes = s2.facet.getColLeafNodes();
 
     expect(Math.floor(colLeafNodes[0].width)).toBeCloseTo(182);
+    expectTextOverflowing(s2);
   });
 });

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../../src';
 import { PivotDataSet } from '../../../src/data-set';
 import { PivotFacet } from '../../../src/facet';
-import { customMerge, setupS2DataConfig } from '@/utils';
+import { customMerge, setupDataConfig } from '@/utils';
 import { BaseTooltip } from '@/ui/tooltip';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
 import type { GEvent } from '@/index';
@@ -457,7 +457,7 @@ describe('PivotSheet Tests', () => {
     // save original data cfg
     expect(s2.store.get('originalDataCfg')).toEqual(newDataCfg);
     // update data cfg
-    expect(s2.dataCfg).toEqual(setupS2DataConfig(originalDataCfg, newDataCfg));
+    expect(s2.dataCfg).toEqual(setupDataConfig(originalDataCfg, newDataCfg));
   });
 
   test('should set options', () => {

--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -12,7 +12,7 @@ import type {
 } from '../../../src';
 import { PivotDataSet } from '../../../src/data-set';
 import { PivotFacet } from '../../../src/facet';
-import { customMerge, getSafetyDataConfig } from '@/utils';
+import { customMerge, setupS2DataConfig } from '@/utils';
 import { BaseTooltip } from '@/ui/tooltip';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
 import type { GEvent } from '@/index';
@@ -457,9 +457,7 @@ describe('PivotSheet Tests', () => {
     // save original data cfg
     expect(s2.store.get('originalDataCfg')).toEqual(newDataCfg);
     // update data cfg
-    expect(s2.dataCfg).toEqual(
-      getSafetyDataConfig(originalDataCfg, newDataCfg),
-    );
+    expect(s2.dataCfg).toEqual(setupS2DataConfig(originalDataCfg, newDataCfg));
   });
 
   test('should set options', () => {

--- a/packages/s2-core/__tests__/unit/utils/__snapshots__/merge-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/__snapshots__/merge-spec.ts.snap
@@ -115,3 +115,42 @@ Object {
   "width": 600,
 }
 `;
+
+exports[`merge test should setup correctly compact layout width type style 1`] = `
+Object {
+  "colCell": Object {
+    "height": 30,
+    "heightByField": null,
+    "maxLines": 1,
+    "textOverflow": "ellipsis",
+    "widthByField": null,
+    "wordWrap": true,
+  },
+  "cornerCell": Object {
+    "maxLines": 1,
+    "textOverflow": "ellipsis",
+    "wordWrap": true,
+  },
+  "dataCell": Object {
+    "height": 30,
+    "maxLines": 1,
+    "textOverflow": "ellipsis",
+    "width": 96,
+    "wordWrap": false,
+  },
+  "layoutWidthType": "compact",
+  "rowCell": Object {
+    "heightByField": null,
+    "maxLines": 1,
+    "showTreeLeafNodeAlignDot": false,
+    "textOverflow": "ellipsis",
+    "widthByField": null,
+    "wordWrap": true,
+  },
+  "seriesNumberCell": Object {
+    "maxLines": 1,
+    "textOverflow": "ellipsis",
+    "wordWrap": true,
+  },
+}
+`;

--- a/packages/s2-core/__tests__/unit/utils/merge-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-spec.ts
@@ -175,14 +175,13 @@ describe('merge test', () => {
     expect(setupOptions(null)).toMatchSnapshot();
   });
 
-  test('should setup correctly compact layout width type options', () => {
-    // 加这个测试可以防止 本地跑 demo 修改了默认配置 直接提交
+  test('should setup correctly compact layout width type style', () => {
     expect(
       setupOptions({
         style: {
           layoutWidthType: LayoutWidthType.Compact,
         },
-      }),
+      }).style,
     ).toMatchSnapshot();
   });
 

--- a/packages/s2-core/__tests__/unit/utils/merge-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-spec.ts
@@ -1,5 +1,5 @@
 import { LayoutWidthType, type S2DataConfig } from '@/common';
-import { customMerge, setupS2DataConfig, setupS2Options } from '@/utils/merge';
+import { customMerge, setupDataConfig, setupOptions } from '@/utils/merge';
 
 describe('merge test', () => {
   test('should replace old array with new one', () => {
@@ -23,7 +23,7 @@ describe('merge test', () => {
   });
 
   test('should get safety data config', () => {
-    expect(setupS2DataConfig(null)).toMatchInlineSnapshot(`
+    expect(setupDataConfig(null)).toMatchInlineSnapshot(`
       Object {
         "data": Array [],
         "fields": Object {
@@ -41,7 +41,7 @@ describe('merge test', () => {
 
   test('should unique dataConfig fields', () => {
     expect(
-      setupS2DataConfig({
+      setupDataConfig({
         fields: {
           rows: ['province', 'city', 'city'],
           columns: ['type', 'type'],
@@ -82,7 +82,7 @@ describe('merge test', () => {
     };
 
     expect(
-      setupS2DataConfig({
+      setupDataConfig({
         fields,
       }),
     ).toMatchInlineSnapshot(`
@@ -115,7 +115,7 @@ describe('merge test', () => {
     };
 
     expect(
-      setupS2DataConfig({
+      setupDataConfig({
         fields,
       }),
     ).toMatchInlineSnapshot(`
@@ -144,7 +144,7 @@ describe('merge test', () => {
     };
 
     expect(
-      setupS2DataConfig(oldDataCfg, {
+      setupDataConfig(oldDataCfg, {
         fields,
       }),
     ).toMatchInlineSnapshot(`
@@ -172,13 +172,13 @@ describe('merge test', () => {
 
   test('should get safety options', () => {
     // 加这个测试可以防止 本地跑 demo 修改了默认配置 直接提交
-    expect(setupS2Options(null)).toMatchSnapshot();
+    expect(setupOptions(null)).toMatchSnapshot();
   });
 
   test('should setup correctly compact layout width type options', () => {
     // 加这个测试可以防止 本地跑 demo 修改了默认配置 直接提交
     expect(
-      setupS2Options({
+      setupOptions({
         style: {
           layoutWidthType: LayoutWidthType.Compact,
         },
@@ -187,7 +187,7 @@ describe('merge test', () => {
   });
 
   test('should get custom options', () => {
-    const options = setupS2Options({
+    const options = setupOptions({
       tooltip: {
         enable: false,
         operation: {
@@ -225,7 +225,7 @@ describe('merge test', () => {
   });
 
   test('should get custom data config', () => {
-    const dataConfig = setupS2DataConfig({
+    const dataConfig = setupDataConfig({
       fields: {
         rows: ['test'],
         values: ['value'],

--- a/packages/s2-core/__tests__/unit/utils/merge-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/merge-spec.ts
@@ -1,9 +1,5 @@
-import type { S2DataConfig } from '@/common';
-import {
-  customMerge,
-  getSafetyDataConfig,
-  getSafetyOptions,
-} from '@/utils/merge';
+import { LayoutWidthType, type S2DataConfig } from '@/common';
+import { customMerge, setupS2DataConfig, setupS2Options } from '@/utils/merge';
 
 describe('merge test', () => {
   test('should replace old array with new one', () => {
@@ -27,7 +23,7 @@ describe('merge test', () => {
   });
 
   test('should get safety data config', () => {
-    expect(getSafetyDataConfig(null)).toMatchInlineSnapshot(`
+    expect(setupS2DataConfig(null)).toMatchInlineSnapshot(`
       Object {
         "data": Array [],
         "fields": Object {
@@ -45,7 +41,7 @@ describe('merge test', () => {
 
   test('should unique dataConfig fields', () => {
     expect(
-      getSafetyDataConfig({
+      setupS2DataConfig({
         fields: {
           rows: ['province', 'city', 'city'],
           columns: ['type', 'type'],
@@ -86,7 +82,7 @@ describe('merge test', () => {
     };
 
     expect(
-      getSafetyDataConfig({
+      setupS2DataConfig({
         fields,
       }),
     ).toMatchInlineSnapshot(`
@@ -119,7 +115,7 @@ describe('merge test', () => {
     };
 
     expect(
-      getSafetyDataConfig({
+      setupS2DataConfig({
         fields,
       }),
     ).toMatchInlineSnapshot(`
@@ -148,7 +144,7 @@ describe('merge test', () => {
     };
 
     expect(
-      getSafetyDataConfig(oldDataCfg, {
+      setupS2DataConfig(oldDataCfg, {
         fields,
       }),
     ).toMatchInlineSnapshot(`
@@ -176,11 +172,22 @@ describe('merge test', () => {
 
   test('should get safety options', () => {
     // 加这个测试可以防止 本地跑 demo 修改了默认配置 直接提交
-    expect(getSafetyOptions(null)).toMatchSnapshot();
+    expect(setupS2Options(null)).toMatchSnapshot();
+  });
+
+  test('should setup correctly compact layout width type options', () => {
+    // 加这个测试可以防止 本地跑 demo 修改了默认配置 直接提交
+    expect(
+      setupS2Options({
+        style: {
+          layoutWidthType: LayoutWidthType.Compact,
+        },
+      }),
+    ).toMatchSnapshot();
   });
 
   test('should get custom options', () => {
-    const options = getSafetyOptions({
+    const options = setupS2Options({
       tooltip: {
         enable: false,
         operation: {
@@ -218,7 +225,7 @@ describe('merge test', () => {
   });
 
   test('should get custom data config', () => {
-    const dataConfig = getSafetyDataConfig({
+    const dataConfig = setupS2DataConfig({
       fields: {
         rows: ['test'],
         values: ['value'],

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -886,8 +886,10 @@ export class PivotFacet extends FrozenFacet {
               valueData,
             ) ?? valueData;
           const cellLabel = `${formattedValue}`;
-          const cellLabelWidth =
-            this.spreadsheet.measureTextWidthRoughly(cellLabel);
+          const cellLabelWidth = this.spreadsheet.measureTextWidthRoughly(
+            cellLabel,
+            dataCellTextStyle,
+          );
 
           if (cellLabelWidth > maxDataLabelWidth) {
             maxDataLabel = cellLabel;

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -69,7 +69,7 @@ import { removeOffscreenCanvas } from '../utils/canvas';
 import { clearValueRangeState } from '../utils/condition/state-controller';
 import { hideColumnsByThunkGroup } from '../utils/hide-columns';
 import { isMobile } from '../utils/is-mobile';
-import { customMerge, setupS2DataConfig, setupS2Options } from '../utils/merge';
+import { customMerge, setupDataConfig, setupOptions } from '../utils/merge';
 import { injectThemeVars } from '../utils/theme';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
 import { getTheme } from '../theme';
@@ -142,8 +142,8 @@ export abstract class SpreadSheet extends EE {
     options: S2Options | null,
   ) {
     super();
-    this.dataCfg = setupS2DataConfig(dataCfg);
-    this.options = setupS2Options(options);
+    this.dataCfg = setupDataConfig(dataCfg);
+    this.options = setupOptions(options);
     this.dataSet = this.getDataSet();
     this.setDebug();
     this.initTooltip();
@@ -362,9 +362,9 @@ export abstract class SpreadSheet extends EE {
   ) {
     this.store.set('originalDataCfg', dataCfg);
     if (reset) {
-      this.dataCfg = setupS2DataConfig(dataCfg);
+      this.dataCfg = setupDataConfig(dataCfg);
     } else {
-      this.dataCfg = setupS2DataConfig(this.dataCfg, dataCfg);
+      this.dataCfg = setupDataConfig(this.dataCfg, dataCfg);
     }
 
     // clear value ranger after each updated data cfg
@@ -385,7 +385,7 @@ export abstract class SpreadSheet extends EE {
     this.hideTooltip();
 
     if (reset) {
-      this.options = setupS2Options(options);
+      this.options = setupOptions(options);
     } else {
       this.options = customMerge(this.options, options);
     }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -69,11 +69,7 @@ import { removeOffscreenCanvas } from '../utils/canvas';
 import { clearValueRangeState } from '../utils/condition/state-controller';
 import { hideColumnsByThunkGroup } from '../utils/hide-columns';
 import { isMobile } from '../utils/is-mobile';
-import {
-  customMerge,
-  getSafetyDataConfig,
-  getSafetyOptions,
-} from '../utils/merge';
+import { customMerge, setupS2DataConfig, setupS2Options } from '../utils/merge';
 import { injectThemeVars } from '../utils/theme';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
 import { getTheme } from '../theme';
@@ -146,8 +142,8 @@ export abstract class SpreadSheet extends EE {
     options: S2Options | null,
   ) {
     super();
-    this.dataCfg = getSafetyDataConfig(dataCfg);
-    this.options = getSafetyOptions(options);
+    this.dataCfg = setupS2DataConfig(dataCfg);
+    this.options = setupS2Options(options);
     this.dataSet = this.getDataSet();
     this.setDebug();
     this.initTooltip();
@@ -366,9 +362,9 @@ export abstract class SpreadSheet extends EE {
   ) {
     this.store.set('originalDataCfg', dataCfg);
     if (reset) {
-      this.dataCfg = getSafetyDataConfig(dataCfg);
+      this.dataCfg = setupS2DataConfig(dataCfg);
     } else {
-      this.dataCfg = getSafetyDataConfig(this.dataCfg, dataCfg);
+      this.dataCfg = setupS2DataConfig(this.dataCfg, dataCfg);
     }
 
     // clear value ranger after each updated data cfg
@@ -389,7 +385,7 @@ export abstract class SpreadSheet extends EE {
     this.hideTooltip();
 
     if (reset) {
-      this.options = getSafetyOptions(options);
+      this.options = setupS2Options(options);
     } else {
       this.options = customMerge(this.options, options);
     }

--- a/packages/s2-core/src/utils/merge.ts
+++ b/packages/s2-core/src/utils/merge.ts
@@ -1,6 +1,6 @@
 import { isArray, isEmpty, isEqual, isString, mergeWith, uniq } from 'lodash';
 import { DEFAULT_DATA_CONFIG } from '../common/constant/dataConfig';
-import { DEFAULT_OPTIONS } from '../common/constant/options';
+import { DEFAULT_OPTIONS, LayoutWidthType } from '../common/constant/options';
 import type {
   CustomHeaderFields,
   Fields,
@@ -41,9 +41,9 @@ const uniqueFields = (fields: Fields): Fields => {
   };
 };
 
-export const getSafetyDataConfig = (
+export const setupS2DataConfig = (
   ...dataConfig: (Partial<S2DataConfig> | null | undefined)[]
-) => {
+): S2DataConfig => {
   const mergedDataCfg = customMerge<S2DataConfig>(
     DEFAULT_DATA_CONFIG,
     ...dataConfig,
@@ -65,6 +65,14 @@ export const getSafetyDataConfig = (
   return mergedDataCfg;
 };
 
-export const getSafetyOptions = (
+export const setupS2Options = (
   options: Partial<S2Options> | null | undefined,
-) => customMerge<S2Options>(DEFAULT_OPTIONS, options);
+): S2Options => {
+  const mergedOptions = customMerge<S2Options>(DEFAULT_OPTIONS, options);
+
+  if (mergedOptions.style?.layoutWidthType === LayoutWidthType.Compact) {
+    mergedOptions.style.dataCell!.wordWrap = false;
+  }
+
+  return mergedOptions;
+};

--- a/packages/s2-core/src/utils/merge.ts
+++ b/packages/s2-core/src/utils/merge.ts
@@ -70,7 +70,10 @@ export const setupOptions = (
 ): S2Options => {
   const mergedOptions = customMerge<S2Options>(DEFAULT_OPTIONS, options);
 
-  if (mergedOptions.style?.layoutWidthType === LayoutWidthType.Compact) {
+  if (
+    mergedOptions.style?.layoutWidthType === LayoutWidthType.Compact &&
+    mergedOptions.style?.dataCell!.maxLines! <= 1
+  ) {
     mergedOptions.style.dataCell!.wordWrap = false;
   }
 

--- a/packages/s2-core/src/utils/merge.ts
+++ b/packages/s2-core/src/utils/merge.ts
@@ -41,7 +41,7 @@ const uniqueFields = (fields: Fields): Fields => {
   };
 };
 
-export const setupS2DataConfig = (
+export const setupDataConfig = (
   ...dataConfig: (Partial<S2DataConfig> | null | undefined)[]
 ): S2DataConfig => {
   const mergedDataCfg = customMerge<S2DataConfig>(
@@ -65,7 +65,7 @@ export const setupS2DataConfig = (
   return mergedDataCfg;
 };
 
-export const setupS2Options = (
+export const setupOptions = (
   options: Partial<S2Options> | null | undefined,
 ): S2Options => {
   const mergedOptions = customMerge<S2Options>(DEFAULT_OPTIONS, options);

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -1,4 +1,4 @@
-import { setupS2DataConfig, S2_PREFIX_CLS } from '@antv/s2';
+import { setupDataConfig, S2_PREFIX_CLS } from '@antv/s2';
 import { Spin } from 'antd';
 import React from 'react';
 import { injectThemeVars } from '@antv/s2-shared';
@@ -32,7 +32,7 @@ export const BaseSheet: React.FC<SheetComponentsProps> = React.memo((props) => {
             style={{
               width: options?.width,
             }}
-            dataCfg={setupS2DataConfig(dataCfg)}
+            dataCfg={setupDataConfig(dataCfg)}
             options={getSheetComponentOptions(options!)}
           />
         )}

--- a/packages/s2-react/src/components/sheets/base-sheet/index.tsx
+++ b/packages/s2-react/src/components/sheets/base-sheet/index.tsx
@@ -1,4 +1,4 @@
-import { getSafetyDataConfig, S2_PREFIX_CLS } from '@antv/s2';
+import { setupS2DataConfig, S2_PREFIX_CLS } from '@antv/s2';
 import { Spin } from 'antd';
 import React from 'react';
 import { injectThemeVars } from '@antv/s2-shared';
@@ -32,7 +32,7 @@ export const BaseSheet: React.FC<SheetComponentsProps> = React.memo((props) => {
             style={{
               width: options?.width,
             }}
-            dataCfg={getSafetyDataConfig(dataCfg)}
+            dataCfg={setupS2DataConfig(dataCfg)}
             options={getSheetComponentOptions(options!)}
           />
         )}

--- a/s2-site/docs/manual/migration-v2.zh.md
+++ b/s2-site/docs/manual/migration-v2.zh.md
@@ -691,6 +691,13 @@ const header = {
 
 具体请查看 [Tooltip](/manual/basic/tooltip) 相关文档。
 
+#### 配置预处理 API 变更
+
+```diff
+- import { getSafetyOptions, getSafetyDataConfig } from '@antv/s2'
++ import { setupOptions, setupDataConfig } from '@antv/s2'
+```
+
 ## ✍️ API 调整
 
 具体请查看标记为 <Badge type="success">New</Badge> 和 <Badge>Updated</Badge> 的 [`API 文档`](/api)


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

紧凑模式下列宽以单元格文本宽度为准 (前50), 不应该出现省略号

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/08765bb5-c9b8-4941-8179-deba205e0781) | ![image](https://github.com/antvis/S2/assets/21015895/fb66b98e-04ec-4be5-af39-14d636439b3f) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
