### PR TITLE
fix: 修复明细表在 dataCfg 为空, 同时开启序号列时, 错误的渲染了占位符的问题

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/table-sheet-spec.ts
@@ -431,29 +431,32 @@ describe('TableSheet normal spec', () => {
       await expectEmptyPlaceholder(s2);
     });
 
-    test('should not render empty placeholder if all fields is empty', async () => {
-      const s2 = new TableSheet(
-        getContainer(),
-        { ...dataCfg, fields: {}, data: [] },
-        {
-          ...options,
-          frozen: {},
-          seriesNumber: {
-            enable: false,
+    test.each([{ showSeriesNumber: true }, { showSeriesNumber: false }])(
+      'should not render empty placeholder if all fields is empty for %o',
+      async ({ showSeriesNumber }) => {
+        const s2 = new TableSheet(
+          getContainer(),
+          { ...dataCfg, fields: {}, data: [] },
+          {
+            ...options,
+            frozen: {},
+            seriesNumber: {
+              enable: showSeriesNumber,
+            },
           },
-        },
-      );
+        );
 
-      await s2.render();
-      const [rect, icon, text] = (s2.facet as TableFacet).emptyPlaceholderGroup
-        .children;
+        await s2.render();
+        const [rect, icon, text] = (s2.facet as TableFacet)
+          .emptyPlaceholderGroup.children;
 
-      expect(
-        (s2.facet as TableFacet).emptyPlaceholderGroup.children,
-      ).toHaveLength(0);
-      expect(rect).not.toBeDefined();
-      expect(icon).not.toBeDefined();
-      expect(text).not.toBeDefined();
-    });
+        expect(
+          (s2.facet as TableFacet).emptyPlaceholderGroup.children,
+        ).toHaveLength(0);
+        expect(rect).not.toBeDefined();
+        expect(icon).not.toBeDefined();
+        expect(text).not.toBeDefined();
+      },
+    );
   });
 });

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -86,6 +86,15 @@ export class TableFacet extends FrozenFacet {
     this.initEmptyPlaceholderGroup();
   }
 
+  protected shouldRender(): boolean {
+    const { fields } = this.spreadsheet.dataSet;
+    const isOnlyContainedSeriesNumber = fields?.columns?.every(
+      (field) => field === SERIES_NUMBER_FIELD,
+    );
+
+    return super.shouldRender() && !isOnlyContainedSeriesNumber;
+  }
+
   public render() {
     if (!this.shouldRender()) {
       return;

--- a/s2-site/docs/common/development.zh.md
+++ b/s2-site/docs/common/development.zh.md
@@ -44,5 +44,6 @@ pnpm react:test -- -u
 pnpm lint
 
 # 本地启动官网
+pnpm build # 首次运行官网需要先执行一次
 pnpm site:start
 ```


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
