### PR TITLE
fix: 透视表紧凑模式下，数值挂列头时隐藏数值，会导致紧凑模式下列头自适应宽度失效

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-3212-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-3212-spec.ts
@@ -5,7 +5,7 @@
 import { createPivotSheet } from '../util/helpers';
 
 describe('PivotSheet', () => {
-  test('should render correctly borders after scroll out of view', async () => {
+  test('should keep column width after hiding value in compact mode', async () => {
     const dataCfg = await fetch(
       'https://gw.alipayobjects.com/os/bmw-prod/2a5dbbc8-d0a7-4d02-b7c9-34f6ca63cff6.json',
     ).then((res) => res.json());
@@ -30,11 +30,13 @@ describe('PivotSheet', () => {
 
     const colWidth = s2.facet.getColCells()[0].getMeta().width;
 
-    s2Options!.style!.colCell = {
-      hideValue: true,
-    };
-
-    s2.setOptions(s2Options);
+    s2.setOptions({
+      style: {
+        colCell: {
+          hideValue: true,
+        },
+      },
+    });
 
     await s2.render();
 

--- a/packages/s2-core/__tests__/bugs/issue-3212-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-3212-spec.ts
@@ -1,0 +1,43 @@
+/**
+ * @description spec for issue #3212
+ * https://github.com/antvis/S2/issues/3212
+ */
+import { createPivotSheet } from '../util/helpers';
+
+describe('PivotSheet', () => {
+  test('should render correctly borders after scroll out of view', async () => {
+    const dataCfg = await fetch(
+      'https://gw.alipayobjects.com/os/bmw-prod/2a5dbbc8-d0a7-4d02-b7c9-34f6ca63cff6.json',
+    ).then((res) => res.json());
+
+    // 增加几条长度不一致的 mock 数据
+    dataCfg.data[0].number = 11111111;
+    dataCfg.data[6].number = 7777;
+    dataCfg.data[dataCfg.data.length - 1].number = 666666;
+    const s2Options = {
+      width: 600,
+      height: 480,
+      style: {
+        // 了解更多: https://s2.antv.antgroup.com/api/general/s2-options#style
+        layoutWidthType: 'compact',
+      },
+    };
+    const s2 = createPivotSheet(s2Options, { useSimpleData: false });
+
+    s2.setDataCfg(dataCfg);
+
+    await s2.render();
+
+    const colWidth = s2.facet.getColCells()[0].getMeta().width;
+
+    s2Options!.style!.colCell = {
+      hideValue: true,
+    };
+
+    s2.setOptions(s2Options);
+
+    await s2.render();
+
+    expect(s2.facet.getColCells()[0].getMeta().width).toBe(colWidth);
+  });
+});

--- a/packages/s2-core/src/facet/pivot-facet.ts
+++ b/packages/s2-core/src/facet/pivot-facet.ts
@@ -924,9 +924,13 @@ export class PivotFacet extends FrozenFacet {
       const rowNode = rowLeafNodes[index];
 
       if (rowNode) {
+        const { valueField, dataQuery } = this.getDataQueryInfo(
+          rowNode.query!,
+          colNode.query!,
+        );
         const cellData = (this.spreadsheet.dataSet as PivotDataSet).getCellData(
           {
-            query: { ...colNode.query, ...rowNode.query },
+            query: dataQuery,
             rowNode,
             isTotals:
               colNode.isTotals ||
@@ -939,16 +943,11 @@ export class PivotFacet extends FrozenFacet {
         if (cellData) {
           // 总小计格子不一定有数据
           const valueData = cellData?.[VALUE_FIELD];
-          const formattedValue =
+          const cellLabel =
             this.spreadsheet.dataSet.getFieldFormatter(cellData[EXTRA_FIELD])?.(
               valueData,
             ) ?? valueData;
-          const cellLabel = formattedValue;
           // 考虑字段标记 icon 的宽度: https://github.com/antvis/S2/pull/2673
-          const { valueField } = this.getDataQueryInfo(
-            rowNode.query!,
-            colNode.query!,
-          );
           const hasIcon = findFieldCondition(
             this.spreadsheet.options.conditions?.icon,
             valueField!,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #3212 

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

查询不匹配问题
在 getCompactGridColNodeWidth 方法中（第895-1001行），第939行的代码：

const cellData = (this.spreadsheet.dataSet as PivotDataSet).getCellData({
  query: { ...colNode.query, ...rowNode.query },
  rowNode,
  isTotals: /* ... */,
});
当 hideValue: true 时，colNode.query 中不包含度量信息

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
|  <img width="650" height="620" alt="image" src="https://github.com/user-attachments/assets/5ef70b5b-c289-456d-91a6-207f07451e3b" />    |  <img width="798" height="638" alt="image" src="https://github.com/user-attachments/assets/af9aec33-112f-4155-bb21-52c2c3122d26" />    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
