### PR TITLE
fix: 复制时相同前缀判断不准确

### DIFF
--- a/packages/s2-core/__tests__/unit/utils/export/__snapshots__/copy-spec.ts.snap
+++ b/packages/s2-core/__tests__/unit/utils/export/__snapshots__/copy-spec.ts.snap
@@ -339,6 +339,24 @@ number	number		number	number",
 ]
 `;
 
+exports[`Pivot Table getBrushHeaderCopyable should copy correct row in grid mode with same prefix 1`] = `
+Array [
+  Object {
+    "content": "	家具	办公用品
+	数量	数量
+浙江省	7789	-
+四川省	-	3551
+四川省省	-	3551
+湖南省	-	3551",
+    "type": "text/plain",
+  },
+  Object {
+    "content": "<meta charset=\\"utf-8\\"><table><tbody><tr><td></td><td>家具</td><td>办公用品</td></tr><tr><td></td><td>数量</td><td>数量</td></tr><tr><td>浙江省</td><td>7789</td><td>-</td></tr><tr><td>四川省</td><td>-</td><td>3551</td></tr><tr><td>四川省省</td><td>-</td><td>3551</td></tr><tr><td>湖南省</td><td>-</td><td>3551</td></tr></tbody></table>",
+    "type": "text/html",
+  },
+]
+`;
+
 exports[`Pivot Table getBrushHeaderCopyable should copy row total data in grid mode 1`] = `
 "浙江省	杭州市
 浙江省	绍兴市

--- a/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
+++ b/packages/s2-core/__tests__/unit/utils/export/copy-spec.ts
@@ -1880,4 +1880,106 @@ describe('Pivot Table getBrushHeaderCopyable', () => {
 
     expect(getCopyPlainContent(s2)).toMatchSnapshot();
   });
+
+  test('should copy correct row in grid mode with same prefix', async () => {
+    const samePrefixDataCfg = {
+      describe: '标准交叉表数据。',
+      fields: {
+        rows: ['province'],
+        columns: ['type'],
+        values: ['number'],
+        valueInCols: true,
+      },
+      meta: [
+        {
+          field: 'number',
+          name: '数量',
+        },
+        {
+          field: 'province',
+          name: '省份',
+        },
+        {
+          field: 'city',
+          name: '城市',
+        },
+        {
+          field: 'type',
+          name: '类别',
+        },
+        {
+          field: 'sub_type',
+          name: '子类别',
+        },
+      ],
+      data: [
+        {
+          number: 7789,
+          province: '浙江省',
+          city: '杭州市',
+          type: '家具',
+          sub_type: '桌子',
+        },
+        {
+          number: 3551,
+          province: '四川省',
+          city: '南充市',
+          type: '办公用品',
+          sub_type: '纸张',
+        },
+        {
+          number: 3551,
+          province: '四川省省',
+          city: '南充市',
+          type: '办公用品',
+          sub_type: '纸张',
+        },
+        {
+          number: 3551,
+          province: '湖南省',
+          city: '南充市',
+          type: '办公用品',
+          sub_type: '纸张',
+        },
+      ],
+    };
+    const sheet = new PivotSheet(
+      getContainer(),
+      samePrefixDataCfg,
+      assembleOptions({
+        hierarchyType: 'grid',
+        interaction: {
+          // 悬停高亮
+          hoverHighlight: true,
+
+          copy: {
+            // 允许复制
+            enable: true,
+            // 是否携带行列头数据
+            withHeader: true,
+            // 是否使用格式化数据
+            withFormat: true,
+          },
+          // 刷选
+          brushSelection: {
+            rowCell: true,
+            colCell: true,
+            dataCell: true,
+          },
+          // 多选
+          multiSelection: true,
+        },
+      }),
+    );
+
+    await sheet.render();
+
+    const cells = sheet.facet.getDataCells();
+
+    selectCells(cells, sheet);
+
+    const copyableList = getSelectedData(sheet);
+
+    expect(copyableList).toMatchSnapshot();
+  });
 });

--- a/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/pivot-data-cell-copy.ts
@@ -10,6 +10,7 @@ import {
 import {
   CornerNodeType,
   EXTRA_FIELD,
+  NODE_ID_SEPARATOR,
   VALUE_FIELD,
   type CellMeta,
   type CustomHeaderField,
@@ -93,10 +94,23 @@ export class PivotDataCellCopy extends BaseDataCellCopy {
     allRowOrColLeafNodes: Node[],
     isTreeData = false,
   ): Node[] {
+    if (isTreeData) {
+      const selectedIds = new Set(selectedMeta.map((meta) => meta.id));
+
+      return allRowOrColLeafNodes.filter((node) => selectedIds.has(node.id));
+    }
+
     return selectedMeta.reduce<Node[]>((nodes, cellMeta) => {
-      const filterNodes = allRowOrColLeafNodes.filter((node) =>
-        isTreeData ? node.id === cellMeta.id : node.id.startsWith(cellMeta.id),
-      );
+      const parentId = cellMeta.id;
+      const filterNodes = allRowOrColLeafNodes.filter((node) => {
+        // 核心修复逻辑：
+        // 1. node.id === parentId   -> 完全匹配，例如 "root[&]四川省" 匹配 "root[&]四川省"
+        // 2. node.id.startsWith(parentId + delimiter) -> 匹配子孙，例如 "root[&]四川省[&]成都市"
+        return (
+          node.id === parentId ||
+          node.id.startsWith(parentId + NODE_ID_SEPARATOR)
+        );
+      });
 
       nodes.push(...filterNodes);
 


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #3254 

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

selectedMeta的某个id是"root[&]四川省"，那么通过startsWith匹配时，"root[&]四川省"和"root[&]四川省省"都会被匹配到，导致bug出现。我理解原作者这里通过startsWith这个函数的本意是"root[&]四川省"可以匹配 "root[&]四川省"、"root[&]四川省[&]成都市"、"root[&]四川省[&]雅安市"。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌  ![iShot_2025-12-10_11 37 55](https://github.com/user-attachments/assets/af4f6398-ab8f-4dcb-871d-aeb93d7b2ecf)    | ✅  ![iShot_2025-12-10_11 36 11](https://github.com/user-attachments/assets/ff22537b-b5c9-4b28-b5c3-5a34deccb11e)    |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

<!-- close #0 -->
<!-- ref #0 -->
<!-- fix #0 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
