### PR TITLE
fix: 减少开启 ReactDOM.unstable_batchedUpdates 后的重渲染次数

### DIFF
--- a/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
+++ b/packages/s2-core/__tests__/unit/sheet-type/pivot-sheet-spec.ts
@@ -773,7 +773,7 @@ describe('PivotSheet Tests', () => {
 
   test('should rebuild hidden columns detail by status', async () => {
     // 重新更新, 但是没有隐藏列信息
-    await s2.render({ reloadData: false, reBuildHiddenColumnsDetail: true });
+    await s2.render({ reloadData: false, rebuildHiddenColumnsDetail: true });
 
     expect(mockHideColumnsByThunkGroup).toHaveBeenCalledTimes(0);
 
@@ -781,16 +781,16 @@ describe('PivotSheet Tests', () => {
       null,
     ] as unknown as HiddenColumnsInfo[]);
 
-    // 重新更新, 有隐藏列信息, 但是 reBuildHiddenColumnsDetail 为 false
+    // 重新更新, 有隐藏列信息, 但是 rebuildHiddenColumnsDetail 为 false
     await s2.render({
       reloadData: false,
-      reBuildHiddenColumnsDetail: false,
+      rebuildHiddenColumnsDetail: false,
     });
 
     expect(mockHideColumnsByThunkGroup).toHaveBeenCalledTimes(0);
 
-    // 重新更新, 有隐藏列信息, 且 reBuildHiddenColumnsDetail 为 true
-    await s2.render({ reloadData: false, reBuildHiddenColumnsDetail: true });
+    // 重新更新, 有隐藏列信息, 且 rebuildHiddenColumnsDetail 为 true
+    await s2.render({ reloadData: false, rebuildHiddenColumnsDetail: true });
 
     expect(mockHideColumnsByThunkGroup).toHaveBeenCalledTimes(1);
   });

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -386,5 +386,5 @@ export interface S2RenderOptions {
   /**
    * 是否重新生成列头隐藏信息
    */
-  reBuildHiddenColumnsDetail?: boolean;
+  rebuildHiddenColumnsDetail?: boolean;
 }

--- a/packages/s2-core/src/sheet-type/spread-sheet.ts
+++ b/packages/s2-core/src/sheet-type/spread-sheet.ts
@@ -423,7 +423,7 @@ export abstract class SpreadSheet extends EE {
     const {
       reloadData = true,
       rebuildDataSet = false,
-      reBuildHiddenColumnsDetail = true,
+      rebuildHiddenColumnsDetail = true,
     } = options || {};
 
     this.emit(S2Event.LAYOUT_BEFORE_RENDER);
@@ -439,7 +439,7 @@ export abstract class SpreadSheet extends EE {
 
     this.buildFacet();
 
-    if (reBuildHiddenColumnsDetail) {
+    if (rebuildHiddenColumnsDetail) {
       await this.initHiddenColumnsDetail();
     }
 
@@ -456,7 +456,7 @@ export abstract class SpreadSheet extends EE {
       s2.render({
         reloadData: true;
         rebuildDataSet: true;
-        reBuildHiddenColumnsDetail: true;
+        rebuildHiddenColumnsDetail: true;
       })
    */
   public async render(options?: S2RenderOptions | boolean): Promise<void> {

--- a/packages/s2-core/src/utils/hide-columns.ts
+++ b/packages/s2-core/src/utils/hide-columns.ts
@@ -131,7 +131,7 @@ export const hideColumns = async (
     spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
     await spreadsheet.render({
       reloadData: false,
-      reBuildHiddenColumnsDetail: false,
+      rebuildHiddenColumnsDetail: false,
     });
   };
 

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -129,10 +129,10 @@ export function useSpreadSheet(props: SheetComponentProps) {
         if (!isEqual(prevOptions?.hierarchyType, options?.hierarchyType)) {
           rebuildDataSet = true;
           reloadData = true;
-          rerender = true;
           s2Ref.current?.setDataCfg(dataCfg);
         }
 
+        rerender = true;
         s2Ref.current?.setOptions(options as S2Options);
         s2Ref.current?.changeSheetSize(options!.width, options!.height);
       }

--- a/packages/s2-react/src/hooks/useSpreadSheet.ts
+++ b/packages/s2-react/src/hooks/useSpreadSheet.ts
@@ -111,7 +111,7 @@ export function useSpreadSheet(props: SheetComponentProps) {
       let reloadData = false;
       let rebuildDataSet = false;
 
-      if (!isEqual(prevDataCfg, dataCfg)) {
+      if (!Object.is(prevDataCfg, dataCfg)) {
         // 列头变化需要重新计算初始叶子节点
         if (
           prevDataCfg?.fields?.columns?.length !==
@@ -126,7 +126,7 @@ export function useSpreadSheet(props: SheetComponentProps) {
       }
 
       if (!isEqual(prevOptions, options)) {
-        if (!isEqual(prevOptions?.hierarchyType, options?.hierarchyType)) {
+        if (prevOptions?.hierarchyType !== options?.hierarchyType) {
           rebuildDataSet = true;
           reloadData = true;
           s2Ref.current?.setDataCfg(dataCfg);

--- a/s2-site/docs/api/basic-class/spreadsheet.zh.md
+++ b/s2-site/docs/api/basic-class/spreadsheet.zh.md
@@ -47,7 +47,7 @@ s2.isPivotMode()
 | setOptions | 更新表格配置                                                                                                                 | (options: [S2Options](/docs/api/general/S2Options), reset?: boolean) => void |  `reset` 参数需在 `@antv/s2^1.34.0`版本使用  |
 | resetDataCfg | 重置表格数据                                                                                                                 | () => void | |
 | resetOptions | 重置表格配置                                                                                                                 | () => void |   |
-| render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据，`rebuildDataSet` = true, 重新构建数据集，`reBuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean \| { reloadData?: boolean, rebuildDataSet?: boolean; reBuildHiddenColumnsDetail?: boolean }) => Promise<void>` |    |
+| render | 重新渲染表格，如果 `reloadData` = true, 则会重新计算数据，`rebuildDataSet` = true, 重新构建数据集，`rebuildHiddenColumnsDetail` = true 重新构建隐藏列信息 | `(reloadData?: boolean \| { reloadData?: boolean, rebuildDataSet?: boolean; rebuildHiddenColumnsDetail?: boolean }) => Promise<void>` |    |
 | destroy | 销毁表格                                                                                                                   | `() => void` |    |
 | setThemeCfg | 更新主题配置 （含主题 schema, 色板，主题名）                                                                                            | (themeCfg: [ThemeCfg](/docs/api/general/S2Theme/#themecfg)) => void |    |
 | setTheme | 更新主题 （只包含主题 scheme)                                                                                                    | (theme: [S2Theme](/docs/api/general/S2Theme/#s2theme)) => void |    |

--- a/s2-site/docs/api/components/sheet-component.zh.md
+++ b/s2-site/docs/api/components/sheet-component.zh.md
@@ -354,7 +354,7 @@ type SheetComponentOptions = S2Options<
 | -- | -- | -- | -- | --- |
 | reloadData | 是否重新加载数据 | `boolean` |  |  |
 | rebuildDataSet | 是否重新生成数据集 | `boolean` |  |  |
-| reBuildHiddenColumnsDetail | 是否重新生成列头隐藏信息 | `boolean` |  |  |
+| rebuildHiddenColumnsDetail | 是否重新生成列头隐藏信息 | `boolean` |  |  |
 
 <embed src="@/docs/common/view-meta.zh.md"></embed>
 <embed src="@/docs/common/interaction.zh.md"></embed>

--- a/s2-site/docs/manual/migration-v2.zh.md
+++ b/s2-site/docs/manual/migration-v2.zh.md
@@ -621,17 +621,20 @@ render 函数的参数从 `boolean` 扩展为 `boolean | object`, 当为 `boolea
 + s2.render({ reloadData: false }) // 等价于 s2.render(false)
 + s2.render({
 +   reloadData: false,
-+   reBuildHiddenColumnsDetail: false,
++   rebuildHiddenColumnsDetail: false,
 + });
 ```
 
 `reBuildDataSet` 重命名为 `rebuildDataSet`:
+`reBuildHiddenColumnsDetail` 重命名为 `rebuildHiddenColumnsDetail`:
 
 ```diff
-+ s2.render({
--   reBuildDataSet: false,
-+   rebuildDataSet: false,
-+ });
+s2.render({
+-  reBuildDataSet: false,
++  rebuildDataSet: false,
+-  reBuildHiddenColumnsDetail: false,
++  rebuildHiddenColumnsDetail: false,
+});
 ```
 
 #### 小计总计配置参数变更


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #2839 

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

背景见 #2839 

```ts
  onDataCellClick={(cell) => {
    ReactDOM.unstable_batchedUpdates(() => {
      setCheckedRowIndex(rowIndex);
      setCheckedColIndex(colIndex);
    });
  }}
```

![image](https://github.com/user-attachments/assets/d11d3402-b28f-46de-827b-cbfd919069d3)


### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
