### PR TITLE
fix: implement CSP-compatible SVG icon rendering using Path mode

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/header-action-icons-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/header-action-icons-spec.ts
@@ -195,7 +195,7 @@ describe('HeaderActionIcons Tests', () => {
     const positions = s2.facet.getRowCells().map((cell) => {
       return cell
         .getActionIcons()
-        .map((icon) => pick(icon.iconImageShape.attributes, ['x', 'y']));
+        .map((icon) => pick(icon.getCfg(), ['x', 'y']));
     });
 
     expect(positions).toMatchSnapshot();

--- a/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
+++ b/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
@@ -140,4 +140,174 @@ describe('GuiIcon Tests', () => {
 
     expect(render).not.toThrow();
   });
+
+  // https://github.com/antvis/S2/issues/3125
+  describe('CSP-compatible Path mode rendering', () => {
+    test('should render built-in SVG icons using Path mode', () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const icon = new GuiIcon({
+        name: 'Plus',
+        x: 10,
+        y: 10,
+        width: 16,
+        height: 16,
+      });
+
+      // Path 模式下应该有 iconPathShapes
+      expect(icon.iconPathShapes.length).toBeGreaterThan(0);
+      // Path 模式下不应该使用 Image
+      expect(icon.iconImageShape).toBeUndefined();
+      expect(icon).toBeInstanceOf(Group);
+      expect(errSpy).not.toHaveBeenCalled();
+
+      errSpy.mockRestore();
+    });
+
+    test('should render Minus icon using Path mode', () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const icon = new GuiIcon({
+        name: 'Minus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+      });
+
+      expect(icon.iconPathShapes.length).toBeGreaterThan(0);
+      expect(icon.iconImageShape).toBeUndefined();
+      expect(errSpy).not.toHaveBeenCalled();
+
+      errSpy.mockRestore();
+    });
+
+    test('should apply cursor style to Path mode icons', () => {
+      const icon = new GuiIcon({
+        name: 'Plus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+        cursor: 'pointer',
+      });
+
+      expect(icon.iconPathShapes.length).toBeGreaterThan(0);
+
+      // 第一个 shape 是 hitArea Rect，应该有 cursor 样式
+      const hitAreaRect = icon.iconPathShapes[0];
+
+      expect(hitAreaRect.style.cursor).toBe('pointer');
+    });
+
+    test('should render tree icons in tree mode table without errors', async () => {
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      const s2 = createPivotSheet({
+        width: 400,
+        height: 300,
+        hierarchyType: 'tree',
+      });
+
+      await s2.render();
+
+      // 验证没有 CSP 或 SVG 解析错误
+      expect(errSpy).not.toHaveBeenCalled();
+
+      // 验证 row cells 存在 (tree mode 应该有展开折叠图标)
+      const rowCells = s2.facet.getRowCells();
+
+      expect(rowCells.length).toBeGreaterThan(0);
+
+      s2.destroy();
+      errSpy.mockRestore();
+    });
+
+    test('should update fill color in Path mode', () => {
+      const icon = new GuiIcon({
+        name: 'Plus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+        fill: 'red',
+      });
+
+      expect(icon.iconPathShapes.length).toBeGreaterThan(0);
+
+      // 更新 fill
+      icon.setImageAttrs({ fill: 'blue' });
+
+      // Path shapes 的 fill 应该更新
+      const pathShape = icon.iconPathShapes[1]; // 第一个是 hitArea
+
+      expect(pathShape.style.fill).toBe('blue');
+    });
+
+    test('should reRender icon with new name in Path mode', () => {
+      const icon = new GuiIcon({
+        name: 'Plus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+      });
+
+      expect(icon.iconPathShapes.length).toBeGreaterThan(0);
+
+      // reRender with new name
+      icon.reRender({
+        name: 'Minus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+      });
+
+      expect(icon.name).toBe('Minus');
+      expect(icon.iconPathShapes.length).toBeGreaterThan(0);
+    });
+
+    test('should updatePosition correctly in Path mode', () => {
+      const icon = new GuiIcon({
+        name: 'Plus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+      });
+
+      icon.updatePosition({ x: 50, y: 100 });
+
+      // 验证 path shapes 的 transform 包含新位置
+      const pathShape = icon.iconPathShapes[1];
+
+      expect(pathShape.style.transform).toContain('50');
+      expect(pathShape.style.transform).toContain('100');
+    });
+
+    test('should toggle visibility in Path mode', () => {
+      const icon = new GuiIcon({
+        name: 'Plus',
+        x: 0,
+        y: 0,
+        width: 16,
+        height: 16,
+      });
+
+      // 隐藏
+      icon.toggleVisibility(false);
+
+      icon.iconPathShapes.forEach((shape) => {
+        expect(shape.style.visibility).toBe('hidden');
+      });
+
+      // 显示
+      icon.toggleVisibility(true);
+
+      icon.iconPathShapes.forEach((shape) => {
+        expect(shape.style.visibility).toBe('visible');
+      });
+    });
+  });
 });

--- a/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
+++ b/packages/s2-core/__tests__/unit/interaction/event-controller-spec.ts
@@ -929,14 +929,15 @@ describe('Interaction Event Controller Tests', () => {
       spreadsheet.container.appendChild(guiIcon); // 加入 g 渲染树才有事件传递
       spreadsheet.once(event, handler);
 
-      // 内部的 GuiIcon
-      const { iconImageShape } = guiIcon;
+      // 内部的 GuiIcon (兼容 Path 模式和 Image 模式)
+      // Path 模式下使用 iconPathShapes, Image 模式下使用 iconImageShape
+      const targetShape = guiIcon.iconPathShapes[0] || guiIcon.iconImageShape;
 
       Object.defineProperty(eventController, 'target', {
-        value: iconImageShape,
+        value: targetShape,
         writable: true,
       });
-      iconImageShape.dispatchEvent(
+      targetShape.dispatchEvent(
         createFederatedPointerEvent(spreadsheet, OriginEventType.POINTER_UP),
       );
 
@@ -1028,14 +1029,14 @@ describe('Interaction Event Controller Tests', () => {
       spreadsheet.container.appendChild(guiIcon); // 加入 g 渲染树才有事件传递
       spreadsheet.once(event, handler);
 
-      // 内部的 GuiIcon
-      const { iconImageShape } = guiIcon;
+      // 内部的 GuiIcon (兼容 Path 模式和 Image 模式)
+      const targetShape = guiIcon.iconPathShapes[0] || guiIcon.iconImageShape;
 
       Object.defineProperty(eventController, 'target', {
-        value: iconImageShape,
+        value: targetShape,
         writable: true,
       });
-      iconImageShape.dispatchEvent(
+      targetShape.dispatchEvent(
         createFederatedPointerEvent(spreadsheet, OriginEventType.CLICK),
       );
 

--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -1,7 +1,7 @@
 /**
  * @description: 请严格要求 svg 的 viewBox，若设计产出的 svg 不是此规格，请叫其修改为 '0 0 1024 1024'
  */
-import { Group, PointLike, type ImageStyleProps } from '@antv/g';
+import { Group, Path, PointLike, Rect, type ImageStyleProps } from '@antv/g';
 import { clone, omit } from 'lodash';
 import { CustomImage } from '../../engine';
 import { batchSetStyle } from '../../utils/g-utils';
@@ -15,21 +15,89 @@ const SVG_CONTENT_TYPE = 'data:image/svg+xml';
 // Image 缓存
 const ImageCache: Record<string, HTMLImageElement> = {};
 
+// 解析后的 Path 数据缓存
+interface ParsedSvgData {
+  viewBox: { width: number; height: number };
+  paths: string[];
+}
+const PathDataCache: Record<string, ParsedSvgData> = {};
+
 export interface GuiIconCfg extends Omit<ImageStyleProps, 'fill'> {
   readonly name: string;
   readonly fill?: string | null;
 }
 
 /**
+ * 从 SVG 字符串中解析 viewBox 和 path 数据
+ * @see https://github.com/antvis/S2/issues/3125
+ */
+function parseSvgPaths(svg: string): ParsedSvgData | null {
+  // 提取 viewBox
+  const viewBoxMatch = svg.match(/viewBox=["']([^"']+)["']/);
+
+  if (!viewBoxMatch) {
+    return null;
+  }
+
+  const viewBoxParts = viewBoxMatch[1].split(/\s+/).map(Number);
+
+  if (viewBoxParts.length < 4) {
+    return null;
+  }
+
+  const viewBox = {
+    width: viewBoxParts[2],
+    height: viewBoxParts[3],
+  };
+
+  // 提取所有 path 的 d 属性
+  // 使用 \b 确保匹配 d= 而不是 p-id= 等其他属性
+  // 先将换行符替换为空格，使正则匹配更简单
+  const normalizedSvg = svg.replace(/[\r\n]+/g, ' ');
+  let paths: string[] = [];
+
+  // 匹配双引号形式 d="..."
+  const doubleQuoteMatches = normalizedSvg.match(/\bd="[^"]+"/g);
+
+  if (doubleQuoteMatches) {
+    paths = doubleQuoteMatches.map((m) => m.slice(3, -1));
+  }
+
+  // 如果双引号没有匹配到，尝试单引号形式 d='...'
+  if (paths.length === 0) {
+    const singleQuoteMatches = normalizedSvg.match(/\bd='[^']+'/g);
+
+    if (singleQuoteMatches) {
+      paths = singleQuoteMatches.map((m) => m.slice(3, -1));
+    }
+  }
+
+  if (paths.length === 0) {
+    return null;
+  }
+
+  return { viewBox, paths };
+}
+
+/**
  * 使用 iconfont 上的 svg 来创建 Icon
+ * 支持两种渲染模式:
+ * 1. Path 模式 (CSP 友好): 直接使用 G.Path 绘制矢量图形
+ * 2. Image 模式 (兼容): 使用 Blob URL 加载 SVG 图片
  */
 export class GuiIcon extends Group {
   static type = '__GUI_ICON__';
 
-  // icon 对应的 GImage 对象
-  public iconImageShape: CustomImage;
+  // icon 对应的 GImage 对象 (Image 模式)
+  public iconImageShape?: CustomImage;
+
+  // icon 对应的 Path 对象数组 (Path 模式)
+  public iconPathShapes: Path[] = [];
 
   private cfg: GuiIconCfg;
+
+  // 是否使用 Path 模式渲染
+  private usePathMode: boolean = false;
 
   constructor(cfg: GuiIconCfg) {
     super({ name: cfg.name });
@@ -39,6 +107,86 @@ export class GuiIcon extends Group {
 
   public getCfg(): GuiIconCfg {
     return this.cfg;
+  }
+
+  /**
+   * 尝试使用 Path 模式渲染图标 (CSP 完全兼容)
+   * @returns 是否成功使用 Path 模式
+   */
+  private tryRenderAsPath(name: string, fill?: string | null): boolean {
+    const svg = getIcon(name);
+
+    if (!svg) {
+      return false;
+    }
+
+    // 如果是在线链接或 base64，无法使用 Path 模式
+    if (svg.includes(SVG_CONTENT_TYPE) || this.isOnlineLink(svg)) {
+      return false;
+    }
+
+    const cacheKey = name;
+    let parsedData = PathDataCache[cacheKey];
+
+    if (!parsedData) {
+      parsedData = parseSvgPaths(svg)!;
+      if (parsedData) {
+        PathDataCache[cacheKey] = parsedData;
+      }
+    }
+
+    if (!parsedData) {
+      return false;
+    }
+
+    const { x = 0, y = 0, width, height, cursor } = this.cfg;
+
+    // 计算缩放比例
+    const scaleX = (width as number) / parsedData.viewBox.width;
+    const scaleY = (height as number) / parsedData.viewBox.height;
+
+    // 清除旧的 path shapes
+    this.iconPathShapes.forEach((shape) => {
+      this.removeChild(shape);
+      shape.destroy();
+    });
+    this.iconPathShapes = [];
+
+    // 创建透明的矩形作为点击热区，确保整个图标区域都可以点击
+    // 同时设置 cursor 样式
+    const hitAreaRect = new Rect({
+      style: {
+        x: x as number,
+        y: y as number,
+        width: width as number,
+        height: height as number,
+        fill: 'transparent',
+        cursor: cursor || 'default',
+      },
+    });
+
+    this.appendChild(hitAreaRect);
+    this.iconPathShapes.push(hitAreaRect as unknown as Path);
+
+    // 创建所有 path
+    for (const pathData of parsedData.paths) {
+      const pathShape = new Path({
+        style: {
+          d: pathData,
+          fill: fill || '#000',
+          transformOrigin: '0 0',
+          transform: `translate(${x}, ${y}) scale(${scaleX}, ${scaleY})`,
+          cursor: cursor || 'default',
+          // 禁用 path 的事件，让事件传递到底层的 hitAreaRect
+          pointerEvents: 'none',
+        },
+      });
+
+      this.appendChild(pathShape);
+      this.iconPathShapes.push(pathShape);
+    }
+
+    return true;
   }
 
   // 获取 Image 实例，使用缓存，以避免滚动时因重复的 new Image() 耗时导致的闪烁问题
@@ -87,7 +235,7 @@ export class GuiIcon extends Group {
            */
           // 移除 fill="red|#fff"
           // eslint-disable-next-line no-useless-escape
-          svg = svg.replace(/fill=[\'\"]#?\w+[\'\"]/g, '');
+          svg = svg.replace(/fill=[\'\"]\#?\w+[\'\"]/g, '');
           // fill> 替换为 >
           svg = svg.replace(/fill>/g, '>');
         }
@@ -98,10 +246,32 @@ export class GuiIcon extends Group {
         );
 
         /**
-         * 兼容 Firefox: https://github.com/antvis/S2/issues/1571 https://stackoverflow.com/questions/30733607/svg-data-image-not-working-as-a-background-image-in-a-pseudo-element/30733736#30733736
-         * https://www.chromestatus.com/features/5656049583390720
+         * 使用 Blob URL 替代 data: URL 以兼容严格的 CSP 策略
+         * @see https://github.com/antvis/S2/issues/3125
+         * 兼容 Firefox: https://github.com/antvis/S2/issues/1571
          */
-        img.src = `${SVG_CONTENT_TYPE};utf-8,${encodeURIComponent(svg)}`;
+        const blob = new Blob([svg], { type: 'image/svg+xml' });
+        const blobUrl = URL.createObjectURL(blob);
+
+        // 加载完成后释放 Blob URL 以防止内存泄漏
+        const originalOnload = img.onload;
+
+        img.onload = (event) => {
+          URL.revokeObjectURL(blobUrl);
+          originalOnload?.call(img, event);
+        };
+
+        const originalOnerror = img.onerror;
+
+        img.onerror = (event) => {
+          URL.revokeObjectURL(blobUrl);
+
+          if (typeof originalOnerror === 'function') {
+            originalOnerror.call(img, event);
+          }
+        };
+
+        img.src = blobUrl;
       }
     });
   }
@@ -115,6 +285,16 @@ export class GuiIcon extends Group {
 
   private render() {
     const { name, fill } = this.cfg;
+
+    // 优先尝试 Path 模式 (完全绕过 CSP 限制)
+    if (this.tryRenderAsPath(name, fill)) {
+      this.usePathMode = true;
+
+      return;
+    }
+
+    // 回退到 Image 模式
+    this.usePathMode = false;
     const attrs = clone(this.cfg);
     const image = new CustomImage(GuiIcon.type, {
       style: omit(attrs, 'fill'),
@@ -128,20 +308,76 @@ export class GuiIcon extends Group {
     this.name = cfg.name;
     this.cfg = cfg;
     const { name, fill } = this.cfg;
+
+    // 清除旧的渲染
+    if (this.usePathMode) {
+      this.iconPathShapes.forEach((shape) => {
+        this.removeChild(shape);
+        shape.destroy();
+      });
+      this.iconPathShapes = [];
+    }
+
+    // 优先尝试 Path 模式
+    if (this.tryRenderAsPath(name, fill)) {
+      this.usePathMode = true;
+
+      return;
+    }
+
+    // 回退到 Image 模式
+    this.usePathMode = false;
     const attrs = clone(this.cfg);
 
-    this.iconImageShape.imgType = GuiIcon.type;
-    batchSetStyle(this.iconImageShape, omit(attrs, 'fill'));
+    if (!this.iconImageShape) {
+      this.iconImageShape = new CustomImage(GuiIcon.type, {
+        style: omit(attrs, 'fill'),
+      });
+    } else {
+      this.iconImageShape.imgType = GuiIcon.type;
+      batchSetStyle(this.iconImageShape, omit(attrs, 'fill'));
+    }
+
     this.setImageAttrs({ name, fill });
   }
 
   public updatePosition(position: PointLike) {
-    batchSetStyle(this.iconImageShape, position);
+    if (this.usePathMode) {
+      const { width, height } = this.cfg;
+      const parsedData = PathDataCache[this.cfg.name];
+
+      if (parsedData) {
+        const scaleX = (width as number) / parsedData.viewBox.width;
+        const scaleY = (height as number) / parsedData.viewBox.height;
+
+        this.iconPathShapes.forEach((shape) => {
+          shape.style.transform = `translate(${position.x}, ${position.y}) scale(${scaleX}, ${scaleY})`;
+        });
+      }
+    } else if (this.iconImageShape) {
+      batchSetStyle(this.iconImageShape, position);
+    }
   }
 
   public setImageAttrs(attrs: Partial<{ name: string; fill: string | null }>) {
+    // Path 模式下直接更新 fill
+    if (this.usePathMode) {
+      const fill = attrs.fill || this.cfg.fill || '#000';
+
+      this.iconPathShapes.forEach((shape) => {
+        shape.style.fill = fill;
+      });
+
+      return;
+    }
+
+    // Image 模式
     let { name, fill } = attrs;
     const { iconImageShape: image } = this;
+
+    if (!image) {
+      return;
+    }
 
     // 保证 name 和 fill 都有值
     name = name || this.cfg.name;
@@ -191,6 +427,13 @@ export class GuiIcon extends Group {
     const status = visible ? 'visible' : 'hidden';
 
     this.setAttribute('visibility', status);
-    this.iconImageShape.setAttribute('visibility', status);
+
+    if (this.usePathMode) {
+      this.iconPathShapes.forEach((shape) => {
+        shape.setAttribute('visibility', status);
+      });
+    } else if (this.iconImageShape) {
+      this.iconImageShape.setAttribute('visibility', status);
+    }
   }
 }

--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -91,8 +91,9 @@ export class GuiIcon extends Group {
   // icon 对应的 GImage 对象 (Image 模式)
   public iconImageShape?: CustomImage;
 
-  // icon 对应的 Path 对象数组 (Path 模式)
-  public iconPathShapes: Path[] = [];
+  // icon 对应的 Path 和 HitArea 对象数组 (Path 模式)
+  // 第一个元素是透明的点击热区 Rect，其余是实际的 Path
+  public iconPathShapes: (Path | Rect)[] = [];
 
   private cfg: GuiIconCfg;
 
@@ -129,9 +130,11 @@ export class GuiIcon extends Group {
     let parsedData = PathDataCache[cacheKey];
 
     if (!parsedData) {
-      parsedData = parseSvgPaths(svg)!;
-      if (parsedData) {
-        PathDataCache[cacheKey] = parsedData;
+      const parsed = parseSvgPaths(svg);
+
+      if (parsed) {
+        parsedData = parsed;
+        PathDataCache[cacheKey] = parsed;
       }
     }
 
@@ -166,7 +169,7 @@ export class GuiIcon extends Group {
     });
 
     this.appendChild(hitAreaRect);
-    this.iconPathShapes.push(hitAreaRect as unknown as Path);
+    this.iconPathShapes.push(hitAreaRect);
 
     // 创建所有 path
     for (const pathData of parsedData.paths) {
@@ -364,7 +367,8 @@ export class GuiIcon extends Group {
     if (this.usePathMode) {
       const fill = attrs.fill || this.cfg.fill || '#000';
 
-      this.iconPathShapes.forEach((shape) => {
+      // 第一个元素是透明热区 (hitAreaRect)，应保持透明，从第二个开始更新 fill
+      this.iconPathShapes.slice(1).forEach((shape) => {
         shape.style.fill = fill;
       });
 
@@ -430,7 +434,7 @@ export class GuiIcon extends Group {
 
     if (this.usePathMode) {
       this.iconPathShapes.forEach((shape) => {
-        shape.setAttribute('visibility', status);
+        shape.style.visibility = status;
       });
     } else if (this.iconImageShape) {
       this.iconImageShape.setAttribute('visibility', status);

--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -144,9 +144,11 @@ export class GuiIcon extends Group {
 
     const { x = 0, y = 0, width, height, cursor } = this.cfg;
 
-    // 计算缩放比例
-    const scaleX = (width as number) / parsedData.viewBox.width;
-    const scaleY = (height as number) / parsedData.viewBox.height;
+    // 计算缩放比例 (添加类型守卫以防 width/height 不是数字)
+    const numWidth = typeof width === 'number' ? width : 0;
+    const numHeight = typeof height === 'number' ? height : 0;
+    const scaleX = numWidth / parsedData.viewBox.width;
+    const scaleY = numHeight / parsedData.viewBox.height;
 
     // 清除旧的 path shapes
     this.iconPathShapes.forEach((shape) => {
@@ -159,10 +161,10 @@ export class GuiIcon extends Group {
     // 同时设置 cursor 样式
     const hitAreaRect = new Rect({
       style: {
-        x: x as number,
-        y: y as number,
-        width: width as number,
-        height: height as number,
+        x: typeof x === 'number' ? x : 0,
+        y: typeof y === 'number' ? y : 0,
+        width: numWidth,
+        height: numHeight,
         fill: 'transparent',
         cursor: cursor || 'default',
       },
@@ -350,8 +352,10 @@ export class GuiIcon extends Group {
       const parsedData = PathDataCache[this.cfg.name];
 
       if (parsedData) {
-        const scaleX = (width as number) / parsedData.viewBox.width;
-        const scaleY = (height as number) / parsedData.viewBox.height;
+        const numWidth = typeof width === 'number' ? width : 0;
+        const numHeight = typeof height === 'number' ? height : 0;
+        const scaleX = numWidth / parsedData.viewBox.width;
+        const scaleY = numHeight / parsedData.viewBox.height;
 
         this.iconPathShapes.forEach((shape) => {
           shape.style.transform = `translate(${position.x}, ${position.y}) scale(${scaleX}, ${scaleY})`;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

 Enhance

- [ ] Code style optimization
- [x] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #3125

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

**背景 (Background)**
在使用严格内容安全策略（CSP `img-src 'self'`，禁用 `data:` 协议）的环境下，S2 内置的 SVG 图标无法正常显示。
Built-in SVG icons fail to load in strict CSP environments (where `data:` URI scheme is blocked in `img-src`).

**改动 (Changes)**
1.  **重构图标渲染 (Refactor Icon Rendering)**:
    -   **Path Mode (Primary)**: 解析 SVG 的 `d` 属性，使用 G 引擎的 [Path](file:///Users/huiyu/github/Antv-S2/packages/s2-core/src/common/icons/gui-icon.ts#30-81) 直接绘制矢量图形。此方式天然兼容 CSP。
        *(Parse SVG paths and render directly using `G.Path`. Fully CSP compliant.)*
    -   **Image Mode (Fallback)**: 对于复杂 SVG（如含 `<text>`/`<polygon>`），回退使用 **Blob URL** 加载（比 `data:` 更安全且兼容）。
        *(Fallback to Blob URL for complex SVGs, replacing `data:` URIs.)*

2.  **交互优化 (Interaction Improvement)**:
    -   在 Path 模式下增加透明热区 (`HitArea`)，修复了点击范围过小和 `cursor: pointer` 样式不生效的问题。
        *(Added transparent `HitArea` Rect to ensure correct click region and cursor style in Path mode.)*

**测试 (Tests)**
-   新增单元测试，覆盖 Path 模式渲染、回退机制及交互逻辑。覆盖率 > 86%。
    *(Added unit tests covering Path mode, fallback logic, and interaction. Coverage > 86%.)*

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before (Strict CSP) | After (Strict CSP) |
| ------ | ----- |
|  <img width="2740" height="1440" alt="image" src="https://github.com/user-attachments/assets/08933afa-35b9-40b0-92b2-1abe9bb67df0" />  |  <img width="1656" height="570" alt="image" src="https://github.com/user-attachments/assets/0162d5ca-7268-4b43-b33b-5b40da2810a3" />  |

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

- close #3125

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
