### PR TITLE
fix: 修复自定义 tooltip 时, 刷选时无法获取到单元格信息

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../../src';
 import { PivotDataSet } from '../../../src/data-set';
 import { PivotFacet } from '../../../src/facet';
+import { createMockCellInfo } from '../../util/helpers';
 import { customMerge, setupDataConfig } from '@/utils';
 import { BaseTooltip } from '@/ui/tooltip';
 import { PivotSheet, SpreadSheet } from '@/sheet-type';
@@ -1369,5 +1370,16 @@ describe('PivotSheet Tests', () => {
     s2.destroy();
     // eslint-disable-next-line no-underscore-dangle
     expect(canvas.__s2_instance__).toBe(undefined);
+  });
+
+  test('should get last interacted cell if event target is empty', () => {
+    const cellA = createMockCellInfo('A');
+    const cellB = createMockCellInfo('B');
+
+    s2.interaction.setInteractedCells(cellA);
+    s2.interaction.setInteractedCells(cellB);
+
+    // @ts-ignore
+    expect(s2.getTargetCell(null)).toEqual(cellB);
   });
 });

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -14,6 +14,7 @@ import {
   isEmpty,
   isFunction,
   isString,
+  last,
   memoize,
   some,
   values,
@@ -240,6 +241,11 @@ export abstract class SpreadSheet extends EE {
     return this.options.tooltip?.render?.(this) || new BaseTooltip(this);
   }
 
+  private getTargetCell(target: CellEventTarget) {
+    // 刷选等场景, 以最后一个发生交互的单元格为准
+    return this.getCell(target) || last(this.interaction.getInteractedCells());
+  }
+
   /**
    * 展示 Tooltip 提示
    * @alias s2.tooltip.show()
@@ -258,7 +264,7 @@ export abstract class SpreadSheet extends EE {
     Menu = BaseTooltipOperatorMenuOptions,
   >(showOptions: TooltipShowOptions<T, Menu>): Promise<void> {
     const { content, event } = showOptions;
-    const cell = this.getCell(event?.target);
+    const cell = this.getTargetCell(event?.target);
     const displayContent = isFunction(content)
       ? content(cell!, showOptions)
       : content;
@@ -285,7 +291,7 @@ export abstract class SpreadSheet extends EE {
       return;
     }
 
-    const targetCell = this.getCell(event?.target);
+    const targetCell = this.getTargetCell(event?.target);
     const tooltipData =
       options?.data ??
       getTooltipData({

--- a/packages/s2-core/src/utils/tooltip.ts
+++ b/packages/s2-core/src/utils/tooltip.ts
@@ -20,6 +20,7 @@ import {
   isNil,
   isNumber,
   isObject,
+  last,
   map,
   mapKeys,
   noop,
@@ -716,7 +717,7 @@ export const getTooltipOptions = (
   const cellType = spreadsheet.getCellType?.(event?.target);
 
   // 如果没有 cellType, 说明是刷选丢失 event target 的场景, 此时从产生过交互状态的单元格里取, 避免刷选读取不到争取 tooltip 配置的问题
-  const sampleCell = interaction.getInteractedCells()[0];
+  const sampleCell = last(interaction.getInteractedCells());
 
   return getTooltipOptionsByCellType(
     options.tooltip!,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

```ts
const s2Options = {
  tooltip: {
	  dataCell: {
	    content(cell, defaultTooltipShowOptions) {
	      console.log(cell, defaultTooltipShowOptions);
	
	      return null;
	    },
	  },
  }
}
```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/cce897dc-47b1-4a1d-a615-98da4f088e9b) | ![image](https://github.com/antvis/S2/assets/21015895/2605747f-28af-4271-8427-0f26854f691e) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
