### PR TITLE
fix: 修复树状模式当一组数据只有一条数据时, 叶子节点判断错误, 也渲染了展开/收起图标 close #2804

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-2804-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-2804-spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/**
+ * 透视表树状模式当某一组数据只有一条数据时, 叶子节点判断错误, 也渲染了展开/收起图标.
+ * @description spec for issue #2804
+ * https://github.com/antvis/S2/issues/2804
+ */
+import { S2Options } from '../../src';
+import * as mockDataConfig from '../data/data-issue-2804.json';
+import { getContainer } from '../util/helpers';
+import { PivotSheet } from '@/sheet-type';
+
+const s2Options: S2Options = {
+  width: 800,
+  height: 600,
+  hierarchyType: 'tree',
+};
+
+describe('Tree Leaf Node Status Tests', () => {
+  test('should get correctly tree icon and leaf node status', () => {
+    const s2 = new PivotSheet(getContainer(), mockDataConfig, s2Options);
+
+    s2.render();
+
+    const [a1, a2] = s2.getRowNodes();
+
+    expect(a1.isLeaf).toBeTruthy();
+    expect(a1.isTotals).toBeFalsy();
+    expect(a2.isLeaf).toBeFalsy();
+    expect(a2.isTotals).toBeTruthy();
+    expect(a1.belongsCell.treeIcon).not.toBeDefined();
+    expect(a2.belongsCell.treeIcon).toBeDefined();
+  });
+});

--- a/packages/s2-core/__tests__/data/data-issue-2804.json
+++ b/packages/s2-core/__tests__/data/data-issue-2804.json
@@ -1,0 +1,21 @@
+{
+  "fields": {
+    "rows": ["row0", "row1"],
+    "columns": ["col0"],
+    "values": ["cost"],
+    "valueInCols": true
+  },
+  "data": [
+    {
+      "row0": "a-1",
+      "col0": "b-1",
+      "cost": 2
+    },
+    {
+      "row0": "a-2",
+      "row1": "a-2-1",
+      "col0": "b-2",
+      "cost": 3
+    }
+  ]
+}

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -1,5 +1,5 @@
-import { isNumber } from 'lodash';
-import { i18n } from '../../common';
+import { isEmpty, isNumber } from 'lodash';
+import { i18n, TOTAL_VALUE } from '../../common';
 import type { SpreadSheet } from '../../sheet-type';
 import { filterOutDetail } from '../../utils/data-set-operate';
 import { generateId } from '../../utils/layout/generate-id';
@@ -118,11 +118,18 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
       hierarchy.maxLevel = level;
     }
 
-    const emptyChildren = !pivotMetaValue?.children?.size;
-    if (emptyChildren || isTotals) {
+    /**
+     * 除了虚拟行小计节点外, 如果为空, 说明当前分组只有一条数据, 应该标记为叶子节点.
+     * https://github.com/antvis/S2/issues/2804
+     */
+    const children = [...(pivotMetaValue?.children?.keys() || [])].filter(
+      (child) => child !== TOTAL_VALUE,
+    );
+    const isEmptyChildren = isEmpty(children);
+    if (isEmptyChildren || isTotals) {
       node.isLeaf = true;
     }
-    if (!emptyChildren) {
+    if (!isEmptyChildren) {
       node.isTotals = true;
     }
 
@@ -133,7 +140,7 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
       hierarchy,
     );
 
-    if (!emptyChildren && !isCollapse && !isTotals && expandCurrentNode) {
+    if (!isEmptyChildren && !isCollapse && !isTotals && expandCurrentNode) {
       buildRowTreeHierarchy({
         level: level + 1,
         currentField: pivotMetaValue.childField,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2804 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

![image](https://github.com/antvis/S2/assets/21015895/c8c5fc80-2a04-45b7-b237-acc96c91f0ef)

树状模式由于一级节点即是普通节点, 又是小计节点, 在当前分组下只有一条数据时, `isLeaf` 判断错误, 错误的展示了折叠展开 icon.

```ts
{
  "fields": {
    "rows": ["row0", "row1"],
    "columns": ["col0"],
    "values": ["cost"],
    "valueInCols": true
  },
  "data": [
    {
      "row0": "a-1",
      "col0": "b-1",
      "cost": 2
    },
    {
      "row0": "a-2",
      "row1": "a-2-1",
      "col0": "b-2",
      "cost": 3
    }
  ]
}

```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/S2/assets/21015895/faa5be08-b134-48e4-8587-a5b7d6d43839) | ![image](https://github.com/antvis/S2/assets/21015895/dd79fe17-a8e3-41eb-80b4-595eef9a281e) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
