### PR TITLE
fix: 明细表导出序号列 formatter 不生效

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-3332-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-3332-spec.ts
@@ -1,0 +1,103 @@
+/**
+ * @description spec for issue #3332
+ * https://github.com/antvis/S2/issues/3332
+ * 明细表导出不支持序号的格式化
+ */
+import { TableSheet } from '@/sheet-type';
+import { asyncGetAllPlainData } from '@/utils';
+import { slice } from 'lodash';
+import { data as originData } from 'tests/data/mock-dataset.json';
+import { LINE_SEPARATOR, SERIES_NUMBER_FIELD, TAB_SEPARATOR } from '../../src';
+import { assembleDataCfg, assembleOptions } from '../util';
+import { getContainer } from '../util/helpers';
+
+describe('TableSheet Export Series Number Formatter Tests', () => {
+  const formatter = (value: number | string) =>
+    String.fromCharCode(96 + Number(value));
+
+  const createSheetWithSeriesNumberFormatter = async () => {
+    const s2 = new TableSheet(
+      getContainer(),
+      assembleDataCfg({
+        meta: [
+          {
+            field: SERIES_NUMBER_FIELD,
+            name: '序号',
+            formatter,
+          },
+        ],
+        fields: {
+          columns: ['province', 'city', 'type', 'sub_type', 'number'],
+        },
+        data: slice(originData, 0, 5),
+      }),
+      assembleOptions({
+        seriesNumber: {
+          enable: true,
+        },
+      }),
+    );
+
+    await s2.render();
+
+    return s2;
+  };
+
+  // https://github.com/antvis/S2/issues/3332
+  test('should apply series number formatter when exporting with formatOptions: true', async () => {
+    const s2 = await createSheetWithSeriesNumberFormatter();
+
+    const data = await asyncGetAllPlainData({
+      sheetInstance: s2,
+      split: TAB_SEPARATOR,
+      formatOptions: true,
+    });
+
+    const rows = data.split(LINE_SEPARATOR);
+
+    // 序号列应为格式化后的字母 a, b, c, d, e
+    for (let i = 1; i < rows.length; i++) {
+      const cols = rows[i].split(TAB_SEPARATOR);
+
+      expect(cols[0]).toBe(formatter(i));
+    }
+  });
+
+  test('should apply series number formatter when exporting async', async () => {
+    const s2 = await createSheetWithSeriesNumberFormatter();
+
+    const data = await asyncGetAllPlainData({
+      sheetInstance: s2,
+      split: TAB_SEPARATOR,
+      formatOptions: true,
+      async: true,
+    });
+
+    const rows = data.split(LINE_SEPARATOR);
+
+    for (let i = 1; i < rows.length; i++) {
+      const cols = rows[i].split(TAB_SEPARATOR);
+
+      expect(cols[0]).toBe(formatter(i));
+    }
+  });
+
+  test('should not apply series number formatter when formatOptions is false', async () => {
+    const s2 = await createSheetWithSeriesNumberFormatter();
+
+    const data = await asyncGetAllPlainData({
+      sheetInstance: s2,
+      split: TAB_SEPARATOR,
+      formatOptions: false,
+    });
+
+    const rows = data.split(LINE_SEPARATOR);
+
+    // formatOptions: false 时，序号列应为原始数字
+    for (let i = 1; i < rows.length; i++) {
+      const cols = rows[i].split(TAB_SEPARATOR);
+
+      expect(cols[0]).toBe(String(i));
+    }
+  });
+});

--- a/packages/s2-core/src/utils/export/copy/table-copy.ts
+++ b/packages/s2-core/src/utils/export/copy/table-copy.ts
@@ -66,7 +66,14 @@ class TableDataCellCopy extends BaseDataCellCopy {
         const field = node?.field;
 
         if (SERIES_NUMBER_FIELD === field && seriesNumber?.enable) {
-          return (i + 1).toString();
+          const seriesValue = i + 1;
+          const formatter = this.getFormatter({
+            field,
+            rowIndex: i,
+            colIndex: j,
+          });
+
+          return formatter(seriesValue);
         }
 
         const formatter = this.getFormatter({
@@ -114,7 +121,14 @@ class TableDataCellCopy extends BaseDataCellCopy {
                 const field = colNode.field;
 
                 if (SERIES_NUMBER_FIELD === field && seriesNumber?.enable) {
-                  row.push((j + 1).toString());
+                  const seriesValue = j + 1;
+                  const formatter = this.getFormatter({
+                    field,
+                    rowIndex: j,
+                    colIndex: i,
+                  });
+
+                  row.push(formatter(seriesValue) as string);
                   // eslint-disable-next-line no-continue
                   continue;
                 }


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix
<!-- 如果没有相关的 issue 需要关闭，请删除这一行 -->
- [x] Solve the issue and close #3332

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
Issue #3332：明细表使用 `asyncGetAllPlainData` 导出数据时，序号列（`SERIES_NUMBER_FIELD`）配置的 `meta.formatter` 不生效。表格渲染中 formatter 正常工作（显示 a, b, c），但导出结果仍为原始数字（1, 2, 3）。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌  ![iShot_2026-03-24_16 52 16](https://github.com/user-attachments/assets/9fda6326-1b0d-484f-9e13-d8a52edd5fac)    | ✅  ![iShot_2026-03-24_16 51 32](https://github.com/user-attachments/assets/e8f8e2af-2a97-428b-99e0-d582d9a900d5)    |

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
