### PR TITLE
fix: 修复导出 CSV 时分隔符错误导致的展示格式错误 close #2701

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-446-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-446-spec.ts
@@ -6,7 +6,7 @@
  */
 import { getContainer } from '../util/helpers';
 import * as mockDataConfig from '../data/data-issue-446.json';
-import type { S2Options } from '../../src';
+import { TAB_SEPARATOR, type S2Options } from '../../src';
 import { TableSheet } from '@/sheet-type';
 import { asyncGetAllPlainData } from '@/utils';
 
@@ -25,7 +25,7 @@ describe('export', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: '\t',
+      split: TAB_SEPARATOR,
       formatOptions: true,
     });
 
@@ -50,7 +50,7 @@ describe('export', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: '\t',
+      split: TAB_SEPARATOR,
     });
 
     expect(data.split('\n').length).toEqual(3);

--- a/packages/s2-core/__tests__/bugs/issue-565-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-565-spec.ts
@@ -6,7 +6,7 @@
  */
 import * as mockDataConfig from 'tests/data/data-issue-565.json';
 import { getContainer } from 'tests/util/helpers';
-import type { S2Options } from '../../src';
+import { TAB_SEPARATOR, type S2Options } from '../../src';
 import { PivotSheet } from '@/sheet-type';
 import { asyncGetAllPlainData } from '@/utils';
 
@@ -24,7 +24,7 @@ describe('Export data in pivot tree mode', () => {
 
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: '\t',
+      split: TAB_SEPARATOR,
     });
     const rows = data.split('\n');
 

--- a/packages/s2-core/__tests__/unit/data-set/pivot-data-set-spec.ts
+++ b/packages/s2-core/__tests__/unit/data-set/pivot-data-set-spec.ts
@@ -464,6 +464,13 @@ describe('Pivot Dataset Test', () => {
       dataSet.setDataCfg(dataConfig);
     });
 
+    test('should return correct field', () => {
+      expect(dataSet.getField('price')).toStrictEqual('price');
+      expect(dataSet.getField({ field: 'price', title: '价格' })).toStrictEqual(
+        'price',
+      );
+    });
+
     test('should return correct field name', () => {
       expect(dataSet.getFieldName('price')).toStrictEqual('价格');
       expect(dataSet.getFieldName('cost')).toStrictEqual('成本');

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
@@ -44,8 +44,8 @@ province	city	number	number	number	number
 
 exports[`PivotSheet Export Test should export correct data in grid mode with totals in col 1`] = `
 "	类别	家具	家具	家具	办公用品	办公用品	办公用品	总计
-	子类别	桌子	沙发	小计	笔	纸张	小计	
-省份	城市	数量	数量		数量	数量		
+	子类别	桌子	沙发	小计	笔	纸张	小计
+省份	城市	数量	数量		数量	数量
 浙江省	杭州市	7789	5343	13132	945	1343	2288	15420
 浙江省	绍兴市	2367	632	2999	1304	1354	2658	5657
 浙江省	宁波市	3877	7234	11111	1145	1523	2668	13779
@@ -61,7 +61,7 @@ exports[`PivotSheet Export Test should export correct data in grid mode with tot
 
 exports[`PivotSheet Export Test should export correct data in grid mode with totals in row 1`] = `
 "	类别		家具	家具	家具	办公用品	办公用品	办公用品	总计
-	子类别		桌子	沙发	小计	笔	纸张	小计	
+	子类别		桌子	沙发	小计	笔	纸张	小计
 浙江省	杭州市	数量	7789	5343	13132	945	1343	2288	15420
 浙江省	绍兴市	数量	2367	632	2999	1304	1354	2658	5657
 浙江省	宁波市	数量	3877	7234	11111	1145	1523	2668	13779
@@ -148,11 +148,11 @@ exports[`PivotSheet Export Test should export correct data when data is incomple
 "	province	浙江省	浙江省	浙江省	浙江省	四川省	四川省	四川省	四川省
 	city	杭州市	绍兴市	宁波市	舟山市	成都市	绵阳市	南充市	乐山市
 type	sub_type	number	number	number	number	number	number	number	number
-家具									
+家具
 家具	桌子		2367	3877	4342	1723	1822	1943	2330
 家具	沙发		632	7234	834	2451	2244	2333	2445
-办公用品									
-办公用品	笔								
+办公用品
+办公用品	笔
 办公用品	纸张		1354	1523	1634	4004	3077	3551	352"
 `;
 
@@ -214,9 +214,9 @@ province	city	数值	数值	数值	数值
 
 exports[`PivotSheet Export Test should export correct data with formatter for custom column headers 1`] = `
 "	自定义节点 a-1	自定义节点 a-1	自定义节点 a-1	自定义节点 a-1	自定义节点 a-2
-	自定义节点 a-2	自定义节点 a-1-1	自定义节点 a-1-1	自定义节点 a-1-2	
-type	sub_type	指标1	指标2		
-家具	桌子	13	2		
+	自定义节点 a-2	自定义节点 a-1-1	自定义节点 a-1-1	自定义节点 a-1-2
+type	sub_type	指标1	指标2
+家具	桌子	13	2
 家具	椅子	11	8		"
 `;
 
@@ -225,11 +225,11 @@ exports[`PivotSheet Export Test should export correct data with formatter for cu
 自定义节点 a-1	自定义节点 a-1-1	指标1	桌子	椅子
 自定义节点 a-1	自定义节点 a-1-1	指标1	13	11
 自定义节点 a-1	自定义节点 a-1-1	指标2	2	8
-自定义节点 a-1	自定义节点 a-1-2			
+自定义节点 a-1	自定义节点 a-1-2
 自定义节点 a-2				"
 `;
 
-exports[`PivotSheet Export Test should export correctly data for single row data by { isAsyncExport: false } 1`] = `
+exports[`PivotSheet Export Test should export correctly data for single row data by { async: false } 1`] = `
 Array [
   "	type	笔	笔",
   "province	city	price	cost",
@@ -237,7 +237,7 @@ Array [
 ]
 `;
 
-exports[`PivotSheet Export Test should export correctly data for single row data by { isAsyncExport: true } 1`] = `
+exports[`PivotSheet Export Test should export correctly data for single row data by { async: true } 1`] = `
 Array [
   "	type	笔	笔",
   "province	city	price	cost",

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
@@ -144,19 +144,7 @@ exports[`PivotSheet Export Test should export correct data in tree mode and coll
 四川省	7818	9473	7495	10984"
 `;
 
-exports[`PivotSheet Export Test should export correct data when data is incomplete 1`] = `
-"	province	浙江省	浙江省	浙江省	浙江省	四川省	四川省	四川省	四川省
-	city	杭州市	绍兴市	宁波市	舟山市	成都市	绵阳市	南充市	乐山市
-type	sub_type	number	number	number	number	number	number	number	number
-家具									
-家具	桌子		2367	3877	4342	1723	1822	1943	2330
-家具	沙发		632	7234	834	2451	2244	2333	2445
-办公用品									
-办公用品	笔								
-办公用品	纸张		1354	1523	1634	4004	3077	3551	352"
-`;
-
-exports[`PivotSheet Export Test should export correct data when isFormat: {formatData: true} 1`] = `
+exports[`PivotSheet Export Test should export correct data when by {formatData: true} 1`] = `
 "	type	家具	家具	办公用品	办公用品
 	sub_type	桌子	沙发	笔	纸张
 province	city	number	number	number	number
@@ -170,7 +158,21 @@ province	city	number	number	number	number
 四川省	乐山市	2330%	2445%	2458%	352%"
 `;
 
-exports[`PivotSheet Export Test should export correct data when isFormat: {formatHeader: true} 1`] = `
+exports[`PivotSheet Export Test should export correct data when by {formatHeader: false, formatData: false} 1`] = `
+"	type	家具	家具	办公用品	办公用品
+	sub_type	桌子	沙发	笔	纸张
+province	city	number	number	number	number
+浙江省	杭州市	7789	5343	945	1343
+浙江省	绍兴市	2367	632	1304	1354
+浙江省	宁波市	3877	7234	1145	1523
+浙江省	舟山市	4342	834	1432	1634
+四川省	成都市	1723	2451	2335	4004
+四川省	绵阳市	1822	2244	245	3077
+四川省	南充市	1943	2333	2457	3551
+四川省	乐山市	2330	2445	2458	352"
+`;
+
+exports[`PivotSheet Export Test should export correct data when by {formatHeader: true} 1`] = `
 "	type	家具-type	家具-type	办公用品-type	办公用品-type
 	sub_type	桌子	沙发	笔	纸张
 province	city	number	number	number	number
@@ -182,6 +184,18 @@ province	city	number	number	number	number
 四川省-province	绵阳市	1822	2244	245	3077
 四川省-province	南充市	1943	2333	2457	3551
 四川省-province	乐山市	2330	2445	2458	352"
+`;
+
+exports[`PivotSheet Export Test should export correct data when data is incomplete 1`] = `
+"	province	浙江省	浙江省	浙江省	浙江省	四川省	四川省	四川省	四川省
+	city	杭州市	绍兴市	宁波市	舟山市	成都市	绵阳市	南充市	乐山市
+type	sub_type	number	number	number	number	number	number	number	number
+家具									
+家具	桌子		2367	3877	4342	1723	1822	1943	2330
+家具	沙发		632	7234	834	2451	2244	2333	2445
+办公用品									
+办公用品	笔								
+办公用品	纸张		1354	1523	1634	4004	3077	3551	352"
 `;
 
 exports[`PivotSheet Export Test should export correct data when series number 1`] = `

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-pivot-spec.ts.snap
@@ -44,8 +44,8 @@ province	city	number	number	number	number
 
 exports[`PivotSheet Export Test should export correct data in grid mode with totals in col 1`] = `
 "	类别	家具	家具	家具	办公用品	办公用品	办公用品	总计
-	子类别	桌子	沙发	小计	笔	纸张	小计
-省份	城市	数量	数量		数量	数量
+	子类别	桌子	沙发	小计	笔	纸张	小计	
+省份	城市	数量	数量		数量	数量		
 浙江省	杭州市	7789	5343	13132	945	1343	2288	15420
 浙江省	绍兴市	2367	632	2999	1304	1354	2658	5657
 浙江省	宁波市	3877	7234	11111	1145	1523	2668	13779
@@ -61,7 +61,7 @@ exports[`PivotSheet Export Test should export correct data in grid mode with tot
 
 exports[`PivotSheet Export Test should export correct data in grid mode with totals in row 1`] = `
 "	类别		家具	家具	家具	办公用品	办公用品	办公用品	总计
-	子类别		桌子	沙发	小计	笔	纸张	小计
+	子类别		桌子	沙发	小计	笔	纸张	小计	
 浙江省	杭州市	数量	7789	5343	13132	945	1343	2288	15420
 浙江省	绍兴市	数量	2367	632	2999	1304	1354	2658	5657
 浙江省	宁波市	数量	3877	7234	11111	1145	1523	2668	13779
@@ -148,11 +148,11 @@ exports[`PivotSheet Export Test should export correct data when data is incomple
 "	province	浙江省	浙江省	浙江省	浙江省	四川省	四川省	四川省	四川省
 	city	杭州市	绍兴市	宁波市	舟山市	成都市	绵阳市	南充市	乐山市
 type	sub_type	number	number	number	number	number	number	number	number
-家具
+家具									
 家具	桌子		2367	3877	4342	1723	1822	1943	2330
 家具	沙发		632	7234	834	2451	2244	2333	2445
-办公用品
-办公用品	笔
+办公用品									
+办公用品	笔								
 办公用品	纸张		1354	1523	1634	4004	3077	3551	352"
 `;
 
@@ -214,9 +214,9 @@ province	city	数值	数值	数值	数值
 
 exports[`PivotSheet Export Test should export correct data with formatter for custom column headers 1`] = `
 "	自定义节点 a-1	自定义节点 a-1	自定义节点 a-1	自定义节点 a-1	自定义节点 a-2
-	自定义节点 a-2	自定义节点 a-1-1	自定义节点 a-1-1	自定义节点 a-1-2
-type	sub_type	指标1	指标2
-家具	桌子	13	2
+	自定义节点 a-2	自定义节点 a-1-1	自定义节点 a-1-1	自定义节点 a-1-2	
+type	sub_type	指标1	指标2		
+家具	桌子	13	2		
 家具	椅子	11	8		"
 `;
 
@@ -225,7 +225,7 @@ exports[`PivotSheet Export Test should export correct data with formatter for cu
 自定义节点 a-1	自定义节点 a-1-1	指标1	桌子	椅子
 自定义节点 a-1	自定义节点 a-1-1	指标1	13	11
 自定义节点 a-1	自定义节点 a-1-1	指标2	2	8
-自定义节点 a-1	自定义节点 a-1-2
+自定义节点 a-1	自定义节点 a-1-2			
 自定义节点 a-2				"
 `;
 

--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-table-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/export-table-spec.ts.snap
@@ -278,14 +278,14 @@ exports[`TableSheet Export Test should export correct data with totals 1`] = `
 浙江省-province	家具-type	沙发	5343"
 `;
 
-exports[`TableSheet Export Test should export correctly data for single row data by { isAsyncExport: false } 1`] = `
+exports[`TableSheet Export Test should export correctly data for single row data by { async: false } 1`] = `
 Array [
   "province	city	type	price	cost",
   "浙江	杭州	笔	1	",
 ]
 `;
 
-exports[`TableSheet Export Test should export correctly data for single row data by { isAsyncExport: true } 1`] = `
+exports[`TableSheet Export Test should export correctly data for single row data by { async: true } 1`] = `
 Array [
   "province	city	type	price	cost",
   "浙江	杭州	笔	1	",

--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -11,7 +11,7 @@ import type { S2CellType, S2DataConfig } from '../../../../src/common';
 import { customRowGridSimpleFields } from '../../../data/custom-grid-simple-fields';
 import { CustomGridData } from '../../../data/data-custom-grid';
 import { TableSeriesNumberCell } from '@/cell';
-import { NewLine, NewTab, S2Event } from '@/common/constant';
+import { LINE_SEPARATOR, TAB_SEPARATOR, S2Event } from '@/common/constant';
 import {
   InteractionStateName,
   SortMethodType,
@@ -24,7 +24,7 @@ import { CopyMIMEType } from '@/common/interface/export';
 import { convertString } from '@/utils/export/method';
 import { getCellMeta } from '@/utils/interaction/select-event';
 
-const newLineTest = `### 问题摘要 ${NewLine}- **会话地址**：`;
+const newLineTest = `### 问题摘要 ${LINE_SEPARATOR}- **会话地址**：`;
 
 const testData = originalData.map((item, i) => {
   if (i === 0) {
@@ -123,7 +123,7 @@ describe('List Table Core Data Process', () => {
       cells: [getCellMeta(cell)],
       stateName: InteractionStateName.SELECTED,
     });
-    expect(getCopyPlainContent(s2).split(NewLine).length).toBe(32);
+    expect(getCopyPlainContent(s2).split(LINE_SEPARATOR).length).toBe(32);
   });
 
   it('should copy row data', () => {
@@ -137,7 +137,7 @@ describe('List Table Core Data Process', () => {
     expect(getCopyPlainContent(s2)).toMatchInlineSnapshot(
       `"1	浙江省	舟山市	家具	桌子	4342"`,
     );
-    expect(getCopyPlainContent(s2).split(NewTab).length).toBe(6);
+    expect(getCopyPlainContent(s2).split(TAB_SEPARATOR).length).toBe(6);
   });
 
   it('should copy all data', () => {
@@ -146,10 +146,10 @@ describe('List Table Core Data Process', () => {
     });
 
     expect(getCopyPlainContent(s2)).toMatchSnapshot();
-    expect(getCopyPlainContent(s2).split(NewLine).length).toBe(33);
-    expect(getCopyPlainContent(s2).split(NewLine)[2]).toMatchInlineSnapshot(
-      `"2	浙江省	绍兴市	家具	桌子	2367"`,
-    );
+    expect(getCopyPlainContent(s2).split(LINE_SEPARATOR).length).toBe(33);
+    expect(
+      getCopyPlainContent(s2).split(LINE_SEPARATOR)[2],
+    ).toMatchInlineSnapshot(`"2	浙江省	绍兴市	家具	桌子	2367"`);
   });
 
   it('should copy all data with header in table mode', async () => {
@@ -525,7 +525,7 @@ describe('List Table Core Data Process', () => {
     });
 
     expect(getCopyPlainContent(s2)).toEqual('浙江省');
-    expect(getCopyPlainContent(s2).split(NewTab).length).toBe(1);
+    expect(getCopyPlainContent(s2).split(TAB_SEPARATOR).length).toBe(1);
   });
 
   it('should support custom copy matrix transformer', async () => {
@@ -759,7 +759,7 @@ describe('Pivot Table Core Data Process', () => {
       cells: [getCellMeta(cell!)],
       stateName: InteractionStateName.SELECTED,
     });
-    expect(getCopyPlainContent(sheet).split(NewTab).length).toBe(4);
+    expect(getCopyPlainContent(sheet).split(TAB_SEPARATOR).length).toBe(4);
   });
 
   it('should copy all data in grid mode', () => {
@@ -767,9 +767,9 @@ describe('Pivot Table Core Data Process', () => {
       stateName: InteractionStateName.ALL_SELECTED,
     });
     expect(getCopyPlainContent(s2).split('\n').length).toBe(COL_COUNT);
-    expect(getCopyPlainContent(s2).split('\n')[1].split(NewTab).length).toBe(
-      ROW_COUNT,
-    );
+    expect(
+      getCopyPlainContent(s2).split('\n')[1].split(TAB_SEPARATOR).length,
+    ).toBe(ROW_COUNT);
   });
 
   it('should copy format data in grid mode', async () => {
@@ -903,9 +903,9 @@ describe('Pivot Table Core Data Process', () => {
       COL_COUNT + COL_HEADER_HEIGHT,
     );
     // 复制的数据宽度 = 行头宽度 + 数据宽度
-    expect(getCopyPlainContent(s2).split('\n')[0].split(NewTab)).toHaveLength(
-      5,
-    );
+    expect(
+      getCopyPlainContent(s2).split('\n')[0].split(TAB_SEPARATOR),
+    ).toHaveLength(5);
   });
 
   // https://gw.alipayobjects.com/zos/antfincdn/q3mBlV9Ii/1d68499a-b529-4594-93ce-8b04f8b4c4bc.png
@@ -931,9 +931,9 @@ describe('Pivot Table Core Data Process', () => {
     });
 
     expect(getCopyPlainContent(s2).split('\n')).toHaveLength(4);
-    expect(getCopyPlainContent(s2).split('\n')[0].split(NewTab)).toHaveLength(
-      9,
-    );
+    expect(
+      getCopyPlainContent(s2).split('\n')[0].split(TAB_SEPARATOR),
+    ).toHaveLength(9);
 
     // 选择某几行，province 维度
     s2.interaction.changeState({
@@ -942,9 +942,9 @@ describe('Pivot Table Core Data Process', () => {
     });
 
     expect(getCopyPlainContent(s2).split('\n')).toHaveLength(8);
-    expect(getCopyPlainContent(s2).split('\n')[0].split(NewTab)).toHaveLength(
-      9,
-    );
+    expect(
+      getCopyPlainContent(s2).split('\n')[0].split(TAB_SEPARATOR),
+    ).toHaveLength(9);
   });
 
   it('should copy row data with format header in grid mode', async () => {
@@ -1009,9 +1009,9 @@ describe('Pivot Table Core Data Process', () => {
     expect(getCopyPlainContent(s2).split('\n').length).toBe(
       COL_COUNT + COL_HEADER_HEIGHT,
     );
-    expect(getCopyPlainContent(s2).split('\n')[1].split(NewTab).length).toBe(
-      ROW_COUNT + ROW_HEADER_WIDTH,
-    );
+    expect(
+      getCopyPlainContent(s2).split('\n')[1].split(TAB_SEPARATOR).length,
+    ).toBe(ROW_COUNT + ROW_HEADER_WIDTH);
   });
 
   it('should copy correct data with data sorted in grid mode', async () => {

--- a/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
@@ -212,7 +212,7 @@ describe('PivotSheet Export Test', () => {
     await expectMatchSnapshot(s2);
   });
 
-  it('should export correct data when isFormat: {formatHeader: true}', async () => {
+  it('should export correct data when by {formatHeader: true}', async () => {
     const s2 = new PivotSheet(
       getContainer(),
       assembleDataCfg({
@@ -239,7 +239,7 @@ describe('PivotSheet Export Test', () => {
     });
   });
 
-  it('should export correct data when isFormat: {formatData: true}', async () => {
+  it('should export correct data when by {formatData: true}', async () => {
     const s2 = new PivotSheet(
       getContainer(),
       assembleDataCfg({
@@ -248,17 +248,65 @@ describe('PivotSheet Export Test', () => {
             field: 'number',
             formatter: (value) => `${value}%`,
           },
+          {
+            field: 'type',
+            name: '类别',
+          },
+          {
+            field: 'type',
+            name: '子类别',
+          },
+          {
+            field: 'province',
+            name: '省份',
+          },
+          {
+            field: 'city',
+            name: '城市',
+          },
         ],
       }),
       assembleOptions({
         interaction: {
-          copy: { enable: true, withFormat: true },
+          copy: { enable: true, withHeader: true, withFormat: true },
         },
       }),
     );
 
     await expectMatchSnapshot(s2, {
       formatData: true,
+    });
+  });
+
+  it('should export correct data when by {formatHeader: false, formatData: false}', async () => {
+    const s2 = new PivotSheet(
+      getContainer(),
+      assembleDataCfg({
+        meta: [
+          {
+            field: 'number',
+            formatter: (value) => `${value}%`,
+          },
+          {
+            field: 'type',
+            name: '类别',
+          },
+          {
+            field: 'city',
+            name: '城市',
+          },
+        ],
+      }),
+      assembleOptions({
+        interaction: {
+          copy: { enable: true, withHeader: true, withFormat: true },
+        },
+      }),
+    );
+
+    await expectMatchSnapshot(s2, {
+      formatHeader: false,
+      formatData: false,
     });
   });
 

--- a/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
@@ -1,5 +1,4 @@
 /* eslint-disable jest/expect-expect */
-import { NewLine, NewTab, PivotSheet, asyncGetAllPlainData } from '@antv/s2';
 import { map, omit } from 'lodash';
 import { data as originData } from 'tests/data/mock-dataset.json';
 import { assembleDataCfg, assembleOptions } from 'tests/util';
@@ -10,7 +9,12 @@ import {
 } from '../../../data/custom-grid-simple-fields';
 import { CustomGridData } from '../../../data/data-custom-grid';
 import { expectMatchSnapshot } from '../../../util/helpers';
-import { CSV_SEPARATOR, TAB_SEPARATOR } from '../../../../src/common/constant';
+import {
+  CSV_SEPARATOR,
+  LINE_SEPARATOR,
+  TAB_SEPARATOR,
+} from '../../../../src/common/constant';
+import { asyncGetAllPlainData, PivotSheet } from '../../../../src';
 import { CopyMIMEType } from '@/common/interface/export';
 
 describe('PivotSheet Export Test', () => {
@@ -42,7 +46,7 @@ describe('PivotSheet Export Test', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: true,
     });
 
@@ -50,7 +54,7 @@ describe('PivotSheet Export Test', () => {
 
     const asyncData = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: true,
       async: true,
     });
@@ -75,7 +79,7 @@ describe('PivotSheet Export Test', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: true,
     });
 
@@ -83,7 +87,7 @@ describe('PivotSheet Export Test', () => {
 
     const asyncData = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: true,
       async: true,
     });
@@ -340,7 +344,7 @@ describe('PivotSheet Export Test', () => {
 
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       customTransformer: () => {
         return {
           [CopyMIMEType.PLAIN]: () => {
@@ -409,7 +413,7 @@ describe('PivotSheet Export Test', () => {
         ...options,
       });
 
-      expect(data.split(NewLine)).toMatchSnapshot();
+      expect(data.split(LINE_SEPARATOR)).toMatchSnapshot();
     },
   );
 });

--- a/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../data/custom-grid-simple-fields';
 import { CustomGridData } from '../../../data/data-custom-grid';
 import { expectMatchSnapshot } from '../../../util/helpers';
+import { CSV_SEPARATOR, TAB_SEPARATOR } from '../../../../src/common/constant';
 import { CopyMIMEType } from '@/common/interface/export';
 
 describe('PivotSheet Export Test', () => {
@@ -51,7 +52,7 @@ describe('PivotSheet Export Test', () => {
       sheetInstance: s2,
       split: NewTab,
       formatOptions: true,
-      isAsyncExport: true,
+      async: true,
     });
 
     expect(asyncData).toMatchSnapshot();
@@ -84,7 +85,7 @@ describe('PivotSheet Export Test', () => {
       sheetInstance: s2,
       split: NewTab,
       formatOptions: true,
-      isAsyncExport: true,
+      async: true,
     });
 
     expect(asyncData).toMatchSnapshot();
@@ -356,7 +357,7 @@ describe('PivotSheet Export Test', () => {
   it('should export correct data When the split separator is configured', async () => {
     const data = await asyncGetAllPlainData({
       sheetInstance: pivotSheet,
-      split: ',',
+      split: CSV_SEPARATOR,
       formatOptions: {
         formatHeader: true,
       },
@@ -392,7 +393,7 @@ describe('PivotSheet Export Test', () => {
   });
 
   // https://github.com/antvis/S2/issues/2681
-  it.each([{ isAsyncExport: false }, { isAsyncExport: true }])(
+  it.each([{ async: false }, { async: true }])(
     'should export correctly data for single row data by %o',
     async (options) => {
       const sheet = createPivotSheet({ width: 600, height: 400 });
@@ -404,7 +405,7 @@ describe('PivotSheet Export Test', () => {
       await sheet.render();
       const data = await asyncGetAllPlainData({
         sheetInstance: sheet,
-        split: '\t',
+        split: TAB_SEPARATOR,
         ...options,
       });
 

--- a/packages/s2-core/__tests__/unit/utils/export/export-table-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-table-spec.ts
@@ -7,7 +7,13 @@ import {
   expectMatchSnapshot,
   getContainer,
 } from '../../../util/helpers';
-import { FormatOptions, S2DataConfig, S2Options } from '../../../../src';
+import {
+  CSV_SEPARATOR,
+  FormatOptions,
+  S2DataConfig,
+  S2Options,
+  TAB_SEPARATOR,
+} from '../../../../src';
 import { customColSimpleColumns } from '../../../data/custom-table-col-fields';
 import { NewLine, NewTab } from '@/common';
 import { CopyMIMEType } from '@/common/interface/export';
@@ -132,7 +138,7 @@ describe('TableSheet Export Test', () => {
       formatOptions: {
         formatHeader: true,
       },
-      isAsyncExport: true,
+      async: true,
     });
 
     testCase(asyncData);
@@ -257,7 +263,7 @@ describe('TableSheet Export Test', () => {
     await tableSheet.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: tableSheet,
-      split: ',',
+      split: CSV_SEPARATOR,
       formatOptions: true,
     });
     // 只取前10行数据
@@ -307,7 +313,7 @@ describe('TableSheet Export Test', () => {
     await tableSheet.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: tableSheet,
-      split: ',',
+      split: CSV_SEPARATOR,
       formatOptions: {
         formatHeader: true,
       },
@@ -352,7 +358,7 @@ describe('TableSheet Export Test', () => {
     await tableSheet.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: tableSheet,
-      split: ',',
+      split: CSV_SEPARATOR,
       formatOptions: {
         formatHeader: true,
       },
@@ -362,7 +368,7 @@ describe('TableSheet Export Test', () => {
   });
 
   // https://github.com/antvis/S2/issues/2681
-  it.each([{ isAsyncExport: false }, { isAsyncExport: true }])(
+  it.each([{ async: false }, { async: true }])(
     'should export correctly data for single row data by %o',
     async (options) => {
       const tableSheet = createTableSheet({ width: 600, height: 400 });
@@ -377,7 +383,7 @@ describe('TableSheet Export Test', () => {
       await tableSheet.render();
       const data = await asyncGetAllPlainData({
         sheetInstance: tableSheet,
-        split: '\t',
+        split: TAB_SEPARATOR,
         ...options,
       });
 

--- a/packages/s2-core/__tests__/unit/utils/export/export-table-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-table-spec.ts
@@ -12,10 +12,10 @@ import {
   FormatOptions,
   S2DataConfig,
   S2Options,
+  LINE_SEPARATOR,
   TAB_SEPARATOR,
 } from '../../../../src';
 import { customColSimpleColumns } from '../../../data/custom-table-col-fields';
-import { NewLine, NewTab } from '@/common';
 import { CopyMIMEType } from '@/common/interface/export';
 import { TableSheet } from '@/sheet-type';
 import { asyncGetAllPlainData } from '@/utils';
@@ -99,8 +99,8 @@ describe('TableSheet Export Test', () => {
     await s2.render();
 
     function testCase(data: string): void {
-      const rows = data.split(NewLine);
-      const headers = rows[0].split(NewTab);
+      const rows = data.split(LINE_SEPARATOR);
+      const headers = rows[0].split(TAB_SEPARATOR);
 
       expect(slice(rows, 0, 5)).toMatchSnapshot();
 
@@ -109,7 +109,7 @@ describe('TableSheet Export Test', () => {
 
       // 6列数据 包括序列号
       rows.forEach((e) => {
-        expect(e.split(NewTab)).toHaveLength(6);
+        expect(e.split(TAB_SEPARATOR)).toHaveLength(6);
       });
 
       expect(headers).toEqual([
@@ -124,7 +124,7 @@ describe('TableSheet Export Test', () => {
 
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: {
         formatHeader: true,
       },
@@ -134,7 +134,7 @@ describe('TableSheet Export Test', () => {
 
     const asyncData = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: {
         formatHeader: true,
       },
@@ -164,16 +164,16 @@ describe('TableSheet Export Test', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
     });
-    const rows = data.split(NewLine);
-    const headers = rows[0].split(NewTab);
+    const rows = data.split(LINE_SEPARATOR);
+    const headers = rows[0].split(TAB_SEPARATOR);
 
     // 33行数据 包括一行列头
     expect(rows).toHaveLength(11);
     // 5列数据 包括序列号
     rows.forEach((e) => {
-      expect(e.split(NewTab)).toHaveLength(5);
+      expect(e.split(TAB_SEPARATOR)).toHaveLength(5);
     });
     expect(headers).toEqual(['province', 'city', 'type', 'sub_type', 'number']);
   });
@@ -207,7 +207,7 @@ describe('TableSheet Export Test', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: true,
     });
 
@@ -233,7 +233,7 @@ describe('TableSheet Export Test', () => {
     await s2.render();
     const data = await asyncGetAllPlainData({
       sheetInstance: s2,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: true,
       customTransformer: () => {
         return {
@@ -267,7 +267,7 @@ describe('TableSheet Export Test', () => {
       formatOptions: true,
     });
     // 只取前10行数据
-    const result = slice(data.split(NewLine), 0, 5);
+    const result = slice(data.split(LINE_SEPARATOR), 0, 5);
 
     expect(result).toMatchSnapshot();
   });
@@ -319,7 +319,7 @@ describe('TableSheet Export Test', () => {
       },
     });
 
-    expect(data.split(NewLine)).toMatchSnapshot();
+    expect(data.split(LINE_SEPARATOR)).toMatchSnapshot();
   });
 
   it('should export correct data with formatter if contain repeat column name', async () => {
@@ -364,7 +364,7 @@ describe('TableSheet Export Test', () => {
       },
     });
 
-    expect(data.split(NewLine)).toMatchSnapshot();
+    expect(data.split(LINE_SEPARATOR)).toMatchSnapshot();
   });
 
   // https://github.com/antvis/S2/issues/2681
@@ -387,7 +387,7 @@ describe('TableSheet Export Test', () => {
         ...options,
       });
 
-      expect(data.split(NewLine)).toMatchSnapshot();
+      expect(data.split(LINE_SEPARATOR)).toMatchSnapshot();
     },
   );
 

--- a/packages/s2-core/__tests__/unit/utils/export/utils-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/utils-spec.ts
@@ -20,7 +20,7 @@ describe('Export & Copy Utils Tests', () => {
       .spyOn(document.body, 'removeChild')
       .mockImplementationOnce(() => null as unknown as Node);
 
-    await copyToClipboard(text, true);
+    await copyToClipboard(text, false);
 
     const result = await navigator.clipboard.readText();
     const textareaValue = document.querySelector('textarea')?.value;
@@ -64,7 +64,7 @@ describe('Export & Copy Utils Tests', () => {
 
     const text = '222';
 
-    await copyToClipboard(text, true);
+    await copyToClipboard(text, false);
 
     expect(window.scrollY).toEqual(scrollY);
   });

--- a/packages/s2-core/__tests__/util/helpers.ts
+++ b/packages/s2-core/__tests__/util/helpers.ts
@@ -22,6 +22,7 @@ import {
   EventController,
   FormatOptions,
   asyncGetAllPlainData,
+  TAB_SEPARATOR,
 } from '../../src';
 
 import { assembleOptions, assembleDataCfg } from '.';
@@ -379,7 +380,7 @@ export const expectMatchSnapshot = async (
   await s2.render();
   const data = await asyncGetAllPlainData({
     sheetInstance: s2,
-    split: '\t',
+    split: TAB_SEPARATOR,
     formatOptions,
   });
 

--- a/packages/s2-core/src/common/constant/copy.ts
+++ b/packages/s2-core/src/common/constant/copy.ts
@@ -4,9 +4,11 @@ export enum CopyType {
   ROW,
 }
 
-export const NewLine = '\r\n';
+export const LINE_SEPARATOR = '\r\n';
 
-export const NewTab = '\t';
+export const TAB_SEPARATOR = '\t';
+
+export const CSV_SEPARATOR = ',';
 
 // 每次异步渲染数据的阈值
 export const AsyncRenderThreshold = 5000;

--- a/packages/s2-core/src/common/interface/export.ts
+++ b/packages/s2-core/src/common/interface/export.ts
@@ -50,7 +50,7 @@ export interface CopyOrExportConfig {
   formatOptions?: FormatOptions;
   separator?: string;
   customTransformer?: (transformer: Transformer) => Partial<Transformer>;
-  isAsyncExport?: boolean;
+  async?: boolean;
 }
 
 export interface CopyAndExportUnifyConfig {
@@ -59,16 +59,37 @@ export interface CopyAndExportUnifyConfig {
   formatData: boolean;
   selectedCells: CellMeta[];
   transformers: Transformer;
-  isAsyncExport: boolean;
+  async: boolean;
 }
 
 export interface CopyAllDataParams {
+  /**
+   * 表格实例
+   */
   sheetInstance: SpreadSheet;
+
+  /**
+   * 数据分割符
+   * @example "\t"
+   */
   split?: string;
+
+  /**
+   * 格式化配置
+   * @example { formatHeader: true, formatData: true }
+   */
   formatOptions?: FormatOptions;
+
+  /**
+   * 导出时支持自定义 (transformer) 数据导出格式化方法
+   * @see https://s2.antv.antgroup.com/manual/advanced/interaction/copy
+   */
   customTransformer?: (transformer: Transformer) => Partial<Transformer>;
-  /** 是否开启异步导出 */
-  isAsyncExport?: boolean;
+
+  /**
+   * 是否开启异步复制/导出
+   */
+  async?: boolean;
 }
 
 export interface SheetCopyConstructorParams {

--- a/packages/s2-core/src/data-set/base-data-set.ts
+++ b/packages/s2-core/src/data-set/base-data-set.ts
@@ -90,7 +90,7 @@ export abstract class BaseDataSet {
   /**
    * 获取字段
    */
-  private getField = (field: CustomHeaderField): string => {
+  public getField = (field: CustomHeaderField): string => {
     const realField = isString(field) ? field : field?.field;
 
     return realField || (field as string);

--- a/packages/s2-core/src/utils/export/copy/base-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/base-data-cell-copy.ts
@@ -1,4 +1,4 @@
-import { NewTab, type DataItem } from '../../../common';
+import { TAB_SEPARATOR, type DataItem } from '../../../common';
 import type {
   CopyableHTML,
   CopyablePlain,
@@ -51,7 +51,7 @@ export abstract class BaseDataCellCopy {
 
   protected matrixTransformer(
     dataMatrix: string[][],
-    separator = NewTab,
+    separator = TAB_SEPARATOR,
   ): [CopyablePlain, CopyableHTML] {
     return [
       this.matrixPlainTextTransformer(dataMatrix, separator),

--- a/packages/s2-core/src/utils/export/copy/common.ts
+++ b/packages/s2-core/src/utils/export/copy/common.ts
@@ -1,7 +1,7 @@
 import { escape, map, max } from 'lodash';
 import type { Node } from '../../../facet/layout/node';
 import type { DataItem } from '../../../common';
-import { NewLine, NewTab, ROOT_NODE_ID } from '../../../common';
+import { LINE_SEPARATOR, TAB_SEPARATOR, ROOT_NODE_ID } from '../../../common';
 import {
   type CopyableHTML,
   type CopyablePlain,
@@ -18,11 +18,13 @@ import type { BaseDataSet } from './../../../data-set/base-data-set';
 // 把 string[][] 矩阵转换成 CopyablePlain
 export const matrixPlainTextTransformer = (
   dataMatrix: DataItem[][],
-  separator = NewTab,
+  separator = TAB_SEPARATOR,
 ): CopyablePlain => {
   return {
     type: CopyMIMEType.PLAIN,
-    content: map(dataMatrix, (line) => line.join(separator)).join(NewLine),
+    content: map(dataMatrix, (line) => line.join(separator)).join(
+      LINE_SEPARATOR,
+    ),
   };
 };
 
@@ -183,10 +185,10 @@ export function unifyConfig({
   },
   config: {
     formatOptions = false,
-    separator = NewTab,
+    separator = TAB_SEPARATOR,
     selectedCells = [],
     customTransformer,
-    isAsyncExport = false,
+    async = false,
   },
   isExport,
 }: SheetCopyConstructorParams): CopyAndExportUnifyConfig {
@@ -207,7 +209,7 @@ export function unifyConfig({
     transformers,
     formatData,
     formatHeader,
-    isAsyncExport,
+    async,
   };
 }
 

--- a/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
@@ -400,7 +400,7 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
     let dataMatrix: string[][] = [];
 
     // 把两类导出都封装成异步的，保证导出类型的一致
-    if (this.config.isAsyncExport) {
+    if (this.config.async) {
       dataMatrix = (await this.getDataMatrixByHeaderNodeRIC()) as string[][];
     } else {
       dataMatrix = (await Promise.resolve(
@@ -466,7 +466,8 @@ export const processSelectedAllPivot = (
 export const asyncProcessSelectedAllPivot = (
   params: CopyAllDataParams,
 ): Promise<CopyableList> => {
-  const { sheetInstance, split, formatOptions, customTransformer } = params;
+  const { sheetInstance, split, formatOptions, customTransformer, async } =
+    params;
   const pivotDataCellCopy = new PivotDataCellCopy({
     spreadsheet: sheetInstance,
     isExport: true,
@@ -474,7 +475,7 @@ export const asyncProcessSelectedAllPivot = (
       separator: split,
       formatOptions,
       customTransformer,
-      isAsyncExport: true,
+      async: async ?? true,
     },
   });
 

--- a/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
@@ -16,6 +16,7 @@ import {
   type DataItem,
   type MiniChartData,
   type MultiData,
+  type CustomHeaderField,
 } from '../../../common';
 import type {
   CopyAllDataParams,
@@ -286,6 +287,12 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
     });
   };
 
+  protected getFieldName = (field: CustomHeaderField) => {
+    return this.config.formatHeader
+      ? this.spreadsheet.dataSet.getFieldName(field)
+      : this.spreadsheet.dataSet.getField(field);
+  };
+
   protected getCornerMatrix = (rowMatrix?: string[][]): string[][] => {
     if (this.spreadsheet.isCustomRowFields()) {
       return this.getCustomRowCornerMatrix(rowMatrix);
@@ -307,12 +314,12 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
       map(customRows, (rowField, rowIndex) => {
         // 角头的最后一行，为行头
         if (colIndex === customColumns.length - 1) {
-          return this.spreadsheet.dataSet.getFieldName(rowField);
+          return this.getFieldName(rowField);
         }
 
         // 角头的最后一列，为列头
         if (rowIndex === maxRowLen - 1) {
-          return this.spreadsheet.dataSet.getFieldName(colField);
+          return this.getFieldName(colField);
         }
 
         return '';

--- a/packages/s2-core/src/utils/export/copy/table-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/table-copy.ts
@@ -228,7 +228,7 @@ class TableDataCellCopy extends BaseDataCellCopy {
   }
 
   async asyncProcessSelectedTable(allSelected = false): Promise<CopyableList> {
-    const matrix = this.config.isAsyncExport
+    const matrix = this.config.async
       ? await this.getDataMatrixRIC()
       : await Promise.resolve(this.getDataMatrix());
 
@@ -269,13 +269,8 @@ export const processSelectedTableByHeader = (
 export const asyncProcessSelectedAllTable = (
   params: CopyAllDataParams,
 ): Promise<CopyableList> => {
-  const {
-    sheetInstance,
-    split,
-    formatOptions,
-    customTransformer,
-    isAsyncExport,
-  } = params;
+  const { sheetInstance, split, formatOptions, customTransformer, async } =
+    params;
   const tableDataCellCopy = new TableDataCellCopy({
     spreadsheet: sheetInstance,
     config: {
@@ -283,7 +278,7 @@ export const asyncProcessSelectedAllTable = (
       separator: split,
       formatOptions,
       customTransformer,
-      isAsyncExport: true ?? isAsyncExport,
+      async: async ?? true,
     },
     isExport: true,
   });

--- a/packages/s2-core/src/utils/export/utils.ts
+++ b/packages/s2-core/src/utils/export/utils.ts
@@ -67,11 +67,11 @@ export const copyToClipboardByClipboard = (data: Copyable): Promise<void> =>
 /**
  * @name 复制数据
  * @param data 数据源
- * @param sync 同步复制
+ * @param async 异步复制
  */
 export const copyToClipboard = (
   data: Copyable | string,
-  sync = false,
+  async = true,
 ): Promise<void> => {
   let copyableItem: Copyable;
 
@@ -84,7 +84,7 @@ export const copyToClipboard = (
     copyableItem = data;
   }
 
-  if (!navigator.clipboard || !window.ClipboardItem || sync) {
+  if (!navigator.clipboard || !window.ClipboardItem || !async) {
     return copyToClipboardByExecCommand(copyableItem);
   }
 

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/__snapshots__/index-spec.tsx.snap
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/__snapshots__/index-spec.tsx.snap
@@ -15,6 +15,51 @@ exports[`<StrategySheet/> Tests StrategySheet Export Tests should export correct
 指标E	自定义节点D													"
 `;
 
+exports[`<StrategySheet/> Tests StrategySheet Export Tests should export correct data by {formatHeader: false, formatData: false} 1`] = `
+"		日期	2022-09			2022-10		2022-11			2021年净增完成度	趋势	2022	
+		指标	数值	环比	同比	数值	环比	数值	环比	同比	净增完成度	趋势	数值	环比
+custom-node-1												-		
+custom-node-1	measure-a					377		3877	4324	0.42	-	-	377	
+custom-node-1	measure-a	measure-b				377	324	377	324	-0.02	-	-	377	324
+custom-node-1	measure-a	custom-node-2												
+custom-node-1	measure-a	measure-c					324	377	0		-	-		324
+custom-node-1	measure-a	measure-d				377	324	377	324	0.02	-	-	377	324
+custom-node-1	custom-node-5													
+measure-e								377	324	0.02	-	-		
+measure-e	custom-node-3													
+measure-e	custom-node-4													"
+`;
+
+exports[`<StrategySheet/> Tests StrategySheet Export Tests should export correct data by {formatHeader: false, formatData: true} 1`] = `
+"		日期	2022-09			2022-10		2022-11			2021年净增完成度	趋势	2022	
+		指标	数值	环比	同比	数值	环比	数值	环比	同比	净增完成度	趋势	数值	环比
+custom-node-1												-		
+custom-node-1	measure-a					377		3877	4324	0.42	-	-	377	
+custom-node-1	measure-a	measure-b				377	324	377	324	-0.02	-	-	377	324
+custom-node-1	measure-a	custom-node-2												
+custom-node-1	measure-a	measure-c					324	377	0		-	-		324
+custom-node-1	measure-a	measure-d				377	324	377	324	0.02	-	-	377	324
+custom-node-1	custom-node-5													
+measure-e								377	324	0.02	-	-		
+measure-e	custom-node-3													
+measure-e	custom-node-4													"
+`;
+
+exports[`<StrategySheet/> Tests StrategySheet Export Tests should export correct data by custom separator 1`] = `
+",,日期,2022-09,,,2022-10,,2022-11,,,2021年净增完成度,趋势,2022,
+,,指标,数值,环比,同比,数值,环比,数值,环比,同比,净增完成度,趋势,数值,环比
+自定义节点A,,,,,,,,,,,,-,,
+自定义节点A,指标A,,,,,377,,3877,4324,42%,-,-,377,
+自定义节点A,指标A,指标B,,,,377,324,377,324,-0.02,-,-,377,324
+自定义节点A,指标A,自定义节点B,,,,,,,,,,,,
+自定义节点A,指标A,指标C,,,,,324,377,0,,-,-,,324
+自定义节点A,指标A,指标D,,,,377,324,377,324,0.02,-,-,377,324
+自定义节点A,自定义节点E,,,,,,,,,,,,,
+指标E,,,,,,,,377,324,0.02,-,-,,
+指标E,自定义节点C,,,,,,,,,,,,,
+指标E,自定义节点D,,,,,,,,,,,,,"
+`;
+
 exports[`<StrategySheet/> Tests StrategySheet Export Tests should export correct data for custom corner text 1`] = `
 "		日期	2022-09			2022-10		2022-11			2021年净增完成度	趋势	2022	
 		指标	数值	环比	同比	数值	环比	数值	环比	同比	净增完成度	趋势	数值	环比

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/index-spec.tsx
@@ -7,6 +7,7 @@ import {
   SpreadSheet,
   customMerge,
   getCellMeta,
+  TAB_SEPARATOR,
   type GEvent,
   type S2DataConfig,
 } from '@antv/s2';
@@ -303,7 +304,7 @@ describe('<StrategySheet/> Tests', () => {
       await waitFor(() => {
         const result = strategyCopy({
           sheetInstance: s2,
-          split: '\t',
+          split: TAB_SEPARATOR,
           formatOptions: true,
         });
 
@@ -330,7 +331,7 @@ describe('<StrategySheet/> Tests', () => {
 
         const result = strategyCopy({
           sheetInstance: s2,
-          split: '\t',
+          split: TAB_SEPARATOR,
           formatOptions: true,
         });
 
@@ -346,7 +347,7 @@ describe('<StrategySheet/> Tests', () => {
 
         const result = strategyCopy({
           sheetInstance: s2,
-          split: '\t',
+          split: TAB_SEPARATOR,
           formatOptions: true,
         });
 
@@ -364,7 +365,7 @@ describe('<StrategySheet/> Tests', () => {
          */
         const result = strategyCopy({
           sheetInstance: s2,
-          split: '\t',
+          split: TAB_SEPARATOR,
           formatOptions: true,
         });
 
@@ -393,7 +394,7 @@ describe('<StrategySheet/> Tests', () => {
          */
         const result = strategyCopy({
           sheetInstance: s2,
-          split: '\t',
+          split: TAB_SEPARATOR,
           formatOptions: true,
         });
 
@@ -410,7 +411,7 @@ describe('<StrategySheet/> Tests', () => {
       await waitFor(() => {
         const result = strategyCopy({
           sheetInstance: s2,
-          split: '\t',
+          split: TAB_SEPARATOR,
           formatOptions: true,
         });
         const rows = result.split('\n');

--- a/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/index-spec.tsx
+++ b/packages/s2-react/__tests__/unit/components/sheets/strategy-sheet/index-spec.tsx
@@ -7,6 +7,7 @@ import {
   SpreadSheet,
   customMerge,
   getCellMeta,
+  CSV_SEPARATOR,
   TAB_SEPARATOR,
   type GEvent,
   type S2DataConfig,
@@ -320,6 +321,48 @@ describe('<StrategySheet/> Tests', () => {
         expect(result).toMatchSnapshot();
         expect(corner1).toEqual(['', '', '日期']);
         expect(corner2).toEqual(['', '', '指标']);
+      });
+    });
+
+    test('should export correct data by {formatHeader: false, formatData: true}', async () => {
+      await waitFor(() => {
+        const result = strategyCopy({
+          sheetInstance: s2,
+          split: TAB_SEPARATOR,
+          formatOptions: {
+            formatHeader: false,
+            formatData: true,
+          },
+        });
+
+        expect(result).toMatchSnapshot();
+      });
+    });
+
+    test('should export correct data by {formatHeader: false, formatData: false}', async () => {
+      await waitFor(() => {
+        const result = strategyCopy({
+          sheetInstance: s2,
+          split: TAB_SEPARATOR,
+          formatOptions: {
+            formatHeader: false,
+            formatData: false,
+          },
+        });
+
+        expect(result).toMatchSnapshot();
+      });
+    });
+
+    test('should export correct data by custom separator', async () => {
+      await waitFor(() => {
+        const result = strategyCopy({
+          sheetInstance: s2,
+          split: CSV_SEPARATOR,
+          formatOptions: true,
+        });
+
+        expect(result).toMatchSnapshot();
       });
     });
 

--- a/packages/s2-react/playground/config.tsx
+++ b/packages/s2-react/playground/config.tsx
@@ -315,9 +315,9 @@ export const s2Options: SheetComponentOptions = {
   debug: true,
   width: 800,
   height: 600,
-  hierarchyType: 'tree',
+  hierarchyType: 'grid',
   seriesNumber: {
-    enable: true,
+    enable: false,
   },
   transformCanvasConfig() {
     return {

--- a/packages/s2-react/src/components/export/index.tsx
+++ b/packages/s2-react/src/components/export/index.tsx
@@ -59,16 +59,22 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
 
   const [messageApi, contextHolder] = message.useMessage();
 
-  const copyData = async (isFormat: boolean) => {
+  const getPlainData = async (split: string, isFormat: boolean) => {
     const params: CopyAllDataParams = {
       sheetInstance: sheet,
-      split: TAB_SEPARATOR,
+      split,
       formatOptions: isFormat,
       async,
     };
 
     const data = await (customCopyMethod?.(params) ||
       asyncGetAllPlainData(params));
+
+    return data;
+  };
+
+  const copyData = async (isFormat: boolean) => {
+    const data = await getPlainData(TAB_SEPARATOR, isFormat);
 
     copyToClipboard(data, async)
       .then(() => {
@@ -82,13 +88,8 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
   };
 
   const downloadData = async (isFormat: boolean) => {
-    const data = await asyncGetAllPlainData({
-      sheetInstance: sheet,
-      // 导出的是 csv 格式, 复制时需要以逗号分割 https://github.com/antvis/S2/issues/2701
-      split: CSV_SEPARATOR,
-      formatOptions: isFormat,
-      async,
-    });
+    // 导出的是 csv 格式, 复制时需要以逗号分割 https://github.com/antvis/S2/issues/2701
+    const data = await getPlainData(CSV_SEPARATOR, isFormat);
 
     try {
       download(data, fileName);

--- a/packages/s2-react/src/components/export/index.tsx
+++ b/packages/s2-react/src/components/export/index.tsx
@@ -1,5 +1,5 @@
 import {
-  NewTab,
+  TAB_SEPARATOR,
   S2_PREFIX_CLS,
   SpreadSheet,
   asyncGetAllPlainData,
@@ -7,6 +7,7 @@ import {
   download,
   i18n,
   type CopyAllDataParams,
+  CSV_SEPARATOR,
 } from '@antv/s2';
 import { Button, Dropdown, message, type DropDownProps } from 'antd';
 import cx from 'classnames';
@@ -24,7 +25,7 @@ export interface ExportBaseProps {
   successText?: string;
   errorText?: string;
   fileName?: string;
-  syncCopy?: boolean;
+  async?: boolean;
   // ref: https://ant.design/components/dropdown-cn/#API
   dropdown?: DropDownProps;
   customCopyMethod?: (params: CopyAllDataParams) => Promise<string> | string;
@@ -38,7 +39,7 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
   const {
     className,
     icon,
-    syncCopy = false,
+    async = true,
     copyOriginalText = i18n('复制原始数据'),
     copyFormatText = i18n('复制格式化数据'),
     downloadOriginalText = i18n('下载原始数据'),
@@ -61,14 +62,15 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
   const copyData = async (isFormat: boolean) => {
     const params: CopyAllDataParams = {
       sheetInstance: sheet,
-      split: NewTab,
+      split: TAB_SEPARATOR,
       formatOptions: isFormat,
+      async,
     };
 
     const data = await (customCopyMethod?.(params) ||
       asyncGetAllPlainData(params));
 
-    copyToClipboard(data, syncCopy)
+    copyToClipboard(data, async)
       .then(() => {
         messageApi.success(successText);
       })
@@ -82,8 +84,10 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
   const downloadData = async (isFormat: boolean) => {
     const data = await asyncGetAllPlainData({
       sheetInstance: sheet,
-      split: NewTab,
+      // 导出的是 csv 格式, 复制时需要以逗号分割 https://github.com/antvis/S2/issues/2701
+      split: CSV_SEPARATOR,
       formatOptions: isFormat,
+      async,
     });
 
     try {
@@ -145,6 +149,6 @@ export const Export: React.FC<ExportProps> = React.memo((props) => {
 
 Export.displayName = 'Export';
 Export.defaultProps = {
-  syncCopy: false,
+  async: true,
   fileName: 'sheet',
 };

--- a/packages/s2-react/src/components/export/strategy-copy.ts
+++ b/packages/s2-react/src/components/export/strategy-copy.ts
@@ -168,6 +168,8 @@ class StrategyCopyData extends PivotDataCellCopy {
         rowMatrix,
         cornerMatrix,
       }),
+      // https://github.com/antvis/S2/issues/2701
+      this.config.separator,
     );
   };
 }

--- a/s2-site/docs/api/components/export.en.md
+++ b/s2-site/docs/api/components/export.en.md
@@ -28,7 +28,7 @@ tag: Updated
 | successText          | Successful operation copy                                                               | `string`                                                        |          |          |
 | errorText            | Operation failure copy                                                                  | `string`                                                        |          |          |
 | fileName             | Customize the download file name                                                        | `string`                                                        | `sheet`  |          |
-| syncCopy             | Copy data synchronously (default is asynchronous)                                       | `boolean`                                                       | `false`  |          |
+| async             | Copy data asynchronously (default is asynchronous)                                       | `boolean`                                                       | `false`  |          |
 | drop down            | Dropdown menu configuration, transparently passed to the `Dropdown` component of `antd` | [DropdownProps](https://ant.design/components/dropdown-cn/#API) |          |          |
 
 <embed src="@/docs/common/copy-export.en.md"></embed>

--- a/s2-site/docs/api/components/export.zh.md
+++ b/s2-site/docs/api/components/export.zh.md
@@ -28,7 +28,7 @@ tag: Updated
 | successText | 操作成功文案 | `string` |  |  |
 | errorText | 操作失败文案 | `string` |  |  |
 | fileName | 自定义下载文件名 (csv) | `string` | `sheet` |  |
-| syncCopy | 同步复制数据 （默认异步） | `boolean` | `false` |  |
+| async | 异步复制/导出数据 （默认异步） | `boolean` | `true` |  |
 | dropdown | 下拉菜单配置，透传给 `antd` 的 `Dropdown` 组件 | [DropdownProps](https://ant.design/components/dropdown-cn/#API) | | |
 | customCopyMethod | 自定义导出组件内部复制处理逻辑 | (params: [CopyAllDataParams](#copyalldataparams)) => `Promise<string> \| string` | | |
 

--- a/s2-site/docs/common/copy-export.en.md
+++ b/s2-site/docs/common/copy-export.en.md
@@ -40,7 +40,7 @@ download(data, 'filename')
 | parameter | illustrate                                                   | type      | Defaults | required |
 | --------- | ------------------------------------------------------------ | --------- | -------- | -------- |
 | data      | data source                                                  | `string`  |          | ✓        |
-| sync      | Whether to copy data synchronously (default is asynchronous) | `boolean` | `false`  |          |
+| async      | Whether to copy data asynchronously (default is asynchronous) | `boolean` | `true`  |          |
 
 ### download
 

--- a/s2-site/docs/common/copy-export.zh.md
+++ b/s2-site/docs/common/copy-export.zh.md
@@ -21,6 +21,9 @@ const data = await asyncGetAllPlainData({
   //   formatHeader: true,
   //   formatData: true
   // },
+
+  // 同步复制
+  // async: false
 });
 
 // 同步复制：copyToClipboard(data, false)
@@ -140,16 +143,19 @@ import { asyncGetAllPlainData, download } from '@antv/s2'
 // 拿到复制数据
 const data = await asyncGetAllPlainData({
   sheetInstance: s2,
-  split: '\t',
+  split: ',',
   formatOptions: true,
   // formatOptions: {
   //   formatHeader: true,
   //   formatData: true
   // },
+
+  // 同步导出
+  // async: false
 });
 
 // 导出数据 (csv)
-download(data, 'filename')
+download(data, 'filename') // filename.csv
 ```
 
 #### 2. 复制数据到剪贴板
@@ -207,17 +213,17 @@ const data = await asyncGetAllPlainData({
 | 参数          | 说明      | 类型              | 默认值           | 必选 |
 | ------------|-----------------|---------------|---------------| --- |
 | sheetInstance | s2 实例    | [SpreadSheet](/docs/api/basic-class/spreadsheet)     |      | ✓    |
-| split       | 分隔符           | `string`       |     | ✓    |
-| formatOptions  | 是否使用 [S2DataConfig.Meta](/api/general/s2-data-config#meta) 进行格式化，可以分别对数据单元格和行列头进行格式化，传 `boolean` 会同时对单元格和行列头生效。 | `boolean \|  { formatHeader?: boolean, formatData?: boolean }`| `false`  |      |
+| split       | 分隔符    | `string`       |     | ✓    |
+| formatOptions  | 是否使用 [S2DataConfig.Meta](/api/general/s2-data-config#meta) 进行格式化，可以分别对数据单元格和行列头进行格式化，传 `boolean` 会同时对单元格和行列头生效。 | `boolean \|  { formatHeader?: boolean, formatData?: boolean }`| `true`  |      |
 | customTransformer  | 导出时支持自定义 (transformer) 数据导出格式化方法  | (transformer: `Transformer`) => [`Partial<Transformer>`](#transformer)      |  |      |
-| isAsyncExport  | 是否异步导出        | boolean      | false         |      |
+| async  | 是否异步复制/导出        | boolean      | `true`         |      |
 
 ##### copyToClipboard
 
 | 参数 | 说明     | 类型     | 默认值 | 必选 |
 | --- | --- | ------- | ----- | --- |
 | data | 数据源 | `string` |        | ✓    |
-| sync | 是否同步复制数据 （默认异步） | `boolean` |   `false`     |     |
+| async | 是否异步复制数据（默认异步） | `boolean` |   `true`     |     |
 
 ##### download
 
@@ -254,7 +260,7 @@ interface CopyAllDataParams {
   split?: string;
   formatOptions?: FormatOptions;
   customTransformer?: (transformer: Transformer) => Partial<Transformer>;
-  isAsyncExport?: boolean;
+  async?: boolean;
 }
 ```
 

--- a/s2-site/docs/manual/migration-v2.zh.md
+++ b/s2-site/docs/manual/migration-v2.zh.md
@@ -212,10 +212,19 @@ const s2Options = {
 +  sheetInstance: s2,
 +  split: '\t',
 +  formatOptions: false,
++  async: true,
 });
 ```
 
-3. 复制默认开启。
+3. `copyToClipboard` 第二个参数含义 从 `sync` 变更为 `async`.
+
+```diff
+- const data = copyToClipboard(data: string, sync: boolean)
++ const data = copyToClipboard(data: string, async: boolean)
+```
+
+4. 复制默认开启。
+5. 复制导出默认异步。
 
 具体请查看 [复制与导出](/manual/advanced/interaction/copy) 相关文档。
 
@@ -667,6 +676,15 @@ const header = {
 ```
 
 具体请查看 [表头](/manual/advanced/analysis/header) 相关文档。
+
+#### 导出组件配置调整
+
+`syncCopy` 变更为 `async`
+
+```diff
+- <Export syncCopy={true} />
++ <Export async={false} />
+```
 
 #### Tooltip 菜单项配置调整
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2701 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

1. BREAKING CHANGE: Export 组件 和 asyncGetAllPlainData, copyToClipboard 的是否异步导出参数统一为 async
2. 修复普通表格导出 CSV 分隔符错误.
3. 修复趋势分析表未接受自定义分隔符导致的导出错误.

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/3a4d8bf0-cb7f-489c-bd58-425e8cbbeabe) | ![image](https://github.com/antvis/S2/assets/21015895/46f9661e-cfca-4a4f-abbd-9fe0201b0a3a) |
| ![image](https://github.com/antvis/S2/assets/21015895/2586b43b-f663-4408-8485-723ea55cbe61) | ![image](https://github.com/antvis/S2/assets/21015895/97e967d4-ce48-4ae9-919e-5245545c149d) |
 

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

close #2701 

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
