### PR TITLE
fix: 处理自定义mini图显示柱状图时，全为正值&全为零值 展示异常问题

### DIFF
--- a/packages/s2-core/src/utils/g-mini-charts.ts
+++ b/packages/s2-core/src/utils/g-mini-charts.ts
@@ -97,13 +97,26 @@ export const scale = (chartData: BaseChartData, cell: S2CellType) => {
             positionY = baseLinePositionY;
           }
         } else {
-          baseLinePositionY = minMeasure < 0 ? yStart : yEnd;
+          // 有三种情况：全为正数 / 全为负数 / 全为零值
+          // baseLinePositionY = minMeasure < 0 ? yStart : yEnd;
           measureRange = max([Math.abs(maxMeasure), Math.abs(minMeasure)])!;
-          barHeight =
-            measureRange === 0
-              ? heightRange
-              : (Math.abs(item?.y - 0) / measureRange) * heightRange;
-          positionY = baseLinePositionY;
+
+          if (measureRange === 0 && minMeasure === 0 && maxMeasure === 0) {
+            // 全为零值: 没有bar
+            barHeight = 0;
+          } else {
+            // 全为非零值: 有bar 高度相同
+            barHeight =
+              measureRange === 0
+                ? heightRange
+                : (Math.abs(item?.y - 0) / measureRange) * heightRange;
+          }
+
+          if (minMeasure < 0) {
+            positionY = yStart;
+          } else {
+            positionY = yEnd - barHeight;
+          }
         }
 
         const barWidth = intervalX - intervalPadding;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #2822

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
这次改动主要是处理用使用 mini画柱状图时，在数据全为正值和全为零值时，柱状图展示异常问题。在单元格内绘制 mini 柱状图时，计算每个坐标转换的函数有点问题，如下图所示。
![image](https://github.com/user-attachments/assets/b3fb8817-0e3f-4121-af13-555741b544c7)

上图框起来的部分需要分情况分别考虑 barHeight 和 positionY：1. 数据全为正、2. 数据全为零、3. 数据全为负，修改如下图所示。
![image](https://github.com/user-attachments/assets/9fa7db3b-1eec-44af-858e-12fb54a7e134)




### 🖼️ Screenshot

改版前后的对比图如下所示。覆盖了以下常见都没有问题了。

1. 数据全为正
2. 数据全为负
3. 数据全为零
4. 数据有正有负
5. 数据有正有负有零

![image](https://github.com/user-attachments/assets/eee9e474-f611-4681-9c99-b2b2145ac583)


| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
