### PR TITLE
feat(type): 使用 Template Literal Types 增强枚举类型的提示

### DIFF
--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -120,8 +120,14 @@ export abstract class HeaderCell<
     // 为什么有排序参数就不展示 actionIcon 了？背景不清楚，先照旧处理
     if (this.showSortIcon()) {
       this.actionIconConfig = {
-        icons: [{ name: get(sortParam, 'type', 'none'), position: 'right' }],
-        belongsCell: this.cellType,
+        icons: [
+          {
+            name: sortParam?.type || 'none',
+            position: 'right',
+          },
+        ],
+        belongsCell: this
+          .cellType as InternalFullyHeaderActionIcon['belongsCell'],
         isSortIcon: true,
       };
     } else {

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -124,7 +124,7 @@ export enum Aggregation {
 
 export interface CalcTotals {
   /** 聚合方式 */
-  aggregation?: Aggregation;
+  aggregation?: `${Aggregation}`;
 
   /**
    * 自定义计算汇总
@@ -360,7 +360,10 @@ export interface HeaderActionIcon extends HeaderActionIconBaseOptions {
    * 所属的 cell 类型, 即当前 icon 展示在哪种类型单元格中
    * @example belongsCell: 'rowCell'
    */
-  belongsCell: Omit<CellType, 'dataCell' | 'mergedCell' | 'seriesNumberCell'>;
+  belongsCell: Omit<
+    `${CellType}`,
+    'dataCell' | 'mergedCell' | 'seriesNumberCell'
+  >;
 }
 
 export interface InternalFullyHeaderActionIcon extends HeaderActionIcon {

--- a/packages/s2-core/src/common/interface/basic.ts
+++ b/packages/s2-core/src/common/interface/basic.ts
@@ -360,7 +360,7 @@ export interface HeaderActionIcon extends HeaderActionIconBaseOptions {
    * 所属的 cell 类型, 即当前 icon 展示在哪种类型单元格中
    * @example belongsCell: 'rowCell'
    */
-  belongsCell: Omit<
+  belongsCell: Exclude<
     `${CellType}`,
     'dataCell' | 'mergedCell' | 'seriesNumberCell'
   >;

--- a/packages/s2-core/src/common/interface/events.ts
+++ b/packages/s2-core/src/common/interface/events.ts
@@ -4,15 +4,6 @@ import type { FederatedPointerEvent as GEvent, IEventTarget } from '@antv/g';
 import type { Node } from '../../facet/layout/node';
 import type { S2CellType } from './interaction';
 
-export interface ListSortParams {
-  sortFieldId: string;
-  sortMethod: string;
-}
-
-export type LayoutRow = [number, string, string];
-
-export type LayoutCol = [number, string, string];
-
 export interface TargetCellInfo {
   target: S2CellType;
   event: GEvent;

--- a/packages/s2-core/src/common/interface/export.ts
+++ b/packages/s2-core/src/common/interface/export.ts
@@ -16,17 +16,17 @@ export enum CopyMIMEType {
 }
 
 export type CopyableItem = {
-  type: CopyMIMEType;
+  type: `${CopyMIMEType}`;
   content: string;
 };
 
 export type CopyablePlain = {
-  type: CopyMIMEType.PLAIN;
+  type: `${CopyMIMEType.PLAIN}`;
   content: string;
 };
 
 export type CopyableHTML = {
-  type: CopyMIMEType.HTML;
+  type: `${CopyMIMEType.HTML}`;
   content: string;
 };
 

--- a/packages/s2-core/src/common/interface/interaction.ts
+++ b/packages/s2-core/src/common/interface/interaction.ts
@@ -259,7 +259,7 @@ export interface InteractionOptions {
    * 滚动条位置 (可用于表格内容未撑满 Canvas 的场景)
    * @example scrollbarPosition: 'content'
    */
-  scrollbarPosition?: ScrollbarPositionType;
+  scrollbarPosition?: `${ScrollbarPositionType}`;
 
   /**
    * 透传 listener 属性的可选参数对象

--- a/packages/s2-core/src/common/interface/resize.ts
+++ b/packages/s2-core/src/common/interface/resize.ts
@@ -52,7 +52,7 @@ export interface ResizeParams {
 
 export interface ResizeInfo {
   theme: ResizeArea;
-  type: ResizeDirectionType;
+  type: `${ResizeDirectionType}`;
   offsetX: number;
   offsetY: number;
   width: number;
@@ -88,10 +88,10 @@ export interface ResizeInteractionOptions {
   colCellVertical?: boolean;
 
   /** 行高调整时，影响当前行还是全部行 */
-  rowResizeType?: ResizeType;
+  rowResizeType?: `${ResizeType}`;
 
   /** 列高调整时，影响当前列还是全部列 */
-  colResizeType?: ResizeType;
+  colResizeType?: `${ResizeType}`;
 
   /** 是否允许调整, 返回 false 时拖拽的宽高无效 */
   disable?: (resizeInfo: ResizeInfo) => boolean;

--- a/packages/s2-core/src/common/interface/s2DataConfig.ts
+++ b/packages/s2-core/src/common/interface/s2DataConfig.ts
@@ -5,7 +5,7 @@ export interface BaseChartData {
   /**
    * 类型
    */
-  type: MiniChartType;
+  type: `${MiniChartType}`;
 
   /**
    * 数据

--- a/packages/s2-core/src/common/interface/style.ts
+++ b/packages/s2-core/src/common/interface/style.ts
@@ -116,7 +116,7 @@ export interface S2Style {
   /**
    * 布局类型
    */
-  layoutWidthType?: LayoutWidthType;
+  layoutWidthType?: `${LayoutWidthType}`;
 
   /**
    * 数值单元格配置

--- a/packages/s2-core/src/common/interface/theme.ts
+++ b/packages/s2-core/src/common/interface/theme.ts
@@ -286,17 +286,24 @@ export interface SplitLine {
   /** 分割线虚线 */
   borderDash?: LineStyleProps['lineDash'];
 }
+
 export interface DefaultCellTheme extends GridAnalysisCellTheme {
-  /** 粗体文本样式 */
+  /**
+   * 粗体文本样式 (如: 总计, 小计, 行列头非叶子节点文本)
+   * @see https://s2.antv.antgroup.com/manual/advanced/custom/cell-align#%E8%A1%8C%E5%A4%B4%E5%AF%B9%E9%BD%90%E6%96%B9%E5%BC%8F
+   */
   bolderText?: TextTheme;
 
-  /** 文本样式 */
+  /** 文本样式 (如: 数值, 行列头叶子节点文本) */
   text?: TextTheme;
 
-  /** 序号样式 */
+  /** 序号文本样式 */
   seriesText?: TextTheme;
 
-  /** 度量值文本样式 */
+  /**
+   * 度量值文本样式 (如: 数值挂行/列头时, 行列头所对应的虚拟数值单元格文本)
+   * @see https://s2.antv.antgroup.com/manual/advanced/custom/cell-align#%E5%88%97%E5%A4%B4%E5%AF%B9%E9%BD%90%E6%96%B9%E5%BC%8F
+   */
   measureText?: TextTheme;
 
   /** 单元格样式 */

--- a/packages/s2-core/src/interaction/event-controller.ts
+++ b/packages/s2-core/src/interaction/event-controller.ts
@@ -32,7 +32,7 @@ interface EventListener {
 }
 
 interface S2EventHandler {
-  type: keyof EmitterType;
+  type: `${keyof EmitterType}`;
   handler: EmitterType[keyof EmitterType];
 }
 
@@ -652,7 +652,7 @@ export class EventController {
   }
 
   private addS2Event<K extends keyof EmitterType>(
-    eventType: K,
+    eventType: `${K}`,
     handler: EmitterType[K],
   ) {
     this.spreadsheet.on(eventType, handler);

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -22,7 +22,6 @@ import {
 import { BaseCell } from '../cell';
 import {
   InterceptType,
-  LayoutWidthType,
   S2Event,
   getDefaultSeriesNumberText,
   getTooltipOperatorSortMenus,
@@ -587,14 +586,14 @@ export abstract class SpreadSheet extends EE {
   }
 
   public override on<K extends keyof EmitterType>(
-    event: K,
+    event: `${K}`,
     listener: EmitterType[K],
   ): this {
     return super.on(event, listener);
   }
 
   public override emit<K extends keyof EmitterType>(
-    event: K,
+    event: `${K}`,
     ...args: Parameters<EmitterType[K]>
   ): void {
     super.emit(event, ...args);
@@ -631,7 +630,7 @@ export abstract class SpreadSheet extends EE {
     };
   }
 
-  public getLayoutWidthType(): LayoutWidthType {
+  public getLayoutWidthType() {
     return this.options.style?.layoutWidthType!;
   }
 

--- a/packages/s2-react/playground/config.tsx
+++ b/packages/s2-react/playground/config.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable no-console */
 import {
   EMPTY_PLACEHOLDER,
-  ResizeType,
   customMerge,
   type CustomHeaderField,
   type CustomTreeNode,
@@ -376,8 +375,8 @@ export const s2Options: SheetComponentOptions = {
       rowCell: true,
     },
     resize: {
-      rowResizeType: ResizeType.ALL,
-      colResizeType: ResizeType.ALL,
+      rowResizeType: 'all',
+      colResizeType: 'all',
     },
   },
   // totals: {

--- a/packages/s2-react/playground/config.tsx
+++ b/packages/s2-react/playground/config.tsx
@@ -340,7 +340,6 @@ export const s2Options: SheetComponentOptions = {
   seriesNumber: {
     enable: false,
   },
-
   transformCanvasConfig() {
     return {
       supportsCSSTransform: true,

--- a/s2-site/docs/api/general/S2Theme.zh.md
+++ b/s2-site/docs/api/general/S2Theme.zh.md
@@ -70,10 +70,10 @@ s2.setTheme({
 
 | 参数              | 说明           | 类型                              | 默认值 | 必选 |
 | ----------------- | -------------- | --------------------------------- | ------ | ---- |
-| bolderText        | 加粗文本样式   | [TextTheme](#texttheme)           | -      |      |
-| text              | 文本样式       | [TextTheme](#texttheme)           | -      |      |
+| bolderText        | 加粗文本样式（如：总计，小计，行列头非叶子节点文本）[了解更多](/manual/advanced/custom/cell-align#%E8%A1%8C%E5%A4%B4%E5%AF%B9%E9%BD%90%E6%96%B9%E5%BC%8F)   | [TextTheme](#texttheme)           | -      |      |
+| text              | 文本样式（如：数值，行列头叶子节点文本）[了解更多](/manual/advanced/custom/cell-align#%E6%95%B0%E6%8D%AE%E5%8D%95%E5%85%83%E6%A0%BC%E5%AF%B9%E9%BD%90%E6%96%B9%E5%BC%8F)      | [TextTheme](#texttheme)           | -      |      |
 | seriesText        | 序号文本样式   | [TextTheme](#texttheme)           | -      |      |
-| measureText       | 度量值文本样式 | [TextTheme](#texttheme)           | -      |      |
+| measureText       | 度量值文本样式（如：数值挂行/列头时，行列头所对应的虚拟数值单元格文本）[了解更多](/manual/advanced/custom/cell-align#%E5%88%97%E5%A4%B4%E5%AF%B9%E9%BD%90%E6%96%B9%E5%BC%8F)  | [TextTheme](#texttheme)           | -      |      |
 | cell              | 单元格样式     | [CellTheme](#celltheme)           | -      |      |
 | icon              | 图标样式       | [IconTheme](#icontheme)           | -      |      |
 | seriesNumberWidth | 序号列宽       | `number`                          | 80     |      |

--- a/s2-site/docs/manual/basic/theme.zh.md
+++ b/s2-site/docs/manual/basic/theme.zh.md
@@ -155,7 +155,9 @@ await s2.render(false);
 
 #### 自定义单元格对齐方式
 
-[查看详情](/manual/advanced/custom/cell-align) 和 [完整 API](/api/general/s2theme#s2theme)
+单元格文本配置分为了 `text（普通文本）`, `bolderText（加粗文本）`, `seriesText（序号文本）`, `measureText（度量值文本）`, 分别对应不同场景。
+
+[查看详情](/manual/advanced/custom/cell-align) 或 [完整 API](/api/general/s2theme#s2theme)
 
 ```ts
 s2.setTheme({
@@ -166,6 +168,12 @@ s2.setTheme({
     bolderText: {
       textAlign: 'left',
     },
+    seriesText: {
+      textAlign: 'left',
+    },
+    measureText: {
+      textAlign: 'left',
+    }
   },
 });
 ```


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [x] Type optimization


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

```diff
export enum LayoutWidthType {
  Adaptive = 'adaptive',
  ColAdaptive = 'colAdaptive',
  Compact = 'compact',
}

export interface A {
-  layoutWidthType?: LayoutWidthType
+  layoutWidthType?: `${LayoutWidthType}`
}
```

将枚举定义改成模版字符串的方式, 可以直接获得编辑器提示, 无需引入额外的枚举定义. 

**注意: 原来枚举的写法不受影响,这样是可以兼容之前的枚举写法的, 相当于多了种选择.**

> 直接写字符串也可以

![image](https://github.com/antvis/S2/assets/21015895/7b4dc91f-4007-4d16-8b06-b5f3328ba89e)

> 直接写枚举也可以

![image](https://github.com/antvis/S2/assets/21015895/6a36f7ae-92a7-4e55-a4b8-9e90c4470ecd)

![image](https://github.com/antvis/S2/assets/21015895/7b448421-35c0-402c-b22c-2219ab8e75f6)




### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
