### PR TITLE
fix: 修复维值包含 '\t' 制表符时导致复制到 Excel 中数据错列的问题

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/export-pivot-spec.ts
@@ -643,4 +643,47 @@ describe('PivotSheet Export Test', () => {
 
     await expectMatchSnapshot(sheet);
   });
+
+  it.each([
+    { formatHeader: true, formatBody: true },
+    { formatHeader: true, formatBody: false },
+    { formatHeader: false, formatBody: true },
+    { formatHeader: false, formatBody: false },
+  ])(
+    'should ignore contains tab trimTabSeparator dimension value by %o',
+    async (formatOptions) => {
+      const data = clone<DataItem[]>(originData);
+
+      data.unshift({
+        number: 7789,
+        province: '测试-province\t',
+        city: '测试-city\t',
+        type: '测试-type\t',
+        sub_type: '测试-sub_type\t',
+      });
+
+      const s2 = new PivotSheet(
+        getContainer(),
+        assembleDataCfg({
+          data,
+          fields: {
+            valueInCols: true,
+            columns: ['province', 'city'],
+            rows: ['type', 'sub_type'],
+            values: ['number'],
+          },
+        }),
+        assembleOptions(),
+      );
+
+      await s2.render();
+      const result = await asyncGetAllPlainData({
+        sheetInstance: s2,
+        split: TAB_SEPARATOR,
+        formatOptions,
+      });
+
+      expect(result.split(TAB_SEPARATOR)).toHaveLength(81);
+    },
+  );
 });

--- a/packages/s2-core/__tests__/unit/utils/export/method-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/method-spec.ts
@@ -1,0 +1,31 @@
+import {
+  convertString,
+  keyEqualTo,
+  trimTabSeparator,
+} from '../../../../src/utils/export/method';
+
+describe('method test', () => {
+  test('#keyEqualTo', () => {
+    expect(keyEqualTo('a', 'a')).toBeTruthy();
+    expect(keyEqualTo('a', 'b')).toBeFalsy();
+    expect(keyEqualTo('a', '')).toBeFalsy();
+    expect(keyEqualTo('A', 'a')).toBeTruthy();
+  });
+
+  test('#convertString', () => {
+    expect(convertString('a')).toBe('a');
+    expect(convertString('a\nb')).toBe('"a\nb"');
+    expect(convertString('a\nb"c')).toBe('"a\nb\'c"');
+    expect(convertString(null)).toBe(null);
+  });
+
+  test('#trimTabSeparator', () => {
+    expect(trimTabSeparator('a\tb')).toBe('ab');
+    expect(trimTabSeparator('a\tb\t')).toBe('ab');
+    expect(trimTabSeparator('')).toBe('');
+    expect(trimTabSeparator('a')).toBe('a');
+    expect(trimTabSeparator('\ta')).toBe('a');
+    expect(trimTabSeparator(null as unknown as string)).toBe(null);
+    expect(trimTabSeparator(1 as unknown as string)).toBe(1);
+  });
+});

--- a/packages/s2-core/src/extends/pivot-chart/cell/pivot-chart-data-cell.ts
+++ b/packages/s2-core/src/extends/pivot-chart/cell/pivot-chart-data-cell.ts
@@ -29,7 +29,7 @@ export class PivotChartDataCell extends ChartDataCell {
     return {
       data,
       encode: {
-        x: (this.spreadsheet as PivotChartSheet).isPolarCoordinate()
+        x: (this.spreadsheet as unknown as PivotChartSheet).isPolarCoordinate()
           ? null
           : xField,
         y: yField,

--- a/packages/s2-core/src/utils/export/copy/common.ts
+++ b/packages/s2-core/src/utils/export/copy/common.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../common/interface/export';
 import type { Node } from '../../../facet/layout/node';
 import type { SpreadSheet } from '../../../sheet-type/spread-sheet';
+import { trimTabSeparator } from '../method';
 
 // 把 string[][] 矩阵转换成 CopyablePlain
 export const matrixPlainTextTransformer = (
@@ -217,9 +218,10 @@ export const getNodeFormatData = (leafNode: Node) => {
     const formatter = node.spreadsheet?.dataSet?.getFieldFormatter?.(
       node.field,
     );
-    const value = formatter?.(node.value);
+    const value = trimTabSeparator(formatter?.(node.value) as string);
 
-    line.unshift(value as string);
+    line.unshift(value);
+
     if (node?.parent) {
       return getNodeFormatterLabel(node.parent);
     }

--- a/packages/s2-core/src/utils/export/method.ts
+++ b/packages/s2-core/src/utils/export/method.ts
@@ -1,12 +1,13 @@
 /**
  * 导出和复制的公共方法，这里的方法都比较纯，参数中都不包含 spreadsheet 对象
  */
-import { forEach, map } from 'lodash';
+import { flow, forEach, includes, map, replace } from 'lodash';
 import type { ColCell, RowCell } from '../../cell';
 import {
   CellType,
   NODE_ID_SEPARATOR,
   SERIES_NUMBER_FIELD,
+  TAB_SEPARATOR,
   type CellMeta,
   type DataItem,
   type SimpleData,
@@ -53,6 +54,18 @@ export function getAllLevels(interactedCells: (RowCell | ColCell)[]) {
   return allLevels;
 }
 
+/**
+ * 复制/导出时会在位置中增加制表符，用于在 Excel 中展示
+ * 兼容极端情况，防止维值中本身就存在制表符的情况，如：“成都市\t” => "成都市\t\t" 导致错列
+ */
+export const trimTabSeparator = (text: string) => {
+  if (!includes(text, TAB_SEPARATOR)) {
+    return text;
+  }
+
+  return replace(text, new RegExp(TAB_SEPARATOR, 'g'), '');
+};
+
 export const getHeaderMeasureFieldNames = (
   fields: string[],
   spreadsheet: SpreadSheet,
@@ -67,10 +80,14 @@ export const getHeaderMeasureFieldNames = (
     // https://github.com/antvis/S2/issues/2688
     // https://github.com/antvis/S2/pull/2829
     if (!formatHeader) {
-      return replaceEmptyFieldValue(resolveNillString(field)!);
+      return flow(
+        resolveNillString,
+        replaceEmptyFieldValue,
+        trimTabSeparator,
+      )(field);
     }
 
-    return spreadsheet.dataSet.getFieldName(field);
+    return trimTabSeparator(spreadsheet.dataSet.getFieldName(field));
   });
 };
 

--- a/packages/s2-core/src/utils/export/method.ts
+++ b/packages/s2-core/src/utils/export/method.ts
@@ -55,7 +55,7 @@ export function getAllLevels(interactedCells: (RowCell | ColCell)[]) {
 }
 
 /**
- * 复制/导出时会在位置中增加制表符，用于在 Excel 中展示
+ * 复制/导出时会在文本的两侧中增加制表符，用于在 Excel 中展示
  * 兼容极端情况，防止维值中本身就存在制表符的情况，如：“成都市\t” => "成都市\t\t" 导致错列
  */
 export const trimTabSeparator = (text: string) => {


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

🐛 Bugfix

- [x] Solve the issue and close #0


### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

复制/导出时会在文本的两侧中增加制表符，用于在 Excel 中展示, 兼容极端情况，防止维值中本身就存在制表符的情况，如：“成都市\t” => "成都市\t\t" 导致错列

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/59abc918-0e8b-45c8-9ed0-a2599b7a27a9) | ![image](https://github.com/user-attachments/assets/b0b5cceb-3600-47aa-bfa2-e90ed4facdd1) |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
