### PR TITLE
fix: 修复隐藏列后变更列顺序，隐藏列展开异常

### DIFF
--- a/packages/s2-core/__tests__/data/mock-dataset-multi-measure.json
+++ b/packages/s2-core/__tests__/data/mock-dataset-multi-measure.json
@@ -1,0 +1,102 @@
+{
+  "describe": "标准透视表数据。注意：不能随意改动！会影响单测结果！",
+  "meta": [
+    {
+      "field": "number",
+      "name": "数量",
+      "description": "数量说明。。"
+    },
+    {
+      "field": "price",
+      "name": "单价",
+      "description": "单价说明。。"
+    },
+    {
+      "field": "money",
+      "name": "金额",
+      "description": "金额说明。。"
+    },
+    {
+      "field": "count",
+      "name": "个数",
+      "description": "个数说明。。"
+    },
+    {
+      "field": "gdp",
+      "name": "gdp",
+      "description": "gdp说明。。"
+    },
+    {
+      "field": "province",
+      "name": "省份",
+      "description": "省份说明。。"
+    },
+    {
+      "field": "city",
+      "name": "城市",
+      "description": "城市说明。。"
+    },
+    {
+      "field": "type",
+      "name": "类别",
+      "description": "类别说明。。"
+    },
+    {
+      "field": "sub_type",
+      "name": "子类别",
+      "description": "子类别说明。。"
+    }
+  ],
+  "fields": {
+    "rows": ["province", "city"],
+    "columns": ["type", "sub_type"],
+    "values": ["number", "money", "price", "count", "gdp"],
+    "valueInCols": true
+  },
+  "data": [
+    {
+      "gdp": 123123,
+      "count": 4444,
+      "money": 3333,
+      "price": 2222,
+      "number": 7789,
+      "province": "浙江省",
+      "city": "杭州市",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "gdp": 123123,
+      "count": 4444,
+      "money": 3333,
+      "price": 2222,
+      "number": 2367,
+      "province": "浙江省",
+      "city": "绍兴市",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "gdp": 123123,
+      "count": 4444,
+      "money": 3333,
+      "price": 2222,
+      "number": 3877,
+      "province": "浙江省",
+      "city": "宁波市",
+      "type": "家具",
+      "sub_type": "桌子"
+    },
+    {
+      "gdp": 123123,
+      "count": 4444,
+      "money": 3333,
+      "price": 2222,
+      "number": 4342,
+      "province": "浙江省",
+      "city": "舟山市",
+      "type": "家具",
+      "sub_type": "桌子"
+    }
+  ]
+}

--- a/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/hidden-columns-spec.ts
@@ -1,6 +1,7 @@
 import type { HiddenColumnsInfo, S2DataConfig, S2Options } from '@/common';
 import { PivotSheet, TableSheet } from '@/sheet-type';
-import { difference, pick } from 'lodash';
+import { difference, merge, pick } from 'lodash';
+import * as mockPivotMultiDataConfig from 'tests/data/mock-dataset-multi-measure.json';
 import * as mockDataConfig from 'tests/data/mock-dataset.json';
 import * as mockPivotDataConfig from 'tests/data/simple-data.json';
 import * as mockTableDataConfig from 'tests/data/simple-table-data.json';
@@ -559,6 +560,60 @@ describe('SpreadSheet Hidden Columns Tests', () => {
       expect(leafNodes[0].belongsCell.rightIconPosition.x).toEqual(
         leafNodes[0].width - expandIconWidth / 2 + borderWidth,
       );
+    });
+
+    test('should hide column correctly when their changes', async () => {
+      const sheet = createPivotSheet(
+        {
+          interaction: {
+            hiddenColumnFields: [],
+          },
+        },
+        { useSimpleData: false },
+      );
+
+      sheet.setDataCfg(mockPivotMultiDataConfig);
+
+      await sheet.render();
+
+      const columnFields = mockPivotMultiDataConfig.fields.values;
+
+      const colIds = [
+        'root[&]家具[&]桌子[&]number',
+        'root[&]家具[&]桌子[&]money',
+        'root[&]家具[&]桌子[&]price',
+        'root[&]家具[&]桌子[&]count',
+        'root[&]家具[&]桌子[&]gdp',
+      ];
+
+      await sheet.interaction.hideColumns([colIds[3]]);
+      await sheet.interaction.hideColumns([colIds[1]]);
+
+      sheet.setDataCfg(
+        merge({}, sheet.dataCfg, {
+          fields: {
+            values: [
+              columnFields[3],
+              columnFields[2],
+              columnFields[1],
+              columnFields[4],
+            ],
+          },
+        }),
+      );
+      await sheet.render();
+      const getInitColIndexLeafNodes = sheet.facet.getInitColIndexLeafNodes();
+
+      expect(
+        getInitColIndexLeafNodes
+          .filter((node) => node.colIndex === -1)
+          .map((node) => node.id),
+      ).toEqual([colIds[3], colIds[1]]);
+      expect(
+        getInitColIndexLeafNodes
+          .filter((node) => [colIds[3], colIds[1]].includes(node.id))
+          .map((node) => node.id),
+      ).toEqual([colIds[3], colIds[1]]);
     });
 
     test('should render expanded icon correctly when use hideColumns', async () => {

--- a/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/base-interaction/click/row-column-click-spec.ts
@@ -15,7 +15,8 @@ import type { Node } from '@/facet/layout/node';
 import type { GEvent } from '@/index';
 import { RowColumnClick } from '@/interaction/base-interaction/click';
 import type { SpreadSheet } from '@/sheet-type';
-import { omit } from 'lodash';
+import { merge, omit } from 'lodash';
+import * as mockPivotMultiDataConfig from 'tests/data/mock-dataset-multi-measure.json';
 import {
   createFakeSpreadSheet,
   createMockCellInfo,
@@ -73,6 +74,7 @@ describe('Interaction Row & Column Cell Click Tests', () => {
     s2.facet.getInitColLeafNodes = () => initColumnNodes as Node[];
     s2.facet.getColNodes = () => initColumnNodes as Node[];
     s2.facet.getColLeafNodes = () => initColumnNodes as Node[];
+    s2.facet.getInitColIndexLeafNodes = () => initColumnNodes as Node[];
     s2.options = {
       interaction: {
         hiddenColumnFields: ['a'],
@@ -372,6 +374,89 @@ describe('Interaction Row & Column Cell Click Tests', () => {
       expect(leafNodes[2].id).toBe(colIds[displayIndex]);
     },
   );
+
+  test('should expand each column in order', async () => {
+    const sheet = createPivotSheet(
+      {
+        interaction: {
+          hiddenColumnFields: [],
+        },
+      },
+      { useSimpleData: false },
+    );
+
+    await sheet.render();
+
+    const colIds = [
+      'root[&]家具[&]桌子[&]number',
+      'root[&]家具[&]沙发[&]number',
+      'root[&]办公用品[&]笔[&]number',
+      'root[&]办公用品[&]纸张[&]number',
+    ];
+
+    await sheet.interaction.hideColumns([colIds[0]]);
+    await sheet.interaction.hideColumns([colIds[1]]);
+    await sheet.interaction.hideColumns([colIds[2]]);
+    sheet.emit(S2Event.COL_CELL_EXPANDED, { id: colIds[3] }, 'next');
+    await sleep(200);
+    expect(sheet.facet.getColLeafNodes().length).toBe(2);
+    sheet.emit(S2Event.COL_CELL_EXPANDED, { id: colIds[2] }, 'next');
+    await sleep(200);
+    expect(sheet.facet.getColLeafNodes().length).toBe(3);
+    sheet.emit(S2Event.COL_CELL_EXPANDED, { id: colIds[1] }, 'next');
+    await sleep(200);
+    expect(sheet.facet.getColLeafNodes().length).toBe(4);
+  });
+
+  test('should expand column correctly when their changes', async () => {
+    const sheet = createPivotSheet(
+      {
+        interaction: {
+          hiddenColumnFields: [],
+        },
+      },
+      { useSimpleData: false },
+    );
+
+    sheet.setDataCfg(mockPivotMultiDataConfig);
+
+    await sheet.render();
+
+    const columnFields = mockPivotMultiDataConfig.fields.values;
+
+    const colIds = [
+      'root[&]家具[&]桌子[&]number',
+      'root[&]家具[&]桌子[&]money',
+      'root[&]家具[&]桌子[&]price',
+      'root[&]家具[&]桌子[&]count',
+      'root[&]家具[&]桌子[&]gdp',
+    ];
+
+    await sheet.interaction.hideColumns([colIds[3]]);
+    await sheet.interaction.hideColumns([colIds[1]]);
+
+    sheet.setDataCfg(
+      merge({}, sheet.dataCfg, {
+        fields: {
+          values: [
+            columnFields[3],
+            columnFields[2],
+            columnFields[1],
+            columnFields[4],
+          ],
+        },
+      }),
+    );
+    await sheet.render();
+    sheet.emit(S2Event.COL_CELL_EXPANDED, { id: colIds[2] }, 'next');
+    await sleep(200);
+    expect(sheet.facet.getColLeafNodes().length).toBe(3);
+    expect(sheet.facet.getColLeafNodes()[0].id).toBe(colIds[3]);
+    sheet.emit(S2Event.COL_CELL_EXPANDED, { id: colIds[4] }, 'next');
+    await sleep(200);
+    expect(sheet.facet.getColLeafNodes().length).toBe(4);
+    expect(sheet.facet.getColLeafNodes()[2].id).toBe(colIds[1]);
+  });
 
   test('should hidden columns correctly', async () => {
     const resetSpy = jest

--- a/packages/s2-core/__tests__/unit/utils/hide-columns-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/hide-columns-spec.ts
@@ -8,6 +8,7 @@ import {
   getHiddenColumnDisplaySiblingNode,
   getHiddenColumnNodes,
   getHiddenColumnsThunkGroup,
+  getSameHiddenGroupIndex,
   getValidDisplaySiblingNode,
   getValidDisplaySiblingNodeId,
   hideColumns,
@@ -565,5 +566,26 @@ describe('Hide Columns Tests', () => {
         'prev',
       ).map((item) => item.id),
     ).toEqual(['id-4']);
+  });
+
+  test('should return column index correctly', () => {
+    expect(
+      getSameHiddenGroupIndex({ hideColumnNodes: [{ id: 'b' }] }, [
+        { hideColumnNodes: [{ id: 'a' }] },
+        { hideColumnNodes: [{ id: 'b' }, { id: 'c' }] },
+      ]),
+    ).toBe(1);
+    expect(
+      getSameHiddenGroupIndex({ hideColumnNodes: [{ id: 'b' }, { id: 'c' }] }, [
+        { hideColumnNodes: [{ id: 'a' }] },
+        { hideColumnNodes: [{ id: 'b' }] },
+      ]),
+    ).toBe(1);
+    expect(
+      getSameHiddenGroupIndex({ hideColumnNodes: [{ id: 'c' }] }, [
+        { hideColumnNodes: [{ id: 'a' }] },
+        { hideColumnNodes: [{ id: 'b' }] },
+      ]),
+    ).toBe(-1);
   });
 });

--- a/packages/s2-core/__tests__/unit/utils/hide-columns-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/hide-columns-spec.ts
@@ -37,6 +37,7 @@ describe('Hide Columns Tests', () => {
         getInitColLeafNodes: () => initColumnNodes,
         getColNodes: () => initColumnNodes,
         getColLeafNodes: () => initColumnNodes,
+        getInitColIndexLeafNodes: () => initColumnNodes,
       },
     } as PivotSheet;
 
@@ -54,6 +55,7 @@ describe('Hide Columns Tests', () => {
     );
     mockSpreadSheetInstance.facet = {
       getInitColLeafNodes: () => initColumnNodes as Node[],
+      getInitColIndexLeafNodes: () => initColumnNodes as Node[],
     } as unknown as PivotFacet;
     mockSpreadSheetInstance.render = jest.fn();
     mockSpreadSheetInstance.interaction = {
@@ -69,7 +71,7 @@ describe('Hide Columns Tests', () => {
   });
 
   test('should return empty list when there is not init columns', () => {
-    sheet.facet.getInitColLeafNodes = function fn() {
+    sheet.facet.getInitColIndexLeafNodes = function fn() {
       return [];
     };
     expect(getHiddenColumnNodes(sheet, ['1', '2', '3'])).toEqual([]);
@@ -209,7 +211,7 @@ describe('Hide Columns Tests', () => {
 
   test('should get correct last column when default last column has been hidden', () => {
     // hidden last column
-    sheet.facet.getInitColLeafNodes = () =>
+    sheet.facet.getInitColIndexLeafNodes = () =>
       initColumnNodes.slice(0, -1) as Node[];
     expect(isLastColumnAfterHidden(sheet, '5')).toBeTruthy();
     expect(isLastColumnAfterHidden(sheet, '4')).toBeFalsy();

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -2439,6 +2439,10 @@ export abstract class BaseFacet {
     return cells.filter((cell) => cellIds.includes(cell.getMeta().id));
   }
 
+  public getInitColIndexLeafNodes(): Node[] {
+    return this.layoutResult.colsHierarchy.getIndexNodes() || [];
+  }
+
   public getInitColLeafNodes(): Node[] {
     return this.spreadsheet.store.get('initColLeafNodes', [])!;
   }

--- a/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
+++ b/packages/s2-core/src/facet/layout/build-row-custom-tree-hierarchy.ts
@@ -37,10 +37,6 @@ export const buildCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
       hideColumnNodes.find((hideNode) => hideNode.field === field),
     );
 
-    if (isHiddenNode) {
-      return;
-    }
-
     // query 只与值本身有关，不会涉及到 parent 节点
     const valueQuery = { [EXTRA_FIELD]: field };
     // 使用 field 作为 id, 保证其唯一性, 复制时再做二次转换
@@ -79,6 +75,14 @@ export const buildCustomTreeHierarchy = (params: CustomTreeHeaderParams) => {
         isCustomNode: true,
       },
     });
+
+    if (isLeaf || isHiddenNode || isCollapsedNode) {
+      hierarchy.pushIndexNode(node);
+    }
+
+    if (isHiddenNode) {
+      return;
+    }
 
     if (level > hierarchy.maxLevel && !node.isSeriesNumberNode()) {
       hierarchy.maxLevel = level;

--- a/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/row-column-click.ts
@@ -266,6 +266,9 @@ export class RowColumnClick extends BaseEvent implements BaseEventImplement {
     });
     this.spreadsheet.store.set('hiddenColumnsDetail', hiddenColumnsDetail);
     this.spreadsheet.interaction.reset();
-    await this.spreadsheet.render(false);
+    await this.spreadsheet.render({
+      reloadData: false,
+      rebuildHiddenColumnsDetail: false,
+    });
   }
 }

--- a/packages/s2-core/src/utils/hide-columns.ts
+++ b/packages/s2-core/src/utils/hide-columns.ts
@@ -20,7 +20,7 @@ export const getHiddenColumnNodes = (
   spreadsheet: SpreadSheet,
   hiddenColumnFields: string[] = [],
 ): Node[] => {
-  const colNodes = spreadsheet.facet.getInitColLeafNodes();
+  const colNodes = spreadsheet.facet.getInitColIndexLeafNodes();
 
   return compact(
     hiddenColumnFields.map((field) => {
@@ -49,18 +49,18 @@ export const getHiddenColumnDisplaySiblingNode = (
     };
   }
 
-  const initColLeafNodes = spreadsheet.facet.getInitColLeafNodes();
+  const initColLeafNodes = spreadsheet.facet.getInitColIndexLeafNodes();
   const hiddenColumnIndexes = getHiddenColumnNodes(
     spreadsheet,
     hiddenColumnFields,
-  ).map((node) => node?.colIndex);
+  ).map((node) => initColLeafNodes.findIndex((item) => item.id === node.id));
   const lastHiddenColumnIndex = Math.max(...hiddenColumnIndexes);
   const firstHiddenColumnIndex = Math.min(...hiddenColumnIndexes);
   const nextSiblingNode = initColLeafNodes.find(
-    (node) => node.colIndex === lastHiddenColumnIndex + 1,
+    (node, index) => index === lastHiddenColumnIndex + 1,
   );
   const prevSiblingNode = initColLeafNodes.find(
-    (node) => node.colIndex === firstHiddenColumnIndex - 1,
+    (node, index) => index === firstHiddenColumnIndex - 1,
   );
 
   return {
@@ -104,6 +104,24 @@ export const getHiddenColumnsThunkGroup = (
 
     return result;
   }, []);
+};
+
+/**
+ * @name 获取相同隐藏组的索引
+ * 原始列: [a, b, c, d, e, f, g, i]
+ * 隐藏部分列: [[a, b], c, [d], e, f, [g], i]
+ * 变换列头顺序后: [[a], e, [b], c, f, [d, g], i]
+ * 也就是说，变换列头顺序后重新分组，本轮遍历时和列头变换顺序之前的隐藏组做对比，只要有一项是相同的, 那么就属于同一个隐藏组，需要进行替换，如 [a, b] => [a], 剩下的 b ，在本轮遍历时就不会有相同组了，会重新添加 [b]，本轮的[d, g]分组会找到上一次的 [d] 分组，并且替换
+ */
+export const getSameHiddenGroupIndex = (
+  currentHiddenColumnsInfo: HiddenColumnsInfo,
+  lastHiddenColumnDetail: HiddenColumnsInfo[],
+) => {
+  return lastHiddenColumnDetail.findIndex((item) =>
+    currentHiddenColumnsInfo.hideColumnNodes.some((node) =>
+      item.hideColumnNodes?.find((hiddenNode) => hiddenNode.id === node.id),
+    ),
+  );
 };
 
 /**
@@ -176,10 +194,24 @@ export const hideColumns = async (
     displaySiblingNode,
   };
 
-  const hiddenColumnsDetail: HiddenColumnsInfo[] = [
-    ...lastHiddenColumnDetail,
+  const index = getSameHiddenGroupIndex(
     currentHiddenColumnsInfo,
-  ];
+    lastHiddenColumnDetail,
+  );
+
+  let hiddenColumnsDetail = [];
+
+  if (index !== -1) {
+    hiddenColumnsDetail = lastHiddenColumnDetail.map((item, i) => {
+      if (i === index) {
+        return currentHiddenColumnsInfo;
+      }
+
+      return item;
+    });
+  } else {
+    hiddenColumnsDetail = [...lastHiddenColumnDetail, currentHiddenColumnsInfo];
+  }
 
   spreadsheet.emit(
     S2Event.COL_CELL_HIDDEN,
@@ -201,7 +233,7 @@ export const getColumns = (spreadsheet: SpreadSheet) => {
     return columns;
   }
 
-  return spreadsheet.facet.getInitColLeafNodes().map(({ id }) => id);
+  return spreadsheet.facet.getInitColIndexLeafNodes().map(({ id }) => id);
 };
 
 /**
@@ -240,7 +272,7 @@ export const isLastColumnAfterHidden = (
   columnField: string,
 ) => {
   const columnLeafNodes = spreadsheet.facet.getColLeafNodes();
-  const initColLeafNodes = spreadsheet.facet.getInitColLeafNodes();
+  const initColLeafNodes = spreadsheet.facet.getInitColIndexLeafNodes();
   const fieldKey = getHiddenColumnFieldKey(columnField);
 
   return (
@@ -291,7 +323,7 @@ export const getHiddenColumnContinuousSiblingNodes = (
     hiddenColumnNodes.map((node) => [node.id, node]),
   );
 
-  const initColLeafNodes = spreadsheet.facet.getInitColLeafNodes();
+  const initColLeafNodes = spreadsheet.facet.getInitColIndexLeafNodes();
   const step = hideDirection === 'prev' ? 1 : -1;
   const nodeIndex = initColLeafNodes.findIndex((node) => node.id === nodeId);
   const startIndex = nodeIndex + step;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
1. 修复改变内容或顺序后，隐藏改变的列，对应展开icon位置异常
2. 修复当连续隐藏N(> 2)列后，第一次点击展开按钮展开一个节点，第二次点击后展开了所有节点

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![iShot_2025-02-27_17 49 41](https://github.com/user-attachments/assets/2a162a93-e2fb-4b71-936d-1a908ff16daf) | ![iShot_2025-02-27_17 50 44](https://github.com/user-attachments/assets/77bc5b4c-eb49-490d-8084-461a86087c36) |
| ![iShot_2025-02-27_17 52 46](https://github.com/user-attachments/assets/a1f2fe41-332f-46ed-bae2-95af3315f6bc) | ![iShot_2025-02-27_17 54 03](https://github.com/user-attachments/assets/6f367de9-3914-4fe2-9002-5b15acc0a754)  |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
