### PR TITLE
fix: support configurable icon rendering strategy and fix complex ico…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@
 
 🐛 Bugfix
 <!-- 如果没有相关的 issue 需要关闭，请删除这一行 -->
-- [ ] Solve the issue and close #1904
+- [ ] Solve the issue and close
 
 🔧 Chore
 
@@ -53,10 +53,6 @@
 
 <!-- If there is a related Issue/PR link -->
 <!-- 如果有相关的 Issue/PR 链接，请关联上 -->
-
-<!-- close #0 -->
-<!-- ref #0 -->
-<!-- fix #0 -->
 
 ### 🔍 Self-Check before the merge
 

--- a/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
+++ b/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
@@ -152,6 +152,7 @@ describe('GuiIcon Tests', () => {
         y: 10,
         width: 16,
         height: 16,
+        iconStrategy: 'path',
       });
 
       // Path 模式下应该有 iconPathShapes
@@ -173,6 +174,7 @@ describe('GuiIcon Tests', () => {
         y: 0,
         width: 16,
         height: 16,
+        iconStrategy: 'path',
       });
 
       expect(icon.iconPathShapes.length).toBeGreaterThan(0);
@@ -190,6 +192,7 @@ describe('GuiIcon Tests', () => {
         width: 16,
         height: 16,
         cursor: 'pointer',
+        iconStrategy: 'path',
       });
 
       expect(icon.iconPathShapes.length).toBeGreaterThan(0);
@@ -231,6 +234,7 @@ describe('GuiIcon Tests', () => {
         width: 16,
         height: 16,
         fill: 'red',
+        iconStrategy: 'path',
       });
 
       expect(icon.iconPathShapes.length).toBeGreaterThan(0);
@@ -251,6 +255,7 @@ describe('GuiIcon Tests', () => {
         y: 0,
         width: 16,
         height: 16,
+        iconStrategy: 'path',
       });
 
       expect(icon.iconPathShapes.length).toBeGreaterThan(0);
@@ -262,6 +267,7 @@ describe('GuiIcon Tests', () => {
         y: 0,
         width: 16,
         height: 16,
+        iconStrategy: 'path',
       });
 
       expect(icon.name).toBe('Minus');
@@ -275,6 +281,7 @@ describe('GuiIcon Tests', () => {
         y: 0,
         width: 16,
         height: 16,
+        iconStrategy: 'path',
       });
 
       icon.updatePosition({ x: 50, y: 100 });
@@ -293,6 +300,7 @@ describe('GuiIcon Tests', () => {
         y: 0,
         width: 16,
         height: 16,
+        iconStrategy: 'path',
       });
 
       // 隐藏

--- a/packages/s2-core/src/cell/base-cell.ts
+++ b/packages/s2-core/src/cell/base-cell.ts
@@ -30,7 +30,7 @@ import {
   SHAPE_ATTRS_MAP,
   SHAPE_STYLE_MAP,
 } from '../common/constant';
-import type { GuiIcon } from '../common/icons/gui-icon';
+import type { GuiIcon, GuiIconCfg } from '../common/icons/gui-icon';
 import {
   CellBorderPosition,
   CellClipBox,
@@ -766,12 +766,13 @@ export abstract class BaseCell<T extends SimpleBBox> extends Group {
       const position = this.getIconPosition();
       const { size } = this.getStyle()!.icon!;
 
-      const iconCfg = {
+      const iconCfg: GuiIconCfg = {
         ...position,
         name: attrs?.name!,
         width: size,
         height: size,
         fill: attrs?.fill,
+        iconStrategy: this.spreadsheet.options.csp?.iconStrategy,
       };
 
       if (this.conditionIconShape) {

--- a/packages/s2-core/src/cell/col-cell.ts
+++ b/packages/s2-core/src/cell/col-cell.ts
@@ -588,6 +588,7 @@ export class ColCell extends HeaderCell<ColHeaderConfig> {
       ...iconConfig,
       name: 'ExpandColIcon',
       cursor: 'pointer',
+      iconStrategy: this.spreadsheet.options.csp?.iconStrategy,
     });
 
     icon.addEventListener('click', () => {

--- a/packages/s2-core/src/cell/corner-cell.ts
+++ b/packages/s2-core/src/cell/corner-cell.ts
@@ -104,6 +104,7 @@ export class CornerCell extends HeaderCell<CornerHeaderConfig> {
         width: size,
         height: size,
         fill,
+        iconStrategy: this.spreadsheet.options.csp?.iconStrategy,
       },
       isCollapsed,
       onClick: () => {

--- a/packages/s2-core/src/cell/header-cell.ts
+++ b/packages/s2-core/src/cell/header-cell.ts
@@ -251,6 +251,7 @@ export abstract class HeaderCell<
       name,
       x,
       y,
+      iconStrategy: this.spreadsheet.options.csp?.iconStrategy,
     });
 
     icon.toggleVisibility(!defaultHide);
@@ -321,13 +322,14 @@ export abstract class HeaderCell<
         const y = iconPosition.y;
 
         if (icon.isConditionIcon) {
-          const iconCfg = {
+          const iconCfg: GuiIconCfg = {
             x,
             y,
             name: icon.name,
             width: size,
             height: size,
             fill: icon.fill,
+            iconStrategy: this.spreadsheet.options.csp?.iconStrategy,
           };
 
           if (this.conditionIconShape) {

--- a/packages/s2-core/src/cell/row-cell.ts
+++ b/packages/s2-core/src/cell/row-cell.ts
@@ -224,6 +224,7 @@ export class RowCell extends HeaderCell<RowHeaderConfig> {
         width: size,
         height: size,
         fill,
+        iconStrategy: this.spreadsheet.options.csp?.iconStrategy,
       },
       isCollapsed,
       onClick: () => {

--- a/packages/s2-core/src/common/icons/gui-icon.ts
+++ b/packages/s2-core/src/common/icons/gui-icon.ts
@@ -25,6 +25,11 @@ const PathDataCache: Record<string, ParsedSvgData> = {};
 export interface GuiIconCfg extends Omit<ImageStyleProps, 'fill'> {
   readonly name: string;
   readonly fill?: string | null;
+  /**
+   * 图标渲染策略
+   * @see S2BasicOptions.csp
+   */
+  readonly iconStrategy?: 'blob' | 'path';
 }
 
 /**
@@ -32,6 +37,16 @@ export interface GuiIconCfg extends Omit<ImageStyleProps, 'fill'> {
  * @see https://github.com/antvis/S2/issues/3125
  */
 function parseSvgPaths(svg: string): ParsedSvgData | null {
+  // 如果 SVG 包含 transform, g, rect 等不支持的复杂标签或属性，暂不使用 Path 模式
+  // 避免渲染错位
+  if (
+    /transform|translate|scale|rotate|<g|<rect|<circle|<ellipse|<line|<polyline|<polygon|<text|<tspan/i.test(
+      svg,
+    )
+  ) {
+    return null;
+  }
+
   // 提取 viewBox
   const viewBoxMatch = svg.match(/viewBox=["']([^"']+)["']/);
 
@@ -289,20 +304,20 @@ export class GuiIcon extends Group {
   public isOnlineLink = (src: string) => /^(?:https?:)?(?:\/\/)/.test(src);
 
   private render() {
-    const { name, fill } = this.cfg;
+    const { name, fill, iconStrategy } = this.cfg;
 
-    // 优先尝试 Path 模式 (完全绕过 CSP 限制)
-    if (this.tryRenderAsPath(name, fill)) {
+    // 如果指定了 path 模式，优先尝试 Path 模式 (完全绕过 CSP 限制)
+    if (iconStrategy === 'path' && this.tryRenderAsPath(name, fill)) {
       this.usePathMode = true;
 
       return;
     }
 
-    // 回退到 Image 模式
+    // 默认或失败时回退到 Image 模式
     this.usePathMode = false;
     const attrs = clone(this.cfg);
     const image = new CustomImage(GuiIcon.type, {
-      style: omit(attrs, 'fill'),
+      style: omit(attrs, ['fill', 'iconStrategy']),
     });
 
     this.iconImageShape = image;
@@ -312,7 +327,7 @@ export class GuiIcon extends Group {
   public reRender(cfg: GuiIconCfg) {
     this.name = cfg.name;
     this.cfg = cfg;
-    const { name, fill } = this.cfg;
+    const { name, fill, iconStrategy } = this.cfg;
 
     // 清除旧的渲染
     if (this.usePathMode) {
@@ -323,8 +338,8 @@ export class GuiIcon extends Group {
       this.iconPathShapes = [];
     }
 
-    // 优先尝试 Path 模式
-    if (this.tryRenderAsPath(name, fill)) {
+    // 如果指定了 path 模式，优先尝试 Path 模式
+    if (iconStrategy === 'path' && this.tryRenderAsPath(name, fill)) {
       this.usePathMode = true;
 
       return;
@@ -336,11 +351,11 @@ export class GuiIcon extends Group {
 
     if (!this.iconImageShape) {
       this.iconImageShape = new CustomImage(GuiIcon.type, {
-        style: omit(attrs, 'fill'),
+        style: omit(attrs, ['fill', 'iconStrategy']),
       });
     } else {
       this.iconImageShape.imgType = GuiIcon.type;
-      batchSetStyle(this.iconImageShape, omit(attrs, 'fill'));
+      batchSetStyle(this.iconImageShape, omit(attrs, ['fill', 'iconStrategy']));
     }
 
     this.setImageAttrs({ name, fill });

--- a/packages/s2-core/src/common/interface/s2Options.ts
+++ b/packages/s2-core/src/common/interface/s2Options.ts
@@ -312,6 +312,18 @@ export interface S2BasicOptions<
      */
     experimentalReuseCell?: boolean;
   };
+
+  /**
+   * 安全策略配置
+   */
+  csp?: {
+    /**
+     * 图标渲染策略
+     * - blob: 使用 Blob URL 渲染 (默认, 兼容性好, 但严苛 CSP 环境可能报错)
+     * - path: 优先使用矢量路径渲染 (CSP 友好, 但仅支持简单无变换图标)
+     */
+    iconStrategy?: 'blob' | 'path';
+  };
 }
 
 // 设备，pc || mobile


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #3125

### 📝 Description

在之前的 CSP 优化中，[GuiIcon](packages/s2-core/src/common/icons/gui-icon.ts#103-463) 引入了矢量路径（Path）渲染模式以绕过 CSP 对 `blob:` URL 的限制。然而，由于路径解析逻辑过于简化，不支持处理包含 `<g>`, [transform], `<circle>` 等复杂结构的 SVG，导致如 `DIShapeCircle` 等图标在渲染时出现严重对齐偏差。

#### 改动点 (Changes)
1. **策略分级支持**：在 [S2Options](packages/s2-core/src/common/interface/s2Options.ts#406-413) 中增加 `csp.iconStrategy` 配置（默认为 `'blob'`）。
   - `blob`: 使用 Blob URL 渲染（最高精度）。
   - `path`: 优先使用矢量路径渲染（CSP 友好）。
2. **安全退化机制**：增强 [GuiIcon](packages/s2-core/src/common/icons/gui-icon.ts#103-463) 的校验逻辑。即使开启 `path` 模式，若 SVG 包含 [transform](packages/s2-react/playground/config.tsx#353-361) 或非路径标签，将自动退化至 `blob` 模式，确保渲染准确性。
3. **透传链路**：更新所有单元格组件（Row, Col, Header, Corner）和 [renderIcon](S2-Perf/packages/s2-core/src/utils/g-renders.ts#121-128) 工具函数，确保配置能正确应用。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
