### PR TITLE
fix: 修复自定义菜单项不触发 click 事件的问题

### DIFF
--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -270,7 +270,7 @@ export class PivotFacet extends FrozenFacet {
           colsHierarchy,
         );
 
-        currentNode.y = preLevelSample?.y! + preLevelSample?.height! ?? 0;
+        currentNode.y = preLevelSample?.y! + preLevelSample?.height! || 0;
       }
 
       // 数值置于行头时, 列头的总计即叶子节点, 此时应该用列高: https://github.com/antvis/S2/issues/1715
@@ -388,7 +388,7 @@ export class PivotFacet extends FrozenFacet {
           (childNode) => childNode.width,
         );
         // 父节点 x 坐标 = 第一个未隐藏的子节点的 x 坐标
-        const parentNodeX = firstVisibleChildNode?.x ?? 0;
+        const parentNodeX = firstVisibleChildNode?.x || 0;
         // 父节点宽度 = 所有子节点宽度之和
         const parentNodeWidth = sumBy(parentNode.children, 'width');
 
@@ -495,7 +495,7 @@ export class PivotFacet extends FrozenFacet {
         cellType,
       );
 
-      iconCount = customIcons?.icons.length ?? 0;
+      iconCount = customIcons?.icons.length || 0;
     }
 
     // calc width

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -471,7 +471,7 @@ export class TableFacet extends FrozenFacet {
         currentNode.y = 0;
       } else {
         currentNode.y =
-          currentNode?.parent?.y! + currentNode?.parent?.height! ?? 0;
+          currentNode?.parent?.y! + currentNode?.parent?.height! || 0;
       }
 
       currentNode.height = this.getColNodeHeight(

--- a/packages/s2-react/src/components/tooltip/components/operator.tsx
+++ b/packages/s2-react/src/components/tooltip/components/operator.tsx
@@ -22,7 +22,7 @@ export const TooltipOperator: React.FC<Required<TooltipOperatorProps>> = (
       className,
       items: menus = [],
       onClick,
-      selectedKeys,
+      selectedKeys = [],
       ...otherMenuProps
     },
   } = props;
@@ -32,7 +32,10 @@ export const TooltipOperator: React.FC<Required<TooltipOperatorProps>> = (
   }
 
   const onMenuClick = (info: TooltipOperatorMenuInfo) => {
+    const currentMenu = menus.find((menu) => menu.key === info.key);
+
     onClick?.(info, cell);
+    currentMenu?.onClick?.(info as any, cell);
   };
 
   const renderMenu = (
@@ -53,7 +56,7 @@ export const TooltipOperator: React.FC<Required<TooltipOperatorProps>> = (
       popupClassName: `${TOOLTIP_PREFIX_CLS}-operator-submenu-popup`,
       onTitleClick: (info) => {
         onTitleClick?.(info as any, cell);
-        onMenuClick?.(info);
+        onClick?.(info, cell);
       },
       children: !isEmpty(subMenus) ? subMenus : undefined,
     };


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

在 https://github.com/antvis/S2/pull/2932 修复箭头的展示后, 由于层级发生变动, 原 sub-menu 变为 menu, 会导致自定义 menu 的 hook 未触发.

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![Kapture 2024-10-28 at 17 03 35](https://github.com/user-attachments/assets/cba308f3-5cda-4774-854a-057b256af2c2) | ![Kapture 2024-10-28 at 17 01 41](https://github.com/user-attachments/assets/e5d165f1-dfbe-41ff-bd11-00d99f3d6b6e) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
