### PR TITLE
fix: 修复明细表自定义列头时开启文本换行, 单元格高度错误的问题 close #2955

### DIFF
--- a/packages/s2-core/__tests__/data/custom-table-col-fields.ts
+++ b/packages/s2-core/__tests__/data/custom-table-col-fields.ts
@@ -23,6 +23,29 @@ export const customColSimpleColumns: CustomTreeNode[] = [
   },
 ];
 
+export const customColSimpleMultipleTextColumns: CustomTreeNode[] = [
+  {
+    field: 'area',
+    title: '地区'.repeat(50),
+    children: [
+      { field: 'province', title: '省份' },
+      { field: 'city', title: '城市' },
+    ],
+  },
+  {
+    field: 'type',
+    title: '类型',
+  },
+  {
+    field: 'money',
+    title: '金额'.repeat(20),
+    children: [
+      { field: 'price', title: '价格', description: '价格描述' },
+      { field: 'number', title: '数量'.repeat(30) },
+    ],
+  },
+];
+
 export const customColMultipleColumns: CustomTreeNode[] = [
   {
     field: 'a-1',

--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
@@ -30434,3 +30434,374 @@ Array [
   },
 ]
 `;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should use actual text height for large max line by custom col group 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 104,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": undefined,
+    "actualTextHeight": 0,
+    "actualTextWidth": 0,
+    "height": 88,
+    "multiLineActualTexts": Array [],
+    "originalText": undefined,
+    "width": 0,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should use actual text height for large max line by custom col group 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": 1,
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": 2,
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": 3,
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should use actual text height for large max line by custom col group 3`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 192,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区",
+    "actualTextHeight": 80,
+    "actualTextWidth": 1205,
+    "height": 88,
+    "multiLineActualTexts": Array [
+      "地区地区地区地区地区地区地区地区地区地区地区",
+      "地区地区地区地区地区地区地区地区地区地区地区",
+      "地区地区地区地区地区地区地区地区地区地区地区",
+      "地区地区地区地区地区地区地区地区地区地区地区",
+      "地区地区地区地区地区地区",
+    ],
+    "originalText": "地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区地区",
+    "width": 287.6,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 104,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "城市",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 104,
+    "multiLineActualTexts": Array [
+      "城市",
+    ],
+    "originalText": "城市",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "类型",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 192,
+    "multiLineActualTexts": Array [
+      "类型",
+    ],
+    "originalText": "类型",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额",
+    "actualTextHeight": 32,
+    "actualTextWidth": 482,
+    "height": 88,
+    "multiLineActualTexts": Array [
+      "金额金额金额金额金额金额金额金额金额金额金额",
+      "金额金额金额金额金额金额金额金额金额",
+    ],
+    "originalText": "金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额金额",
+    "width": 287.6,
+  },
+  Object {
+    "actualText": "价格",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 104,
+    "multiLineActualTexts": Array [
+      "价格",
+    ],
+    "originalText": "价格",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 96,
+    "actualTextWidth": 726,
+    "height": 104,
+    "multiLineActualTexts": Array [
+      "数量数量数量数量数量",
+      "数量数量数量数量数量",
+      "数量数量数量数量数量",
+      "数量数量数量数量数量",
+      "数量数量数量数量数量",
+      "数量数量数量数量数量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 143.8,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should use actual text height for large max line by custom col group 4`] = `Array []`;
+
+exports[`SpreadSheet Multi Line Text Tests TableSheet should use actual text height for large max line by custom col group 5`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": 1,
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": 2,
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": 3,
+    "width": 80,
+  },
+  Object {
+    "actualText": "浙江",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江",
+    ],
+    "originalText": "浙江",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "浙江",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江",
+    ],
+    "originalText": "浙江",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "浙江",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江",
+    ],
+    "originalText": "浙江",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "义乌",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "义乌",
+    ],
+    "originalText": "义乌",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "义乌",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "义乌",
+    ],
+    "originalText": "义乌",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "杭州",
+    "actualTextHeight": 15,
+    "actualTextWidth": 25,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "杭州",
+    ],
+    "originalText": "杭州",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "笔",
+    "actualTextHeight": 15,
+    "actualTextWidth": 13,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "笔",
+    ],
+    "originalText": "笔",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": 1,
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": 1,
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": 1,
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 143.8,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 143.8,
+  },
+]
+`;

--- a/packages/s2-core/__tests__/spreadsheet/multi-line-text-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/multi-line-text-spec.ts
@@ -13,6 +13,7 @@ import type {
   S2CellType,
   S2Options,
 } from '../../src/common';
+import { customColSimpleMultipleTextColumns } from '../data/custom-table-col-fields';
 import {
   PivotSheetMultiLineTextDataCfg,
   TableSheetMultiLineTextDataCfg,
@@ -972,6 +973,29 @@ describe('SpreadSheet Multi Line Text Tests', () => {
 
       matchCellStyleSnapshot();
       expect(s2.facet.getLayoutResult().colsHierarchy.height).toEqual(56);
+    });
+
+    // https://github.com/antvis/S2/issues/2955
+    test('should use actual text height for large max line by custom col group', async () => {
+      updateStyle(20);
+
+      s2.setDataCfg(
+        {
+          ...SimpleDataCfg,
+          fields: {
+            rows: [],
+            columns: customColSimpleMultipleTextColumns,
+            values: [],
+          },
+        },
+        true,
+      );
+
+      s2.changeSheetSize(800, 600);
+      await s2.render();
+
+      matchCellStyleSnapshot();
+      expect(s2.facet.getLayoutResult().colsHierarchy.height).toEqual(192);
     });
 
     test.each(range(1, 11))(

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -205,10 +205,10 @@ export class PivotFacet extends FrozenFacet {
     this.calculateColLeafNodesWidth(layoutResult);
     // 2. 根据叶子节点宽度计算所有父级节点宽度和 x 坐标, 便于计算自动换行后节点的真实高度
     this.calculateColNodeWidthAndX(colLeafNodes);
-    // 3. 计算每一层级的采样节点
-    this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
-    // 4. 计算所有节点的高度
+    // 3. 计算所有节点的高度
     this.calculateColNodesHeight(colsHierarchy);
+    // 4. 计算每一层级的采样节点
+    this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
     // 5. 如果存在自定义多级列头, 还需要更新某一层级的采样
     this.updateCustomFieldsSampleNodes(colsHierarchy);
     // 6. 补齐自定义列头节点缺失的高度

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -205,10 +205,10 @@ export class PivotFacet extends FrozenFacet {
     this.calculateColLeafNodesWidth(layoutResult);
     // 2. 根据叶子节点宽度计算所有父级节点宽度和 x 坐标, 便于计算自动换行后节点的真实高度
     this.calculateColNodeWidthAndX(colLeafNodes);
-    // 3. 计算所有节点的高度
-    this.calculateColNodesHeight(colsHierarchy);
-    // 4. 计算每一层级的采样节点
+    // 3. 计算每一层级的采样节点
     this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
+    // 4. 计算所有节点的高度
+    this.calculateColNodesHeight(colsHierarchy);
     // 5. 如果存在自定义多级列头, 还需要更新某一层级的采样
     this.updateCustomFieldsSampleNodes(colsHierarchy);
     // 6. 补齐自定义列头节点缺失的高度

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -489,8 +489,8 @@ export class TableFacet extends FrozenFacet {
     // 先计算宽度, 再计算高度, 确保计算多行文本时能获取到正确的最大文本宽度
     this.calculateColLeafNodesWidth(colLeafNodes, colsHierarchy);
     this.calculateColNodeWidthAndX(colLeafNodes);
-    this.calculateColNodesHeight(colsHierarchy);
     this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
+    this.calculateColNodesHeight(colsHierarchy);
     this.updateCustomFieldsSampleNodes(colsHierarchy);
     this.adjustCustomColLeafNodesHeight({
       leafNodes: colLeafNodes,

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -489,8 +489,8 @@ export class TableFacet extends FrozenFacet {
     // 先计算宽度, 再计算高度, 确保计算多行文本时能获取到正确的最大文本宽度
     this.calculateColLeafNodesWidth(colLeafNodes, colsHierarchy);
     this.calculateColNodeWidthAndX(colLeafNodes);
-    this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
     this.calculateColNodesHeight(colsHierarchy);
+    this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
     this.updateCustomFieldsSampleNodes(colsHierarchy);
     this.adjustCustomColLeafNodesHeight({
       leafNodes: colLeafNodes,

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -486,10 +486,11 @@ export class TableFacet extends FrozenFacet {
     colLeafNodes: Node[],
     colsHierarchy: Hierarchy,
   ) {
+    // 先计算宽度, 再计算高度, 确保计算多行文本时能获取到正确的最大文本宽度
     this.calculateColLeafNodesWidth(colLeafNodes, colsHierarchy);
+    this.calculateColNodeWidthAndX(colLeafNodes);
     this.updateColsHierarchySampleMaxHeightNodes(colsHierarchy);
     this.calculateColNodesHeight(colsHierarchy);
-    this.calculateColNodeWidthAndX(colLeafNodes);
     this.updateCustomFieldsSampleNodes(colsHierarchy);
     this.adjustCustomColLeafNodesHeight({
       leafNodes: colLeafNodes,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2955 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

在 https://github.com/antvis/S2/pull/2705 中修复明细表单列头, 单测未覆盖自定义列头的场景, 先计算宽度, 再计算高度, 确保计算多行文本时能获取到正确的最大文本宽度

```tsx
const s2Options = {
  style: {
    colCell: {
      maxLines: 10,
    },
  }
}
```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/6643b787-3afb-4a68-855e-52e39ab31820) | ![image](https://github.com/user-attachments/assets/baa7cce9-6eab-4f43-b79f-15da3a0459ba) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
