### PR TITLE
fix: 相同长度的字符串，其渲染后的实际宽度可能完全不同

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
@@ -5799,7 +5799,7 @@ Array [
     "actualText": "序号",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "序号",
     ],
@@ -5810,7 +5810,7 @@ Array [
     "actualText": "省份",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "省份",
     ],
@@ -5821,7 +5821,7 @@ Array [
     "actualText": "城市城市城市城市城市城市城市城市城市城市城市城市",
     "actualTextHeight": 64,
     "actualTextWidth": 292,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "城市城市城市",
       "城市城市城市",
@@ -5835,7 +5835,7 @@ Array [
     "actualText": "数值",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "数值",
     ],
@@ -5900,7 +5900,7 @@ Array [
     "actualText": "桌子",
     "actualTextHeight": 15,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "桌子",
     ],
@@ -5911,7 +5911,7 @@ Array [
     "actualText": "沙发",
     "actualTextHeight": 15,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "沙发",
     ],
@@ -5937,7 +5937,7 @@ Array [
     "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
     "actualTextHeight": 75,
     "actualTextWidth": 365,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "桌子桌子桌子",
       "桌子桌子桌子",
@@ -5963,7 +5963,7 @@ Array [
     "actualText": "笔",
     "actualTextHeight": 15,
     "actualTextWidth": 13,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "笔",
     ],
@@ -5974,7 +5974,7 @@ Array [
     "actualText": "纸张",
     "actualTextHeight": 15,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 106,
     "multiLineActualTexts": Array [
       "纸张",
     ],
@@ -14018,7 +14018,7 @@ Array [
     "actualText": "子类别",
     "actualTextHeight": 16,
     "actualTextWidth": 37,
-    "height": 96,
+    "height": 64,
     "multiLineActualTexts": Array [
       "子类别",
     ],
@@ -14083,7 +14083,7 @@ Array [
     "actualText": "桌子",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 96,
+    "height": 64,
     "multiLineActualTexts": Array [
       "桌子",
     ],
@@ -14108,7 +14108,7 @@ Array [
     "actualText": "沙发",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 96,
+    "height": 64,
     "multiLineActualTexts": Array [
       "沙发",
     ],
@@ -14145,7 +14145,7 @@ Array [
     "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子...",
     "actualTextHeight": 48,
     "actualTextWidth": 253,
-    "height": 96,
+    "height": 64,
     "multiLineActualTexts": Array [
       "桌子桌子桌子桌",
       "子桌子桌子桌子",
@@ -14183,7 +14183,7 @@ Array [
     "actualText": "笔",
     "actualTextHeight": 16,
     "actualTextWidth": 13,
-    "height": 96,
+    "height": 64,
     "multiLineActualTexts": Array [
       "笔",
     ],
@@ -14208,7 +14208,7 @@ Array [
     "actualText": "纸张",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 96,
+    "height": 64,
     "multiLineActualTexts": Array [
       "纸张",
     ],

--- a/packages/s2-core/__tests__/spreadsheet/multi-line-text-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/multi-line-text-spec.ts
@@ -1465,5 +1465,178 @@ describe('SpreadSheet Multi Line Text Tests', () => {
 
       expect(actualText1).toEqual(actualText2);
     });
+
+    test('should render maxLines text correctly with icon', async () => {
+      const pivotSheet = new PivotSheet(
+        getContainer(),
+        {
+          fields: {
+            rows: ['dimValue'],
+            columns: ['indicatorName'],
+            values: ['value'],
+            valueInCols: true,
+          },
+          meta: [
+            {
+              field: 'dimValue',
+              name: '当日自',
+            },
+            {
+              field: 'indicatorName',
+              name: '指标名称',
+            },
+            {
+              field: 'value',
+              name: '值',
+            },
+          ],
+          data: [
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              dimValueDetail: {
+                dim_f01aa4ca_202406131000000000004274951: '测试数据',
+              },
+              value: '--',
+              indicatorName: '当日自证任务且数据采集用户数',
+              format: 'NONE',
+              id: '[#]当日自[#]测试数据[#]当日自证任务且数据采集用户数[#]',
+              maxValue: 37041,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日主动提额提额申请用户数',
+              format: 'NONE',
+              id: '[#]当日自[#]测试数据[#]当日主动提额提额申请用户数[#]',
+              maxValue: 1849575,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日主动提额提额成功用户数',
+              format: 'NONE',
+              id: '[#]当日自[#]测试数据[#]当日主动提额提额成功用户数[#]',
+              maxValue: 414581,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日主动提额提额后授信额度',
+              format: 'cent',
+              id: '[#]当日自[#]测试数据[#]当日主动提额提额后授信额度[#]',
+              maxValue: 211008545.95,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日主动提额授信提升额度',
+              format: 'yuan',
+              id: '[#]当日自[#]测试数据[#]当日主动提额授信提升额度[#]',
+              maxValue: 4721735188.31,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日主动提额额度提升提额成功用户数',
+              format: 'NONE',
+              id: '[#]当日自[#]测试数据[#]当日主动提额额度提升提额成功用户数[#]',
+              maxValue: 34536,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日cy25业绩客群支用用户数',
+              format: 'NONE',
+              id: '[#]当日自[#]测试数据[#]当日cy25业绩客群支用用户数[#]',
+              maxValue: 935010,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当日cy25业绩客群支用金额',
+              format: 'cent',
+              id: '[#]当日自[#]测试数据[#]当日cy25业绩客群支用金额[#]',
+              maxValue: 31536381479.07,
+            },
+            {
+              dimName: '当日自',
+              dimValue: '测试数据',
+              dt: '',
+              crowdName: '',
+              crowdId: '',
+              value: '--',
+              indicatorName: '当前CY25业绩客群余额用户数',
+              format: 'NONE',
+              id: '[#]当日自[#]测试数据[#]当前CY25业绩客群余额用户数[#]',
+              maxValue: 9331634,
+            },
+          ],
+          sortParams: [],
+        },
+        {
+          width: 1920,
+          height: 480,
+          showDefaultHeaderActionIcon: true,
+          style: {
+            colCell: {
+              hideValue: true,
+              maxLines: 2,
+              wordWrap: true,
+              textOverflow: 'ellipsis',
+              // "height": 30
+            },
+            cornerCell: {
+              maxLines: 2,
+              wordWrap: true,
+              textOverflow: 'ellipsis',
+            },
+            rowCell: {
+              maxLines: 2,
+              wordWrap: true,
+              textOverflow: 'ellipsis',
+              collapseAll: false,
+            },
+            layoutWidthType: 'adaptive',
+          },
+        },
+      );
+
+      await pivotSheet.render();
+      expect(
+        pivotSheet.facet.getCornerCells()[0].getHeaderConfig().height,
+      ).toEqual(46);
+    });
   });
 });

--- a/packages/s2-core/package.json
+++ b/packages/s2-core/package.json
@@ -79,6 +79,7 @@
     "@antv/g-lite": "^2.2.16",
     "@antv/vendor": "^1.0.11",
     "decimal.js": "^10.4.3",
+    "flru": "^1.0.2",
     "lodash": "^4.17.21",
     "tinycolor2": "^1.6.0"
   },

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -6,6 +6,7 @@ import {
 } from '@antv/g';
 import { interpolateArray } from '@antv/vendor/d3-interpolate';
 import { timer, type Timer } from '@antv/vendor/d3-timer';
+import flru, { flruCache } from 'flru';
 import {
   clamp,
   compact,
@@ -26,7 +27,6 @@ import {
   max,
   maxBy,
   reduce,
-  size,
   sumBy,
 } from 'lodash';
 import {
@@ -175,7 +175,7 @@ export abstract class BaseFacet {
 
   public gridInfo: GridInfo;
 
-  protected textWrapNodeHeightCache: Map<string, number>;
+  protected textWrapNodeHeightCache: flruCache<number>;
 
   protected textWrapTempCornerCell: CornerCell | null;
 
@@ -272,7 +272,7 @@ export abstract class BaseFacet {
     this.textWrapTempRowCell = this.getRowCellInstance(...args);
     this.textWrapTempColCell = this.getColCellInstance(...args);
     this.textWrapTempCornerCell = this.getCornerCellInstance?.(...args);
-    this.textWrapNodeHeightCache = new Map();
+    this.textWrapNodeHeightCache = flru(500);
     this.customRowHeightStatusMap = {};
   }
 
@@ -521,11 +521,15 @@ export abstract class BaseFacet {
       return defaultHeight;
     }
 
-    // 相同文本长度, 并且单元格宽度一致, 无需再计算换行高度, 使用缓存
-    const cacheKey = `${size(fieldValue)}${NODE_ID_SEPARATOR}${maxTextWidth}`;
+    /**
+     * [Bug Fix] 使用完整的 fieldValue 作为缓存键，确保准确性
+     * 之前的 `size(fieldValue)` (即 fieldValue.length) 是不准确的
+     * 相同长度的字符串，其渲染后的实际宽度可能完全不同
+     * * */
+    const cacheKey = `${fieldValue}${NODE_ID_SEPARATOR}${maxTextWidth}`;
     const cacheHeight = this.textWrapNodeHeightCache.get(cacheKey);
 
-    if (cacheHeight && useCache) {
+    if (useCache && isNumber(cacheHeight)) {
       return cacheHeight || defaultHeight;
     }
 
@@ -827,7 +831,7 @@ export abstract class BaseFacet {
     this.clearAllGroup();
     this.preCellIndexes = null;
     this.customRowHeightStatusMap = {};
-    this.textWrapNodeHeightCache.clear();
+    this.textWrapNodeHeightCache.clear(false);
     cancelAnimationFrame(this.scrollFrameId!);
   }
 

--- a/packages/s2-core/src/facet/table-facet.ts
+++ b/packages/s2-core/src/facet/table-facet.ts
@@ -248,7 +248,7 @@ export class TableFacet extends FrozenFacet {
     if (keys(heightByField!).length || isEnableHeightAdaptive) {
       const data = this.spreadsheet.dataSet.getDisplayDataSet();
 
-      this.textWrapNodeHeightCache.clear();
+      this.textWrapNodeHeightCache.clear(false);
       this.customRowHeightStatusMap = {};
       this.rowOffsets = [0];
       this.lastRowOffset = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       decimal.js:
         specifier: ^10.4.3
         version: 10.4.3
+      flru:
+        specifier: ^1.0.2
+        version: 1.0.2
       lodash:
         specifier: ^4.17.21
         version: 4.17.21


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

```ts
import '@antv/s2/src/styles/theme/dark.css';
import React from 'react';
import type { SheetComponentOptions } from '../src';
import { SheetComponent } from '../src';
import { reactRender } from '../src/utils/reactRender';

const dataCfg = {
  fields: {
    rows: ['dimValue'],
    columns: ['indicatorName'],
    values: ['value'],
    valueInCols: true,
  },
  meta: [
    {
      field: 'dimValue',
      name: '当日自',
    },
    {
      field: 'indicatorName',
      name: '指标名称',
    },
    {
      field: 'value',
      name: '值',
    },
  ],
  data: [
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      dimValueDetail: {
        dim_f01aa4ca_202406131000000000004274951: '测试数据',
      },
      value: '--',
      indicatorName: '当日自证任务且数据采集用户数',
      format: 'NONE',
      id: '[#]当日自[#]测试数据[#]当日自证任务且数据采集用户数[#]',
      maxValue: 37041,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日主动提额提额申请用户数',
      format: 'NONE',
      id: '[#]当日自[#]测试数据[#]当日主动提额提额申请用户数[#]',
      maxValue: 1849575,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日主动提额提额成功用户数',
      format: 'NONE',
      id: '[#]当日自[#]测试数据[#]当日主动提额提额成功用户数[#]',
      maxValue: 414581,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日主动提额提额后授信额度',
      format: 'cent',
      id: '[#]当日自[#]测试数据[#]当日主动提额提额后授信额度[#]',
      maxValue: 211008545.95,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日主动提额授信提升额度',
      format: 'yuan',
      id: '[#]当日自[#]测试数据[#]当日主动提额授信提升额度[#]',
      maxValue: 4721735188.31,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日主动提额额度提升提额成功用户数',
      format: 'NONE',
      id: '[#]当日自[#]测试数据[#]当日主动提额额度提升提额成功用户数[#]',
      maxValue: 34536,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日cy25业绩客群支用用户数',
      format: 'NONE',
      id: '[#]当日自[#]测试数据[#]当日cy25业绩客群支用用户数[#]',
      maxValue: 935010,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当日cy25业绩客群支用金额',
      format: 'cent',
      id: '[#]当日自[#]测试数据[#]当日cy25业绩客群支用金额[#]',
      maxValue: 31536381479.07,
    },
    {
      dimName: '当日自',
      dimValue: '测试数据',
      dt: '',
      crowdName: '',
      crowdId: '',
      value: '--',
      indicatorName: '当前CY25业绩客群余额用户数',
      format: 'NONE',
      id: '[#]当日自[#]测试数据[#]当前CY25业绩客群余额用户数[#]',
      maxValue: 9331634,
    },
  ],
  sortParams: [],
};

const s2Options: SheetComponentOptions = {
  width: 600,
  height: 480,
  // showDefaultHeaderActionIcon: false,
  style: {
    colCell: {
      hideValue: true,
      maxLines: 2,
      wordWrap: true,
      textOverflow: 'ellipsis',
      // "height": 30
    },
    cornerCell: {
      maxLines: 2,
      wordWrap: true,
      textOverflow: 'ellipsis',
    },
    rowCell: {
      maxLines: 2,
      wordWrap: true,
      textOverflow: 'ellipsis',
      collapseAll: false,
    },
    layoutWidthType: 'adaptive',
  },
};

reactRender(
  <React.StrictMode>
    <SheetComponent
      dataCfg={dataCfg}
      options={s2Options}
      adaptive={{
        width: true,
        height: false,
      }}
    />
  </React.StrictMode>,
  document.getElementById('root')!,
);

```


| Before | After |
| ------ | ----- |
|  <img width="3832" height="174" alt="image" src="https://github.com/user-attachments/assets/01c0460e-4dc9-4f38-86fa-c4760e8010e2" />    |  <img width="3838" height="210" alt="image" src="https://github.com/user-attachments/assets/60dd0178-6802-4db6-b7e2-3ce8f2c6a5e8" />  |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
