### PR TITLE
fix: 修复滚动边界问题 close #2720

### DIFF
--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -505,7 +505,7 @@ export abstract class BaseFacet {
   onContainerWheelForPc = () => {
     const canvas = this.spreadsheet.getCanvasElement();
 
-    canvas?.addEventListener('wheel', this.onWheel, { passive: true });
+    canvas?.addEventListener('wheel', this.onWheel);
   };
 
   onContainerWheelForMobile = () => {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2720 

### 📝 Description

#### 背景

滚动表格的时候，表格和父容器的滚动条会同时滚动：

![file](https://github.com/antvis/S2/assets/11677125/71ec858f-1996-451c-a5aa-daa446cd37f9)

#### 原因

<img width="792" alt="image" src="https://github.com/antvis/S2/assets/11677125/78fcc7ba-5abc-485a-884f-66b569d65f7c">

`passive` 设置为 `true` 使浏览器忽略了 `preventDefault`，滚动事件会冒泡到父元素，导致父元素开始滚动。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![file](https://github.com/antvis/S2/assets/11677125/71ec858f-1996-451c-a5aa-daa446cd37f9)  |  ![3](https://github.com/antvis/S2/assets/11677125/4f143b19-1f8a-4383-8e58-e6453a4a0a47) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

close #2720

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
