### PR TITLE
fix(typo): Change target attribute from _black to _blank

### DIFF
--- a/s2-site/playground/config-panel/config-component/dragger-upload/index.tsx
+++ b/s2-site/playground/config-panel/config-component/dragger-upload/index.tsx
@@ -101,7 +101,7 @@ export class DraggerUpload extends PureComponent<Props> {
           ；可选参数有总计/小计数据{' '}
           <a
             href="https://s2.antv.antgroup.com/api/general/s2dataconfig#data"
-            target="_black"
+            target="_blank"
             rel="noopener noreferrer"
           >
             totalData
@@ -109,7 +109,7 @@ export class DraggerUpload extends PureComponent<Props> {
           、字段元数据{' '}
           <a
             href="https://s2.antv.antgroup.com/api/general/s2dataconfig#meta"
-            target="_black"
+            target="_blank"
             rel="noopener noreferrer"
           >
             meta
@@ -117,7 +117,7 @@ export class DraggerUpload extends PureComponent<Props> {
           、排序参数配置{' '}
           <a
             href="https://s2.antv.antgroup.com/api/general/s2dataconfig#sortparam"
-            target="_black"
+            target="_blank"
             rel="noopener noreferrer"
           >
             sortParams
@@ -125,7 +125,7 @@ export class DraggerUpload extends PureComponent<Props> {
           。参考数据格式见：
           <a
             href="https://gw.alipayobjects.com/os/bmw-prod/2a5dbbc8-d0a7-4d02-b7c9-34f6ca63cff6.json"
-            target="_black"
+            target="_blank"
             rel="noopener noreferrer"
           >
             标准透视表数据


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0 (no existing issue found)

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

This commit addresses the issue where page navigation incorrectly overwrote the content of previously opened tabs. By changing the target attribute of the a-tag from _black to _blank, new pages will now open in a new tab, preventing the overwriting of existing tabs.

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
