### PR TITLE
fix: 修复自定义选中交互主题对行列叶子节点不生效

### DIFF
--- a/packages/s2-core/__tests__/unit/interaction/root-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/root-spec.ts
@@ -178,17 +178,33 @@ describe('RootInteraction Tests', () => {
   });
 
   test('should selected header cell', () => {
+    const highlightNodesSpy = jest
+      .spyOn(rootInteraction, 'highlightNodes')
+      .mockImplementationOnce(() => {});
+
     rootInteraction.selectCell(mockCell);
 
     expect(rootInteraction.getState()).toMatchSnapshot();
     expect(rootInteraction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+    expect(highlightNodesSpy).toHaveBeenCalledWith(
+      [],
+      InteractionStateName.SELECTED,
+    );
   });
 
   test('should highlight header cell', () => {
+    const highlightNodesSpy = jest
+      .spyOn(rootInteraction, 'highlightNodes')
+      .mockImplementationOnce(() => {});
+
     rootInteraction.highlightCell(mockCell);
 
     expect(rootInteraction.getState()).toMatchSnapshot();
     expect(rootInteraction.hasIntercepts([InterceptType.HOVER])).toBeTruthy();
+    expect(highlightNodesSpy).toHaveBeenCalledWith(
+      [],
+      InteractionStateName.HOVER,
+    );
   });
 
   // https://github.com/antvis/S2/issues/1243
@@ -444,7 +460,7 @@ describe('RootInteraction Tests', () => {
       expect(rootInteraction.getActiveCells()).toEqual([]);
     });
 
-    test('should set selected status after highlight nodes', () => {
+    test('should set hover status after highlight nodes', () => {
       const belongsCell = createMockCellInfo('test-A').mockCell;
 
       const mockNodeA = new Node({
@@ -469,6 +485,28 @@ describe('RootInteraction Tests', () => {
           belongsCell,
         );
       });
+    });
+
+    // https://github.com/antvis/S2/discussions/3062
+    test('should set selected status after highlight nodes', () => {
+      const belongsCell = createMockCellInfo('test-A').mockCell;
+
+      const mockNodeA = new Node({
+        id: 'test',
+        field: 'test',
+        value: '1',
+        belongsCell,
+      });
+
+      rootInteraction.highlightNodes(
+        [mockNodeA],
+        InteractionStateName.SELECTED,
+      );
+
+      expect(mockNodeA.belongsCell?.updateByState).toHaveBeenCalledWith(
+        InteractionStateName.SELECTED,
+        belongsCell,
+      );
     });
 
     test.each`

--- a/packages/s2-core/src/interaction/base-interaction/click/corner-cell-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/corner-cell-click.ts
@@ -145,7 +145,7 @@ export class CornerCellClick extends BaseEvent implements BaseEventImplement {
       cells,
       stateName: InteractionStateName.SELECTED,
     });
-    interaction.highlightNodes(nodes);
+    interaction.highlightNodes(nodes, InteractionStateName.SELECTED);
     cornerCell?.updateByState(InteractionStateName.SELECTED);
 
     this.showTooltip(event);

--- a/packages/s2-core/src/interaction/root.ts
+++ b/packages/s2-core/src/interaction/root.ts
@@ -658,7 +658,7 @@ export class RootInteraction {
 
     // 平铺模式或者是树状模式下的列头单元格, 高亮子节点
     if (!isHierarchyTree || isColCell) {
-      this.highlightNodes(childrenNodes);
+      this.highlightNodes(childrenNodes, stateName);
     }
 
     // 如果不在可视范围, 自动滚动
@@ -684,12 +684,12 @@ export class RootInteraction {
    * 高亮节点对应的单元格
    * @example s2.interaction.highlightNodes([node])
    */
-  public highlightNodes = (nodes: Node[] = []) => {
+  public highlightNodes = (
+    nodes: Node[] = [],
+    stateName: `${InteractionStateName}` = InteractionStateName.HOVER,
+  ) => {
     nodes.forEach((node) => {
-      node?.belongsCell?.updateByState(
-        InteractionStateName.HOVER,
-        node.belongsCell,
-      );
+      node?.belongsCell?.updateByState(stateName, node.belongsCell);
     });
   };
 

--- a/s2-site/docs/api/basic-class/interaction.zh.md
+++ b/s2-site/docs/api/basic-class/interaction.zh.md
@@ -51,7 +51,7 @@ s2.interaction.reset()
 | addIntercepts | 新增交互拦截                                           | (interceptTypes: [InterceptType](#intercepttype)[]) => void |
 | hasIntercepts | 是否有指定拦截的交互                                       | (interceptTypes: [InterceptType](#intercepttype)[]) => boolean |
 | removeIntercepts | 移除指定交互拦截                                         | (interceptTypes: [InterceptType](#intercepttype)[]) => void |
-| highlightNodes | 高亮节点对应的单元格                                       | (nodes: [Node](/api/basic-class/node)[]) => void |
+| highlightNodes | 高亮节点对应的单元格                                       | (nodes: [Node](/api/basic-class/node)[], stateName: [InteractionStateName](#interactionstatename)) => void |
 | scrollTo | 滚动至指定位置   | (offsetConfig: [ScrollOffsetConfig](#offsetconfig)) => void |    |
 | scrollToNode | 滚动至指定单元格节点   | (node: [Node](/api/basic-class/node), options?: [CellScrollToOptions](#cellscrolltooptions)) => void |    |
 | scrollToCell | 滚动至指定单元格   | (cell: [S2CellType](#s2celltype), options?: [CellScrollToOptions](#cellscrolltooptions)) => void |    |

--- a/s2-site/docs/manual/advanced/interaction/highlight-and-select-cell.zh.md
+++ b/s2-site/docs/manual/advanced/interaction/highlight-and-select-cell.zh.md
@@ -33,6 +33,8 @@ s2.interaction.getCurrentStateName() // "hover"
 const targetNodes = s2.facet.getRowNodes()
 
 s2.interaction.highlightNodes(targetNodes)
+s2.interaction.highlightNodes(targetNodes, 'hover')
+s2.interaction.highlightNodes(targetNodes, 'selected')
 ```
 
 ## 选中单元格


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

```tsx
s2.setTheme({
    rowCell: {
      cell: {
        interactionState: {
          selected: {
            backgroundColor: "red",
          },
        },
      },
    }
  },
});
```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/68e37812-0fc6-4982-9679-fba36aba9586) | ![image](https://github.com/user-attachments/assets/fafdcc61-4055-4b51-a8c2-2d684fb51b1e) |

### 🔗 Related issue link

https://github.com/antvis/S2/discussions/3062

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
