### PR TITLE
fix: 修复表格卸载后, 高清适配逻辑还会触发的问题

### DIFF
--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -98,7 +98,7 @@ export abstract class SpreadSheet extends EE {
   /**
    * 表格是否已销毁
    */
-  private destroyed = false;
+  public destroyed = false;
 
   protected abstract bindEvents(): void;
 

--- a/packages/s2-core/src/ui/hd-adapter/index.ts
+++ b/packages/s2-core/src/ui/hd-adapter/index.ts
@@ -21,7 +21,7 @@ export class HdAdapter {
 
   private zoomOffsetLeft: number | undefined;
 
-  private destroyed: boolean = false
+  private destroyed: boolean = false;
 
   constructor(spreadsheet: SpreadSheet) {
     this.spreadsheet = spreadsheet;
@@ -33,7 +33,7 @@ export class HdAdapter {
   };
 
   public destroy = () => {
-    this.destroyed = true
+    this.destroyed = true;
     this.removeDevicePixelRatioListener();
     this.removeDeviceZoomListener();
   };
@@ -113,6 +113,10 @@ export class HdAdapter {
   private renderByDevicePixelRatio = async (
     ratio = window.devicePixelRatio,
   ) => {
+    if (this.destroyed) {
+      return;
+    }
+
     const {
       container,
       options: { width, height },
@@ -121,7 +125,7 @@ export class HdAdapter {
     const currentRatio = Math.ceil(ratio);
     const lastRatio = container.getConfig().devicePixelRatio ?? 1;
 
-    if (this.destroyed || lastRatio === currentRatio || !canvas) {
+    if (lastRatio === currentRatio || !canvas) {
       return;
     }
 
@@ -134,8 +138,9 @@ export class HdAdapter {
 
   private renderByZoomScale = debounce(async (event: Event) => {
     if (this.destroyed) {
-      return
+      return;
     }
+
     const target = event.target as VisualViewport;
     const ratio = Math.ceil(target?.scale);
 

--- a/packages/s2-core/src/ui/hd-adapter/index.ts
+++ b/packages/s2-core/src/ui/hd-adapter/index.ts
@@ -21,8 +21,6 @@ export class HdAdapter {
 
   private zoomOffsetLeft: number | undefined;
 
-  private destroyed: boolean = false;
-
   constructor(spreadsheet: SpreadSheet) {
     this.spreadsheet = spreadsheet;
   }
@@ -33,7 +31,6 @@ export class HdAdapter {
   };
 
   public destroy = () => {
-    this.destroyed = true;
     this.removeDevicePixelRatioListener();
     this.removeDeviceZoomListener();
   };
@@ -113,7 +110,7 @@ export class HdAdapter {
   private renderByDevicePixelRatio = async (
     ratio = window.devicePixelRatio,
   ) => {
-    if (this.destroyed) {
+    if (this.spreadsheet.destroyed) {
       return;
     }
 
@@ -137,7 +134,7 @@ export class HdAdapter {
   };
 
   private renderByZoomScale = debounce(async (event: Event) => {
-    if (this.destroyed) {
+    if (this.spreadsheet.destroyed) {
       return;
     }
 

--- a/packages/s2-core/src/ui/hd-adapter/index.ts
+++ b/packages/s2-core/src/ui/hd-adapter/index.ts
@@ -21,6 +21,8 @@ export class HdAdapter {
 
   private zoomOffsetLeft: number | undefined;
 
+  private destroyed: boolean = false
+
   constructor(spreadsheet: SpreadSheet) {
     this.spreadsheet = spreadsheet;
   }
@@ -31,6 +33,7 @@ export class HdAdapter {
   };
 
   public destroy = () => {
+    this.destroyed = true
     this.removeDevicePixelRatioListener();
     this.removeDeviceZoomListener();
   };
@@ -118,7 +121,7 @@ export class HdAdapter {
     const currentRatio = Math.ceil(ratio);
     const lastRatio = container.getConfig().devicePixelRatio ?? 1;
 
-    if (lastRatio === currentRatio || !canvas) {
+    if (this.destroyed || lastRatio === currentRatio || !canvas) {
       return;
     }
 
@@ -130,6 +133,9 @@ export class HdAdapter {
   };
 
   private renderByZoomScale = debounce(async (event: Event) => {
+    if (this.destroyed) {
+      return
+    }
     const target = event.target as VisualViewport;
     const ratio = Math.ceil(target?.scale);
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] 解决启用高清适配时因 resize 事件的异步执行导致的报错问题

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
1. 项目中使用了浏览器全屏演示表格组件，并配置了缩放比例，启用了高清适配属性
2. 在退出全屏时主动销毁了表格组件，但因为退出全屏的同时触发了 `resize` 事件，而经过查看源码发现 `resize` 事件的处理器是异步执行并且使用了防抖函数，导致该事件的执行时机滞后于 `spreadsheet` 的销毁时机，进而导致后续过程的报错，浏览器控制台报错信息如下：
![image](https://github.com/user-attachments/assets/f5491889-6f90-4612-8d11-10517a19e0b9)
![image](https://github.com/user-attachments/assets/e8c32a13-4fd0-4c83-a581-8a6b35c2a272)

3. 在 hdAdapter 销毁后添加 destroyed 标识，并在 resize 事件处理器执行前检查是否已销毁，避免后续过程报错

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
