### PR TITLE
chore: playground 增加 grid-tree，修复 vue playground 多行文本不生效

### DIFF
--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -104,6 +104,13 @@ export class RowCell extends HeaderCell<RowHeaderConfig> {
       spanWidth += levelSample?.width ?? 0;
     }
 
+    // CONTENT_BOX 需要减去左右 padding
+    if (type === CellClipBox.CONTENT_BOX) {
+      const { padding } = this.getStyle()!.cell!;
+
+      spanWidth -= (padding?.left ?? 0) + (padding?.right ?? 0);
+    }
+
     return {
       ...baseBBox,
       width: spanWidth || baseBBox.width,

--- a/packages/s2-core/src/data-set/pivot-data-set.ts
+++ b/packages/s2-core/src/data-set/pivot-data-set.ts
@@ -412,8 +412,11 @@ export class PivotDataSet extends BaseDataSet {
       getAggregationAndCalcFuncByQuery(status, options?.totals) || {};
 
     // 聚合方式从用户配置的 s2Options.totals 取, 在触发前端兜底计算汇总逻辑时, 如果没有汇总的配置, 默认按 [求和] 计算,避免排序失效.
+    // tree 和 grid-tree 模式下，如果用户没有配置 totals，不应该自动聚合
     const defaultAggregation =
-      isEmpty(options?.totals) && !this.spreadsheet.isHierarchyTreeType()
+      isEmpty(options?.totals) &&
+      !this.spreadsheet.isHierarchyTreeType() &&
+      !this.spreadsheet.isHierarchyGridTreeType()
         ? Aggregation.SUM
         : '';
 

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -495,19 +495,27 @@ function MainLayout() {
                                     updateOptions({ debug: checked });
                                   }}
                                 />
-                                <Switch
-                                  checkedChildren="树形"
-                                  unCheckedChildren="平铺"
-                                  checked={
-                                    mergedOptions.hierarchyType === 'tree'
-                                  }
-                                  onChange={(checked) => {
-                                    updateOptions({
-                                      hierarchyType: checked ? 'tree' : 'grid',
-                                    });
-                                  }}
-                                  disabled={sheetType === 'table'}
-                                />
+                                <Tooltip title="透视表层级结构">
+                                  <Radio.Group
+                                    value={mergedOptions.hierarchyType}
+                                    onChange={(e) => {
+                                      updateOptions({
+                                        hierarchyType: e.target.value,
+                                      });
+                                    }}
+                                    disabled={sheetType === 'table'}
+                                  >
+                                    <Radio.Button value="grid">
+                                      平铺
+                                    </Radio.Button>
+                                    <Radio.Button value="tree">
+                                      树形
+                                    </Radio.Button>
+                                    <Radio.Button value="grid-tree">
+                                      grid-tree
+                                    </Radio.Button>
+                                  </Radio.Group>
+                                </Tooltip>
                                 <Switch
                                   checkedChildren="数值挂列头"
                                   unCheckedChildren="数值挂行头"

--- a/packages/s2-react/playground/index.tsx
+++ b/packages/s2-react/playground/index.tsx
@@ -31,6 +31,7 @@ import {
   DatePicker,
   Divider,
   Input,
+  InputNumber,
   Pagination,
   Popover,
   Radio,
@@ -470,6 +471,40 @@ function MainLayout() {
                                     </Radio.Button>
                                   </Radio.Group>
                                 </Tooltip>
+                                <InputNumber
+                                  style={{ width: 120 }}
+                                  min={0}
+                                  placeholder="紧凑布局（附加宽）"
+                                  disabled={
+                                    options?.style?.layoutWidthType !==
+                                    'compact'
+                                  }
+                                  value={options?.style?.compactExtraWidth ?? 0}
+                                  onChange={(value) => {
+                                    updateOptions({
+                                      style: {
+                                        compactExtraWidth: value ?? 0,
+                                      },
+                                    });
+                                  }}
+                                />
+                                <InputNumber
+                                  style={{ width: 120 }}
+                                  min={0}
+                                  placeholder="紧凑布局（最小宽）"
+                                  disabled={
+                                    options?.style?.layoutWidthType !==
+                                    'compact'
+                                  }
+                                  value={options?.style?.compactMinWidth ?? 0}
+                                  onChange={(value) => {
+                                    updateOptions({
+                                      style: {
+                                        compactMinWidth: value ?? 0,
+                                      },
+                                    });
+                                  }}
+                                />
                                 <Button
                                   danger
                                   onClick={() => {

--- a/packages/s2-vue/playground/App.vue
+++ b/packages/s2-vue/playground/App.vue
@@ -347,16 +347,18 @@ const setThemeCfg = (cb: any) => {
                 :checked="mergedOptions.debug"
                 @change="(checked) => updateOptions({ debug: checked })"
               />
-              <a-switch
-                checked-children="树形"
-                un-checked-children="平铺"
-                :checked="mergedOptions.hierarchyType === 'tree'"
-                @change="
-                  (checked) =>
-                    updateOptions({ hierarchyType: checked ? 'tree' : 'grid' })
-                "
-                :disabled="sheetType === 'table'"
-              />
+              <a-tooltip title="透视表层级结构">
+                <a-radio-group
+                  :value="mergedOptions.hierarchyType"
+                  @change="
+                    (e) => updateOptions({ hierarchyType: e.target.value })
+                  "
+                >
+                  <a-radio-button value="grid">平铺</a-radio-button>
+                  <a-radio-button value="tree">树形</a-radio-button>
+                  <a-radio-button value="grid-tree">grid-tree</a-radio-button>
+                </a-radio-group>
+              </a-tooltip>
               <a-switch
                 checked-children="数值挂列头"
                 un-checked-children="数值挂行头"

--- a/packages/s2-vue/playground/App.vue
+++ b/packages/s2-vue/playground/App.vue
@@ -328,6 +328,29 @@ const setThemeCfg = (cb: any) => {
                 </a-radio-group>
               </a-tooltip>
 
+              <a-input-number
+                style="width: 120px"
+                :min="0"
+                placeholder="紧凑布局（附加宽）"
+                :disabled="options?.style?.layoutWidthType !== 'compact'"
+                :value="mergedOptions.style?.compactExtraWidth ?? 0"
+                @change="
+                  (value) =>
+                    updateOptions({ style: { compactExtraWidth: value } })
+                "
+              />
+              <a-input-number
+                style="width: 120px"
+                :min="0"
+                placeholder="紧凑布局（最小宽）"
+                :disabled="options?.style?.layoutWidthType !== 'compact'"
+                :value="mergedOptions.style?.compactMinWidth ?? 0"
+                @change="
+                  (value) =>
+                    updateOptions({ style: { compactMinWidth: value } })
+                "
+              />
+
               <a-button
                 danger
                 @click="

--- a/packages/s2-vue/playground/App.vue
+++ b/packages/s2-vue/playground/App.vue
@@ -23,6 +23,7 @@ import {
   headerActionIcons,
   pivotSheetDataCfg,
   pivotSheetDataCfgForCompactMode,
+  pivotSheetMultiLineTextDataCfg,
   s2ConditionsOptions,
   s2ThemeConfig,
   tableSheetDataCfg,
@@ -127,6 +128,10 @@ const onThemeChange = (e: any) => {
   themeCfg.value = {
     name: e.target.value,
   };
+};
+
+const onMaxLinesChange = () => {
+  updateDataCfg(pivotSheetMultiLineTextDataCfg);
 };
 
 const logHandler =
@@ -594,6 +599,7 @@ const setThemeCfg = (cb: any) => {
               :options="mergedOptions"
               :setOptions="setOptions"
               :setThemeCfg="setThemeCfg"
+              :onMaxLinesChange="onMaxLinesChange"
             />
           </a-collapse-panel>
         </a-collapse>

--- a/packages/s2-vue/playground/App.vue
+++ b/packages/s2-vue/playground/App.vue
@@ -130,8 +130,10 @@ const onThemeChange = (e: any) => {
   };
 };
 
-const onMaxLinesChange = () => {
-  updateDataCfg(pivotSheetMultiLineTextDataCfg);
+const onMaxLinesChange = (maxLines: number) => {
+  updateDataCfg(
+    maxLines > 1 ? pivotSheetMultiLineTextDataCfg : pivotSheetDataCfg,
+  );
 };
 
 const logHandler =
@@ -339,7 +341,10 @@ const setThemeCfg = (cb: any) => {
               </a-button>
             </a-space>
 
-            <a-space class="filter-container">
+            <a-space
+              class="filter-container"
+              style="margin-bottom: 20px; align-items: flex-start"
+            >
               <a-switch
                 checked-children="渲染组件"
                 un-checked-children="卸载组件"
@@ -355,6 +360,7 @@ const setThemeCfg = (cb: any) => {
               <a-tooltip title="透视表层级结构">
                 <a-radio-group
                   :value="mergedOptions.hierarchyType"
+                  :disabled="sheetType === 'table'"
                   @change="
                     (e) => updateOptions({ hierarchyType: e.target.value })
                   "

--- a/packages/s2-vue/playground/components/ResizeConfig.vue
+++ b/packages/s2-vue/playground/components/ResizeConfig.vue
@@ -109,7 +109,7 @@ const resizeConfig = () =>
 
 <template>
   <div class="resize-config-container">
-    <a-space class="filter-container">
+    <a-space class="filter-container" style="margin-bottom: 20px">
       <span class="label">
         热区配置
         <a-divider type="vertical" />


### PR DESCRIPTION

| Before | After |
| ------ | ----- |
| ❌   <img width="78" height="54" alt="image" src="https://github.com/user-attachments/assets/d34d1dab-d905-4923-8a88-13bfb24bc531" />   | ✅  <img width="275" height="107" alt="image" src="https://github.com/user-attachments/assets/c855bb08-0f85-497c-892c-84eebacf9e32" />   |

