### PR TITLE
fix: 修复只有一行数据时异步导出数据为空 close #2681

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
@@ -42,3 +42,19 @@ Array [
   "自定义节点 a-2				",
 ]
 `;
+
+exports[`PivotSheet Export Test should export correctly data for single row data by { isAsyncExport: false } 1`] = `
+Array [
+  "	type	笔	笔",
+  "province	city	price	cost",
+  "浙江	义乌	1	2",
+]
+`;
+
+exports[`PivotSheet Export Test should export correctly data for single row data by { isAsyncExport: true } 1`] = `
+Array [
+  "	type	笔	笔",
+  "province	city	price	cost",
+  "浙江	义乌	1	2",
+]
+`;

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-table-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-table-spec.ts.snap
@@ -224,3 +224,17 @@ exports[`TableSheet Export Test should export correct data with totals 1`] = `
 浙江省-province	家具-type	桌子	4342
 浙江省-province	家具-type	沙发	5343"
 `;
+
+exports[`TableSheet Export Test should export correctly data for single row data by { isAsyncExport: false } 1`] = `
+Array [
+  "province	city	type	price	cost",
+  "浙江	杭州	笔	1	",
+]
+`;
+
+exports[`TableSheet Export Test should export correctly data for single row data by { isAsyncExport: true } 1`] = `
+Array [
+  "province	city	type	price	cost",
+  "浙江	杭州	笔	1	",
+]
+`;

--- a/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
@@ -2,7 +2,7 @@ import { NewLine, NewTab, PivotSheet, asyncGetAllPlainData } from '@antv/s2';
 import { map, omit } from 'lodash';
 import { data as originData } from 'tests/data/mock-dataset.json';
 import { assembleDataCfg, assembleOptions } from 'tests/util';
-import { getContainer } from 'tests/util/helpers';
+import { createPivotSheet, getContainer } from 'tests/util/helpers';
 import {
   customColGridSimpleFields,
   customRowGridSimpleFields,
@@ -601,4 +601,25 @@ describe('PivotSheet Export Test', () => {
 
     expect(data.split(NewLine)).toMatchSnapshot();
   });
+
+  // https://github.com/antvis/S2/issues/2681
+  it.each([{ isAsyncExport: false }, { isAsyncExport: true }])(
+    'should export correctly data for single row data by %o',
+    async (options) => {
+      const sheet = createPivotSheet({ width: 600, height: 400 });
+
+      sheet.setDataCfg({
+        data: sheet.dataCfg.data.slice(0, 1),
+      });
+
+      await sheet.render();
+      const data = await asyncGetAllPlainData({
+        sheetInstance: sheet,
+        split: '\t',
+        ...options,
+      });
+
+      expect(data.split(NewLine)).toMatchSnapshot();
+    },
+  );
 });

--- a/packages/s2-core/__tests__/unit/utils/export/export-table-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-table-spec.ts
@@ -1,11 +1,11 @@
 import { slice } from 'lodash';
 import { data as originData } from 'tests/data/mock-dataset.json';
 import { assembleDataCfg, assembleOptions } from '../../../util';
-import { getContainer } from '../../../util/helpers';
+import { createTableSheet, getContainer } from '../../../util/helpers';
+import { NewLine, NewTab } from '@/common';
+import { CopyMIMEType } from '@/common/interface/export';
 import { TableSheet } from '@/sheet-type';
 import { asyncGetAllPlainData } from '@/utils';
-import { NewTab, NewLine } from '@/common';
-import { CopyMIMEType } from '@/common/interface/export';
 
 describe('TableSheet Export Test', () => {
   it('should export correct data with series number', async () => {
@@ -360,6 +360,30 @@ describe('TableSheet Export Test', () => {
       });
 
       // 自定义列头, 不管有没有开启格式化, 配置 meta, 都使用 field.title 展示
+      expect(data.split(NewLine)).toMatchSnapshot();
+    },
+  );
+
+  // https://github.com/antvis/S2/issues/2681
+  it.each([{ isAsyncExport: false }, { isAsyncExport: true }])(
+    'should export correctly data for single row data by %o',
+    async (options) => {
+      const tableSheet = createTableSheet({ width: 600, height: 400 });
+
+      tableSheet.setDataCfg({
+        fields: {
+          columns: ['province', 'city', 'type', 'price', 'cost'],
+        },
+        data: [{ province: '浙江', city: '杭州', type: '笔', price: 1 }],
+      });
+
+      await tableSheet.render();
+      const data = await asyncGetAllPlainData({
+        sheetInstance: tableSheet,
+        split: '\t',
+        ...options,
+      });
+
       expect(data.split(NewLine)).toMatchSnapshot();
     },
   );

--- a/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
@@ -152,7 +152,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
               : rowLength;
 
           while (
-            deadline.timeRemaining() > 0 &&
+            (deadline.timeRemaining() > 0 || deadline.didTimeout) &&
             rowIndex <= rowLength - 1 &&
             count > 0
           ) {

--- a/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
@@ -144,15 +144,19 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
       try {
         // 因为每次 requestIdleCallback 执行的时间不一样，所以需要记录下当前执行到的 this.leafRowNodes 和 this.leafColNodes
         const dataMatrixIdleCallback = (deadline: IdleDeadline) => {
-          let count = AsyncRenderThreshold;
-          const rowLen: number = this.leafRowNodes.length;
+          const rowLength: number = this.leafRowNodes.length;
+          // requestIdleCallback 浏览器空闲时会多次执行, 只有一行数据时执行一次即可, 避免生成重复数据
+          let count =
+            rowLength >= AsyncRenderThreshold
+              ? AsyncRenderThreshold
+              : rowLength;
 
           while (
             deadline.timeRemaining() > 0 &&
-            rowIndex < rowLen - 1 &&
+            rowIndex <= rowLength - 1 &&
             count > 0
           ) {
-            for (let j = rowIndex; j < rowLen && count > 0; j++) {
+            for (let j = rowIndex; j < rowLength && count > 0; j++) {
               const row: DataItem[] = [];
               const rowNode = this.leafRowNodes[j];
 
@@ -177,7 +181,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
             }
           }
 
-          if (rowIndex === rowLen - 1) {
+          if (rowIndex === rowLength - 1) {
             resolve(matrix);
           } else {
             requestIdleCallback(dataMatrixIdleCallback);

--- a/packages/s2-core/src/utils/export/copy/table-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/table-copy.ts
@@ -97,8 +97,8 @@ class TableDataCellCopy extends BaseDataCellCopy {
 
           while (
             (deadline.timeRemaining() > 0 || deadline.didTimeout) &&
-            count > 0 &&
-            rowIndex <= rowLength - 1
+            rowIndex <= rowLength - 1 &&
+            count > 0
           ) {
             for (let j = rowIndex; j < rowLength && count > 0; j++) {
               const rowData = this.displayData[j];

--- a/packages/s2-core/src/utils/export/copy/table-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/table-copy.ts
@@ -88,13 +88,17 @@ class TableDataCellCopy extends BaseDataCellCopy {
     return new Promise((resolve, reject) => {
       try {
         const dataMatrixIdleCallback = (deadline: IdleDeadline) => {
-          let count = AsyncRenderThreshold;
           const rowLength = this.displayData.length;
+          // requestIdleCallback 浏览器空闲时会多次执行, 只有一行数据时执行一次即可, 避免生成重复数据
+          let count =
+            rowLength >= AsyncRenderThreshold
+              ? AsyncRenderThreshold
+              : rowLength;
 
           while (
-            deadline.timeRemaining() > 0 &&
+            (deadline.timeRemaining() > 0 || deadline.didTimeout) &&
             count > 0 &&
-            rowIndex < rowLength - 1
+            rowIndex <= rowLength - 1
           ) {
             for (let j = rowIndex; j < rowLength && count > 0; j++) {
               const rowData = this.displayData[j];


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2681 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

调整异步导出 `requestIdleCallback` 的计算逻辑, 兼容只有一行数据的导出链路.

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/antvis/S2/assets/21015895/3e397c83-910a-4bd6-a892-808fae0d9cb6) |    ![image](https://github.com/antvis/S2/assets/21015895/40762e94-a75d-4794-ac9f-02ca59a0739f) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

close #2681 

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
