### PR TITLE
fix: 多行文本紧凑模式shouldShowDefaultHeaderActionIcon导致数值单元格高度不对

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
@@ -5793,13 +5793,13 @@ Array [
 ]
 `;
 
-exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and valuesInCols=false 1`] = `
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and layoutWidthType === compact 1`] = `
 Array [
   Object {
     "actualText": "序号",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 106,
+    "height": 30,
     "multiLineActualTexts": Array [
       "序号",
     ],
@@ -5810,7 +5810,406 @@ Array [
     "actualText": "省份",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 106,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "省份",
+    ],
+    "originalText": "省份",
+    "width": 378,
+  },
+  Object {
+    "actualText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "actualTextHeight": 16,
+    "actualTextWidth": 289,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "城市城市城市城市城市城市城市城市城市城市城市城市",
+    ],
+    "originalText": "城市城市城市城市城市城市城市城市城市城市城市城市",
+    "width": 378,
+  },
+  Object {
+    "actualText": "类别类别类别类别类别类别类别类别类别类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 241,
+    "height": 48,
+    "multiLineActualTexts": Array [
+      "类别类别类别类别类别类别类别类别类别类别",
+    ],
+    "originalText": "类别类别类别类别类别类别类别类别类别类别",
+    "width": 836,
+  },
+  Object {
+    "actualText": "子类别",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 48,
+    "multiLineActualTexts": Array [
+      "子类别",
+    ],
+    "originalText": "子类别",
+    "width": 836,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and layoutWidthType === compact 2`] = `
+Array [
+  Object {
+    "actualText": "1",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "1",
+    ],
+    "originalText": "1",
+    "width": 80,
+  },
+  Object {
+    "actualText": "2",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2",
+    ],
+    "originalText": "2",
+    "width": 80,
+  },
+  Object {
+    "actualText": "3",
+    "actualTextHeight": 15,
+    "actualTextWidth": 7,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "3",
+    ],
+    "originalText": "3",
+    "width": 80,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and layoutWidthType === compact 3`] = `
+Array [
+  Object {
+    "actualText": "家具",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 48,
+    "multiLineActualTexts": Array [
+      "家具",
+    ],
+    "originalText": "家具",
+    "width": 602,
+  },
+  Object {
+    "actualText": "桌子",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 48,
+    "multiLineActualTexts": Array [
+      "桌子",
+    ],
+    "originalText": "桌子",
+    "width": 301,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 15,
+    "actualTextWidth": 265,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "数量数量数量数量数量数量数量数量数量数量数量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 301,
+  },
+  Object {
+    "actualText": "沙发",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 48,
+    "multiLineActualTexts": Array [
+      "沙发",
+    ],
+    "originalText": "沙发",
+    "width": 301,
+  },
+  Object {
+    "actualText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "actualTextHeight": 15,
+    "actualTextWidth": 265,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "数量数量数量数量数量数量数量数量数量数量数量",
+    ],
+    "originalText": "数量数量数量数量数量数量数量数量数量数量数量",
+    "width": 301,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and layoutWidthType === compact 4`] = `
+Array [
+  Object {
+    "actualText": "浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "浙江省",
+    ],
+    "originalText": "浙江省",
+    "width": 378,
+  },
+  Object {
+    "actualText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 361,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    ],
+    "originalText": "浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省浙江省",
+    "width": 378,
+  },
+  Object {
+    "actualText": "四川省",
+    "actualTextHeight": 16,
+    "actualTextWidth": 37,
+    "height": 120,
+    "multiLineActualTexts": Array [
+      "四川省",
+    ],
+    "originalText": "四川省",
+    "width": 378,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and layoutWidthType === compact 5`] = `
+Array [
+  Object {
+    "actualText": "236723672361111",
+    "actualTextHeight": 15,
+    "actualTextWidth": 98,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "236723672361111",
+    ],
+    "originalText": 236723672361111,
+    "width": 301,
+  },
+  Object {
+    "actualText": "3877",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "3877",
+    ],
+    "originalText": 3877,
+    "width": 301,
+  },
+  Object {
+    "actualText": "4342",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "4342",
+    ],
+    "originalText": 4342,
+    "width": 301,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 301,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 301,
+  },
+  Object {
+    "actualText": "1723",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1723",
+    ],
+    "originalText": 1723,
+    "width": 301,
+  },
+  Object {
+    "actualText": "1822",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1822",
+    ],
+    "originalText": 1822,
+    "width": 301,
+  },
+  Object {
+    "actualText": "1943",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "1943",
+    ],
+    "originalText": 1943,
+    "width": 301,
+  },
+  Object {
+    "actualText": "2330",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2330",
+    ],
+    "originalText": 2330,
+    "width": 301,
+  },
+  Object {
+    "actualText": "632",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "632",
+    ],
+    "originalText": 632,
+    "width": 301,
+  },
+  Object {
+    "actualText": "7234",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "7234",
+    ],
+    "originalText": 7234,
+    "width": 301,
+  },
+  Object {
+    "actualText": "834",
+    "actualTextHeight": 15,
+    "actualTextWidth": 21,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "834",
+    ],
+    "originalText": 834,
+    "width": 301,
+  },
+  Object {
+    "actualText": "5343",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "5343",
+    ],
+    "originalText": 5343,
+    "width": 301,
+  },
+  Object {
+    "actualText": "-",
+    "actualTextHeight": 15,
+    "actualTextWidth": 4,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "-",
+    ],
+    "originalText": "-",
+    "width": 301,
+  },
+  Object {
+    "actualText": "2451",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2451",
+    ],
+    "originalText": 2451,
+    "width": 301,
+  },
+  Object {
+    "actualText": "2244",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2244",
+    ],
+    "originalText": 2244,
+    "width": 301,
+  },
+  Object {
+    "actualText": "2333",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2333",
+    ],
+    "originalText": 2333,
+    "width": 301,
+  },
+  Object {
+    "actualText": "2445",
+    "actualTextHeight": 15,
+    "actualTextWidth": 27,
+    "height": 30,
+    "multiLineActualTexts": Array [
+      "2445",
+    ],
+    "originalText": 2445,
+    "width": 301,
+  },
+]
+`;
+
+exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons and valuesInCols=false 1`] = `
+Array [
+  Object {
+    "actualText": "序号",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 91,
+    "multiLineActualTexts": Array [
+      "序号",
+    ],
+    "originalText": "序号",
+    "width": 80,
+  },
+  Object {
+    "actualText": "省份",
+    "actualTextHeight": 16,
+    "actualTextWidth": 25,
+    "height": 91,
     "multiLineActualTexts": Array [
       "省份",
     ],
@@ -5821,7 +6220,7 @@ Array [
     "actualText": "城市城市城市城市城市城市城市城市城市城市城市城市",
     "actualTextHeight": 64,
     "actualTextWidth": 292,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "城市城市城市",
       "城市城市城市",
@@ -5835,7 +6234,7 @@ Array [
     "actualText": "数值",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "数值",
     ],
@@ -5846,7 +6245,7 @@ Array [
     "actualText": "类别类别类别类别类别类别类别类别类别类别",
     "actualTextHeight": 16,
     "actualTextWidth": 241,
-    "height": 112,
+    "height": 96,
     "multiLineActualTexts": Array [
       "类别类别类别类别类别类别类别类别类别类别",
     ],
@@ -5889,7 +6288,7 @@ Array [
     "actualText": "家具",
     "actualTextHeight": 16,
     "actualTextWidth": 25,
-    "height": 112,
+    "height": 96,
     "multiLineActualTexts": Array [
       "家具",
     ],
@@ -5900,7 +6299,7 @@ Array [
     "actualText": "桌子",
     "actualTextHeight": 15,
     "actualTextWidth": 25,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "桌子",
     ],
@@ -5911,7 +6310,7 @@ Array [
     "actualText": "沙发",
     "actualTextHeight": 15,
     "actualTextWidth": 25,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "沙发",
     ],
@@ -5922,7 +6321,7 @@ Array [
     "actualText": "家具家具家具家具家具家具家具家具家具家具家具家具家具家具",
     "actualTextHeight": 80,
     "actualTextWidth": 341,
-    "height": 112,
+    "height": 96,
     "multiLineActualTexts": Array [
       "家具家具家具",
       "家具家具家具",
@@ -5937,7 +6336,7 @@ Array [
     "actualText": "桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子桌子",
     "actualTextHeight": 75,
     "actualTextWidth": 365,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "桌子桌子桌子",
       "桌子桌子桌子",
@@ -5952,7 +6351,7 @@ Array [
     "actualText": "办公用品",
     "actualTextHeight": 16,
     "actualTextWidth": 49,
-    "height": 112,
+    "height": 96,
     "multiLineActualTexts": Array [
       "办公用品",
     ],
@@ -5963,7 +6362,7 @@ Array [
     "actualText": "笔",
     "actualTextHeight": 15,
     "actualTextWidth": 13,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "笔",
     ],
@@ -5974,7 +6373,7 @@ Array [
     "actualText": "纸张",
     "actualTextHeight": 15,
     "actualTextWidth": 25,
-    "height": 106,
+    "height": 91,
     "multiLineActualTexts": Array [
       "纸张",
     ],

--- a/packages/s2-core/__tests__/spreadsheet/multi-line-text-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/multi-line-text-spec.ts
@@ -786,6 +786,20 @@ describe('SpreadSheet Multi Line Text Tests', () => {
       matchCellStyleSnapshot();
     });
 
+    test('should calculate correctly max text width for default sort header action icons and layoutWidthType === compact', async () => {
+      updateStyle(Infinity);
+      s2.changeSheetSize(800, 600);
+      s2.setOptions({
+        showDefaultHeaderActionIcon: true,
+        style: {
+          layoutWidthType: 'compact',
+        },
+      });
+      await s2.render(false);
+
+      matchCellStyleSnapshot();
+    });
+
     test('should render Col Height correct after hide Sample Nodes', async () => {
       const cellTextWordWrapStyle: CellTextWordWrapStyle = {
         heightByField: null,

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -635,4 +635,11 @@ export class ColCell extends HeaderCell<ColHeaderConfig> {
       })
     );
   }
+
+  protected shouldShowDefaultHeaderActionIcon() {
+    return (
+      this.spreadsheet.options.showDefaultHeaderActionIcon &&
+      this.spreadsheet.isValueInCols()
+    );
+  }
 }

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -178,11 +178,15 @@ export abstract class HeaderCell<
     };
   }
 
+  protected shouldShowDefaultHeaderActionIcon() {
+    return this.spreadsheet.options.showDefaultHeaderActionIcon;
+  }
+
   protected showSortIcon() {
-    const { options, dataCfg } = this.spreadsheet;
+    const { dataCfg } = this.spreadsheet;
     const isEmptyValues = isEmpty(dataCfg.fields.values);
 
-    if (options.showDefaultHeaderActionIcon && !isEmptyValues) {
+    if (this.shouldShowDefaultHeaderActionIcon() && !isEmptyValues) {
       const { sortParam } = this.getHeaderConfig();
       const query = this.meta.query;
 

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -514,4 +514,11 @@ export class RowCell extends HeaderCell<RowHeaderConfig> {
       })
     );
   }
+
+  protected shouldShowDefaultHeaderActionIcon() {
+    return (
+      this.spreadsheet.options.showDefaultHeaderActionIcon &&
+      !this.spreadsheet.isValueInCols()
+    );
+  }
 }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #3240 

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

原因是base-facet.ts计算高度时，会先去generate一次icon。
<img width="1904" height="1074" alt="image" src="https://github.com/user-attachments/assets/8caeaeae-c768-474d-a528-20a6277e8bc4" />
在开启shouldShowDefaultHeaderActionIcon并且shallowRender的情况下会认为需要渲染icon，**实际上数值置于列头的时候只需要给列头留icon的位置，数值置于行头只需要给行头留icon位置，不需要都留位置。这里误留位置导致base-facet认为多行文本需要换行，所以高度异常。**
<img width="1622" height="1430" alt="image" src="https://github.com/user-attachments/assets/7a01bc0f-f5a8-45f3-a629-f89e4646b0ba" />

下面的代码可以复现。
```ts
import { PivotSheet, S2Options } from '@antv/s2';

fetch(
  'https://gw.alipayobjects.com/os/bmw-prod/2a5dbbc8-d0a7-4d02-b7c9-34f6ca63cff6.json',
)
  .then((res) => res.json())
  .then(async (dataCfg) => {
    // 增加几条长度不一致的 mock 数据
    dataCfg.data.at(0).number = 11111111;
    dataCfg.data.at(6).number = 7777;
    dataCfg.data.at(-1).number = 666666;

    const container = document.getElementById('root');

    const s2Options: S2Options = {
      width: 600,
      height: 480,
      showDefaultHeaderActionIcon: true,
      // showDefaultHeaderActionIcon: false,
      style: {
        layoutWidthType: 'compact',
        rowCell: { maxLines: 2, wordWrap: true, textOverflow: 'ellipsis' },
      },
    };

    const s2 = new PivotSheet(container, dataCfg, s2Options);

    // 紧凑模式下, 列头宽度为实际内容宽度 (取当前列最大值, 采样每一列前 50 条数据)
    s2.setTheme({
      dataCell: {
        text: {
          fontSize: 16,
        },
      },
    });

    await s2.render();
    console.log(s2);
  });

```

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌ <img width="848" height="954" alt="image" src="https://github.com/user-attachments/assets/a4d16ce2-135d-4481-bbf1-71c38211be09" />    | ✅  <img width="842" height="684" alt="image" src="https://github.com/user-attachments/assets/c56a0c24-74c3-4b57-b72e-cf45f8232c80" />    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
