### PR TITLE
fix: ssr 兼容高版本node

### DIFF
--- a/packages/s2-ssr/package.json
+++ b/packages/s2-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/s2-ssr",
-  "version": "0.0.2",
+  "version": "0.1.1-alpha.1",
   "description": "Support SSR for S2",
   "keywords": [
     "antv",

--- a/packages/s2-ssr/package.json
+++ b/packages/s2-ssr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/s2-ssr",
-  "version": "0.1.1-alpha.1",
+  "version": "0.1.1",
   "description": "Support SSR for S2",
   "keywords": [
     "antv",

--- a/packages/s2-ssr/src/env.ts
+++ b/packages/s2-ssr/src/env.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 // @ts-nocheck - This file contains intentionally minimal mock implementations
 /**
  * Node.js environment setup for SSR
@@ -30,33 +31,49 @@ function setupModuleExtensions(): void {
   }
 }
 
-/**
- * Setup browser-like globals in Node.js environment
- */
-function setupBrowserGlobals(): void {
-  const g = globalThis as typeof globalThis & {
-    navigator: unknown;
-    document: unknown;
-    window: unknown;
-    HTMLElement: unknown;
-    HTMLCanvasElement: unknown;
-    HTMLImageElement: unknown;
-    requestAnimationFrame: unknown;
-    cancelAnimationFrame: unknown;
-    performance: unknown;
-    ResizeObserver: unknown;
-    MutationObserver: unknown;
-    PointerEvent: unknown;
-    CustomEvent: unknown;
-  };
+type GlobalEnv = typeof globalThis & {
+  navigator: unknown;
+  document: unknown;
+  window: unknown;
+  HTMLElement: unknown;
+  HTMLCanvasElement: unknown;
+  HTMLImageElement: unknown;
+  requestAnimationFrame: unknown;
+  cancelAnimationFrame: unknown;
+  performance: unknown;
+  ResizeObserver: unknown;
+  MutationObserver: unknown;
+  PointerEvent: unknown;
+  CustomEvent: unknown;
+};
 
+function setupNavigator(g: GlobalEnv): void {
   // Mock navigator
-  g.navigator = {
+  // Node.js >= 21 introduces a global `navigator` object with only getters.
+  // We need to gracefully handle it or override it securely.
+  const mockNavigator = {
     userAgent: 'node',
     language: 'en-US',
     platform: 'node',
   };
 
+  try {
+    Object.defineProperty(g, 'navigator', {
+      value: mockNavigator,
+      writable: true,
+      configurable: true,
+    });
+  } catch (e) {
+    // If it still fails, just fallback to direct assignment and catch
+    try {
+      g.navigator = mockNavigator;
+    } catch (err) {
+      // Ignore
+    }
+  }
+}
+
+function setupDocument(g: GlobalEnv): void {
   // Mock document (before window so window.document works)
   g.document = {
     createElement: (tag: string) => ({
@@ -102,7 +119,9 @@ function setupBrowserGlobals(): void {
     querySelector: () => null,
     querySelectorAll: () => [],
   };
+}
 
+function setupWindowAndClasses(g: GlobalEnv): void {
   // Mock window (after document)
   g.window = {
     navigator: g.navigator,
@@ -125,7 +144,9 @@ function setupBrowserGlobals(): void {
   g.HTMLElement = class HTMLElement {};
   g.HTMLCanvasElement = class HTMLCanvasElement {};
   g.HTMLImageElement = class HTMLImageElement {};
+}
 
+function setupAPIsAndEvents(g: GlobalEnv): void {
   // Mock animation frame APIs
   g.requestAnimationFrame = (cb: FrameRequestCallback) =>
     setTimeout(cb as unknown as () => void, 16);
@@ -171,6 +192,18 @@ function setupBrowserGlobals(): void {
       this.detail = opts?.detail;
     }
   };
+}
+
+/**
+ * Setup browser-like globals in Node.js environment
+ */
+function setupBrowserGlobals(): void {
+  const g = globalThis as GlobalEnv;
+
+  setupNavigator(g);
+  setupDocument(g);
+  setupWindowAndClasses(g);
+  setupAPIsAndEvents(g);
 }
 
 /**

--- a/packages/s2-ssr/src/env.ts
+++ b/packages/s2-ssr/src/env.ts
@@ -134,9 +134,8 @@ function setupWindowAndClasses(g: GlobalEnv): void {
     }),
     setTimeout: globalThis.setTimeout,
     clearTimeout: globalThis.clearTimeout,
-    requestAnimationFrame: (cb: FrameRequestCallback) =>
-      setTimeout(cb as unknown as () => void, 16),
-    cancelAnimationFrame: (id: number) => clearTimeout(id),
+    requestAnimationFrame: g.requestAnimationFrame,
+    cancelAnimationFrame: g.cancelAnimationFrame,
     location: { href: 'http://localhost/' },
   };
 
@@ -202,8 +201,8 @@ function setupBrowserGlobals(): void {
 
   setupNavigator(g);
   setupDocument(g);
-  setupWindowAndClasses(g);
   setupAPIsAndEvents(g);
+  setupWindowAndClasses(g);
 }
 
 /**


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

 s2-ssr 内部使用了类似 jsdom 或手写的全局挂载逻辑来模拟浏览器环境（比如直接通过赋值 global.navigator = { userAgent: 'node' }）。 但是在 Node.js v21.0.0 之后，Node 原生实现了全局的 navigator 对象，并且定义为一个只读（getter-only）属性。所以在高版本的 Node.js（比如 v24.11.1）下，任何试图覆写 global.navigator 的代码都会抛出上述类型错误。

目前的影响： 只要使用高版本 Node.js（>= 21），无论是 0.0.2 还是 0.1.0 版本的 @antv/s2-ssr 都无法直接运行其 export CLI。这个需要 @antv/s2-ssr 本身发布新版本修复环境初始化的逻辑（比如改成 Object.defineProperty(global, 'navigator', { ... }) 或者绕过只读限制）。
