### PR TITLE
fix: 移动端关闭 supportsPointerEvents, 避免禁用 touchAction close #2857

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-spec.ts
@@ -307,6 +307,22 @@ describe('SpreadSheet Tests', () => {
         await expect(render()).resolves.toBe(undefined);
       },
     );
+
+    // https://github.com/antvis/S2/issues/2857
+    test('should enable touch action on mobile device', async () => {
+      const s2 = createPivotSheet({
+        ...s2Options,
+        device: 'mobile',
+      });
+
+      await s2.render();
+
+      const { supportsPointerEvents } = s2.container.getConfig();
+      const canvas = s2.getCanvasElement();
+
+      expect(supportsPointerEvents).toBeFalsy();
+      expect(canvas.style.touchAction).not.toEqual('none');
+    });
   });
 
   describe('Destroy Sheet Tests', () => {

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -67,6 +67,7 @@ import { BaseTooltip } from '../ui/tooltip';
 import { removeOffscreenCanvas } from '../utils/canvas';
 import { clearValueRangeState } from '../utils/condition/state-controller';
 import { hideColumnsByThunkGroup } from '../utils/hide-columns';
+import { isMobile } from '../utils/is-mobile';
 import { customMerge, setupDataConfig, setupOptions } from '../utils/merge';
 import { injectThemeVars } from '../utils/theme';
 import { getTooltipData, getTooltipOptions } from '../utils/tooltip';
@@ -703,16 +704,22 @@ export abstract class SpreadSheet extends EE {
    * @private
    */
   protected initContainer(dom: S2MountContainer) {
-    const { width, height, transformCanvasConfig } = this.options;
+    const { width, height, device, transformCanvasConfig } = this.options;
 
     const renderer = new Renderer() as unknown as CanvasConfig['renderer'];
     const canvasConfig = transformCanvasConfig?.(renderer, this);
+    /**
+     * https://github.com/antvis/S2/issues/2857
+     * 开启 supportsPointerEvents 后, G Canvas 会禁用 `touchAction`: https://github.com/antvis/G/blob/910c58e9bcba48cfa7bb0585064d27d3ae0bff4c/packages/g-plugin-dom-interaction/src/DOMInteractionPlugin.ts#L135
+     */
+    const supportsPointerEvents = !isMobile(device);
 
     this.container = new Canvas({
       container: this.getMountContainer(dom) as HTMLElement,
       width,
       height,
       renderer,
+      supportsPointerEvents,
       ...canvasConfig,
     });
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->


🐛 Bugfix

- [x] Solve the issue and close #2857


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

G 的 supportsPointerEvents 默认开启, 会给 canvas 设置 `touchAction: none`, 会导致移动端无法滚动

https://github.com/antvis/G/blob/910c58e9bcba48cfa7bb0585064d27d3ae0bff4c/packages/g-plugin-dom-interaction/src/DOMInteractionPlugin.ts#L134-L136

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
