### PR TITLE
fix: 修复 expandDepth 在自定义行头场景下不生效

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/spread-sheet-collapse-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/spread-sheet-collapse-spec.ts.snap
@@ -27,3 +27,18 @@ Array [
   "root[&]四川省",
 ]
 `;
+
+exports[`SpreadSheet Collapse/Expand Tests should support expandDepth for custom tree 1`] = `
+Array [
+  "root[&]a-1",
+  "root[&]a-1[&]a-1-1",
+  "root[&]a-1[&]a-1-2",
+  "root[&]a-2",
+  "root[&]a-2[&]a-2-1",
+  "root[&]a-2[&]a-2-2",
+  "root[&]a-3",
+  "root[&]a-3[&]a-3-1",
+  "root[&]a-3[&]a-3-2",
+  "root[&]a-3[&]measure-5",
+]
+`;

--- a/packages/s2-core/__tests__/spreadsheet/spread-sheet-collapse-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/spread-sheet-collapse-spec.ts
@@ -401,4 +401,28 @@ describe('SpreadSheet Collapse/Expand Tests', () => {
       expect(s2.facet.getRowNodes().map(({ id }) => id)).toMatchSnapshot();
     });
   });
+
+  test('should support expandDepth for custom tree', async () => {
+    const customRowDataCfg: S2DataConfig = {
+      data: CustomGridData,
+      fields: customRowGridFields,
+    };
+
+    s2 = createPivotSheet({
+      ...s2Options,
+      style: {
+        rowCell: {
+          expandDepth: 0,
+          // expandDepth > collapseAll
+          collapseAll: true,
+        },
+      },
+    });
+
+    s2.setDataCfg(customRowDataCfg);
+    await s2.render();
+
+    expectCornerIconName(s2, 'Minus');
+    expect(s2.facet.getRowNodes().map(({ id }) => id)).toMatchSnapshot();
+  });
 });

--- a/packages/s2-core/src/common/interface/s2DataConfig.ts
+++ b/packages/s2-core/src/common/interface/s2DataConfig.ts
@@ -92,6 +92,7 @@ export interface CustomTreeNode {
   title?: string;
   /**
    * 是否收起（默认都展开）
+   * @description 优先级 `collapseFields` > `expandDepth` > `collapseAll` > `collapsed`
    */
   collapsed?: boolean;
   /**

--- a/packages/s2-core/src/common/interface/style.ts
+++ b/packages/s2-core/src/common/interface/style.ts
@@ -82,19 +82,21 @@ export interface RowCellStyle extends BaseCellStyle, CellTextWordWrapStyle {
 
   /**
    * 收起所有 (对应角头收起展开按钮)
+   * @description 优先级 `collapseFields` > `expandDepth` > `collapseAll`
    */
   collapseAll?: boolean | null;
 
   /**
    * 折叠节点
-   * 优先级大于 collapseAll 和 expandDepth
    * id 级别: { ['root[&]浙江省']: true, ['root[&]河南省']: false } 即 只有 浙江省 对应的节点才会被折叠
    * field 级别: { city: true, type: false } : 即 所有 city 对应的维值都会被折叠
+   * @description 优先级 `collapseFields` > `expandDepth` > `collapseAll`
    */
   collapseFields?: Record<string, boolean> | null;
 
   /**
-   * 行头默认展开到第几层 (从 0 开始)
+   * 行头节点默认展开到第几层 (从 0 开始)
+   * @description 优先级 `collapseFields` > `expandDepth` > `collapseAll`
    */
   expandDepth?: number | null;
 }

--- a/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import { isEmpty, isNumber } from 'lodash';
 import type { CustomTreeNode } from '../../common';
 import { EXTRA_FIELD } from '../../common/constant';
 import { generateId } from '../../utils/layout/generate-id';
@@ -24,7 +24,8 @@ export const buildCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
     spreadsheet,
     isRowHeader,
   } = params;
-  const { collapseFields, collapseAll } = spreadsheet.options.style?.rowCell!;
+  const { collapseFields, collapseAll, expandDepth } =
+    spreadsheet.options.style?.rowCell!;
 
   const hiddenColumnsDetail =
     spreadsheet.store.get('hiddenColumnsDetail') || [];
@@ -48,10 +49,14 @@ export const buildCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
     const defaultCollapsed = collapsed ?? false;
     const isDefaultCollapsed =
       collapseFields?.[nodeId] ?? collapseFields?.[field];
-    const isCollapsed = isDefaultCollapsed ?? (collapseAll || defaultCollapsed);
+    // 如果 level 大于 rowExpandDepth 或者没有配置层级展开配置时，返回 null，保证能正确降级到 collapseAll
+    const isLevelCollapsed = isNumber(expandDepth) ? level > expandDepth : null;
+    const isCollapsed =
+      isDefaultCollapsed ??
+      isLevelCollapsed ??
+      (collapseAll || defaultCollapsed);
 
-    // TODO: 平铺模式支持 折叠/展开
-    // https://github.com/antvis/S2/issues/2019
+    // TODO: 平铺模式支持 折叠/展开: https://github.com/antvis/S2/issues/2019
     const isCollapsedNode =
       spreadsheet.isHierarchyTreeType() && isRowHeader && isCollapsed;
     const isLeaf = isEmpty(children);

--- a/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-tree-hierarchy.ts
@@ -103,7 +103,7 @@ export const buildRowTreeHierarchy = (params: TreeHeaderParams) => {
      */
     const isDefaultCollapsed =
       collapseFields?.[nodeId] ?? collapseFields?.[currentField];
-    // 如果 level 大于 rowExpandDepth或者没有配置层级展开配置时，返回 null，保证能正确降级到 collapseAll
+    // 如果 level 大于 rowExpandDepth 或者没有配置层级展开配置时，返回 null，保证能正确降级到 collapseAll
     const isLevelCollapsed = isNumber(expandDepth) ? level > expandDepth : null;
     const isCollapsed = isDefaultCollapsed ?? isLevelCollapsed ?? collapseAll;
 

--- a/packages/s2-react/playground/components/CustomTree.tsx
+++ b/packages/s2-react/playground/components/CustomTree.tsx
@@ -42,7 +42,8 @@ export const CustomTreeOptions: SheetComponentOptions = {
   },
   style: {
     rowCell: {
-      collapseAll: true,
+      // expandDepth: 0,
+      // collapseAll: true,
     },
   },
   // cornerText: '指标',

--- a/s2-site/docs/manual/advanced/custom/custom-collapse-nodes.zh.md
+++ b/s2-site/docs/manual/advanced/custom/custom-collapse-nodes.zh.md
@@ -108,7 +108,7 @@ const s2Options = {
 
 ## 折叠所有节点
 
-配置 `collapseAll` 即可，**优先级小于** `collapseFields`, 详见 [配置优先级](#配置优先级)
+配置 `collapseAll` 即可，**优先级小于** `collapseFields` 和 `expandDepth`, 详见 [配置优先级](#配置优先级)
 
 ```ts
 const s2Options = {
@@ -149,7 +149,7 @@ const s2Options = {
 
 ## 配置优先级
 
-S2 提供了三个 折叠/展开相关配置，已满足不同的使用场景，优先级如下：
+S2 提供了三个 折叠/展开相关配置，以满足不同的使用场景，优先级如下：
 
 `collapseFields` > `expandDepth` > `collapseAll`
 
@@ -160,12 +160,16 @@ const s2Options = {
   style: {
     rowCell: {
       collapseFields: null, // 无效
-      collapseAll: true, // 生效
       expandDepth: null, // 无效
+      collapseAll: true, // 生效
     },
   },
 }
 ```
+
+如果行头是 [自定义节点 (CustomTreeNode)](api/general/s2-data-config#customtreenode), 则优先级如下：
+
+`collapseFields` > `expandDepth` > `collapseAll` > `CustomTreeNode.collapsed`
 
 ## API 文档
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2896

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

自定义行头节点的树状模式场景未适配, 导致和普通树状模式表现不一致

```ts
  style: {
    rowCell: {
      expandDepth: 0,
    },
  }
```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/73b53d82-ddd7-4994-8c86-081fde7b7ab5) | ![image](https://github.com/user-attachments/assets/5232a5c1-3f87-463e-82ae-0cc99be525ab) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
