### PR TITLE
fix(TableSheet): 修复中文字符串排序与 PivotSheet 不一致的问题

### DIFF
--- a/packages/s2-core/__tests__/bugs/issue-3335-spec.ts
+++ b/packages/s2-core/__tests__/bugs/issue-3335-spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @description spec for issue #3335
+ * https://github.com/antvis/S2/issues/3335
+ */
+import type { S2DataConfig, S2Options, SpreadSheet } from '@/index';
+import { createTableSheet } from '../util/helpers';
+
+const s2Options: S2Options = {
+  width: 800,
+  height: 480,
+};
+
+const dataCfg: S2DataConfig = {
+  fields: {
+    columns: ['city'],
+  },
+  data: [
+    { city: '长春' },
+    { city: '舟山' },
+    { city: '北京' },
+    { city: '上海' },
+  ],
+};
+
+describe('issue #3335', () => {
+  let s2: SpreadSheet;
+
+  beforeEach(async () => {
+    s2 = createTableSheet(s2Options);
+    s2.setDataCfg(dataCfg);
+    await s2.render();
+  });
+
+  test('should sort chinese strings by zh locale in asc order', async () => {
+    s2.setDataCfg({
+      ...dataCfg,
+      sortParams: [{ sortFieldId: 'city', sortMethod: 'ASC' }],
+    });
+    await s2.render();
+
+    expect(
+      s2.dataSet.getCellMultiData({
+        query: {
+          field: 'city',
+        },
+      }),
+    ).toEqual(['北京', '上海', '长春', '舟山']);
+  });
+
+  test('should sort chinese strings by zh locale in desc order', async () => {
+    s2.setDataCfg({
+      ...dataCfg,
+      sortParams: [{ sortFieldId: 'city', sortMethod: 'DESC' }],
+    });
+    await s2.render();
+
+    expect(
+      s2.dataSet.getCellMultiData({
+        query: {
+          field: 'city',
+        },
+      }),
+    ).toEqual(['舟山', '长春', '上海', '北京']);
+  });
+});

--- a/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
+++ b/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
@@ -46,7 +46,7 @@ describe('GuiIcon Tests', () => {
 
   test('should not render icon with invalid online url', async () => {
     registerIcon('test', 'https://www.test.svg');
-    jest
+    const getImageSpy = jest
       .spyOn(GuiIcon.prototype, 'getImage')
       .mockRejectedValueOnce(new Error('mock load failed'));
 
@@ -65,6 +65,8 @@ describe('GuiIcon Tests', () => {
     await Promise.resolve();
 
     expect(errSpy).toHaveBeenCalled();
+    getImageSpy.mockRestore();
+    errSpy.mockRestore();
   });
 
   test('should get is online link result', () => {
@@ -98,9 +100,8 @@ describe('GuiIcon Tests', () => {
     });
 
     const spy = jest.spyOn(icon, 'getImage');
-    const oldVal = icon.iconImageShape.style.src;
 
-    expect(oldVal).toBeDefined();
+    expect(icon.iconImageShape).toBeInstanceOf(CustomImage);
     icon.setImageAttrs({ fill: 'red' });
     expect(spy).toHaveBeenCalled();
   });

--- a/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
+++ b/packages/s2-core/__tests__/unit/common/icons/gui-icon-spec.ts
@@ -3,7 +3,7 @@ import { ArrowDown } from '@/common/icons/svg/svgs';
 import { CustomImage } from '@/engine/CustomImage';
 import { Group } from '@antv/g';
 import { registerIcon } from '../../../../src/common/icons';
-import { createPivotSheet, sleep } from '../../../util/helpers';
+import { createPivotSheet } from '../../../util/helpers';
 
 describe('GuiIcon Tests', () => {
   test('should get gui icon static type', () => {
@@ -46,10 +46,11 @@ describe('GuiIcon Tests', () => {
 
   test('should not render icon with invalid online url', async () => {
     registerIcon('test', 'https://www.test.svg');
+    jest
+      .spyOn(GuiIcon.prototype, 'getImage')
+      .mockRejectedValueOnce(new Error('mock load failed'));
 
-    const errSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementationOnce(() => {});
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     // eslint-disable-next-line no-new
     new GuiIcon({
@@ -60,7 +61,8 @@ describe('GuiIcon Tests', () => {
       height: 20,
     });
 
-    await sleep(300);
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(errSpy).toHaveBeenCalled();
   });

--- a/packages/s2-core/src/data-set/table-data-set.ts
+++ b/packages/s2-core/src/data-set/table-data-set.ts
@@ -1,4 +1,4 @@
-import { each, filter, hasIn, isFunction, isObject, orderBy } from 'lodash';
+import { each, filter, hasIn, isFunction, isNil, isObject } from 'lodash';
 import type { CellMeta } from '../common';
 import type {
   Data,
@@ -7,11 +7,38 @@ import type {
   SimpleData,
 } from '../common/interface';
 import { getEmptyPlaceholder } from '../utils';
+import { canConvertToNumber } from '../utils/number-calculate';
 import { isAscSort, isDescSort } from '../utils/sort-action';
 import { BaseDataSet } from './base-data-set';
 import type { GetCellDataParams, GetCellMultiDataParams } from './interface';
 
 export class TableDataSet extends BaseDataSet {
+  private compareSortValues(
+    valueA: SimpleData,
+    valueB: SimpleData,
+    sortMethod: 'asc' | 'desc',
+  ) {
+    const sort = isAscSort(sortMethod) ? 1 : -1;
+
+    if (isNil(valueA) && isNil(valueB)) {
+      return 0;
+    }
+
+    if (isNil(valueA)) {
+      return 1;
+    }
+
+    if (isNil(valueB)) {
+      return -1;
+    }
+
+    if (canConvertToNumber(valueA) && canConvertToNumber(valueB)) {
+      return (Number(valueA) - Number(valueB)) * sort;
+    }
+
+    return valueA.toString().localeCompare(valueB.toString(), 'zh') * sort;
+  }
+
   public processDataCfg(dataCfg: S2DataConfig): S2DataConfig {
     return dataCfg;
   }
@@ -136,25 +163,32 @@ export class TableDataSet extends BaseDataSet {
           return idxB - idxA;
         });
       } else if (isAscSort(sortMethod!) || isDescSort(sortMethod!)) {
+        const normalizedSortMethod = sortMethod!.toLocaleLowerCase() as
+          | 'asc'
+          | 'desc';
         const placeholder = getEmptyPlaceholder(
           this.spreadsheet,
           this.spreadsheet.options?.placeholder,
         );
         const customSortBy = isFunction(sortBy) ? sortBy : null;
-        const customSort = (record: RawData) => {
+        const customSort = (record: RawData): SimpleData => {
           // 空值占位符按最小值处理 https://github.com/antvis/S2/issues/2707
           if (record[sortFieldId] === placeholder) {
             return Number.MIN_VALUE;
           }
 
-          return record[sortFieldId];
+          return record[sortFieldId] as SimpleData;
         };
 
-        sortedData = orderBy(
-          data,
-          [customSortBy || customSort],
-          [sortMethod?.toLocaleLowerCase() as boolean | 'asc' | 'desc'],
-        ) as RawData[];
+        const getSortValue = customSortBy || customSort;
+
+        sortedData = [...data].sort((recordA, recordB) =>
+          this.compareSortValues(
+            getSortValue(recordA) as SimpleData,
+            getSortValue(recordB) as SimpleData,
+            normalizedSortMethod,
+          ),
+        );
       }
 
       if (restData.length) {


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

- [x] Solve the issue and close #3335 

🔧 Chore

- [x] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

本次 PR 修复了 `TableSheet` 中文字符串排序行为与 `PivotSheet` 不一致的问题。

变更前，`TableSheet` 在 `ASC` / `DESC` 排序场景下使用 `lodash/orderBy` 对字符串进行排序，实际表现为按码点顺序比较，导致中文排序结果与 `PivotSheet` 当前基于 `zh` locale 的排序行为不一致。

本次修改将 `TableSheet` 的字符串排序调整为基于 `zh` locale 的比较方式，同时保留了现有的数值排序逻辑、自定义 `sortBy` / `sortFunc` 能力，以及空占位符的排序处理逻辑。

此外，补充了 `#3335` 的回归测试，覆盖中文字符串升序和降序场景。

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| <img width="1656" height="730" alt="image" src="https://github.com/user-attachments/assets/f959d2c9-0697-44ce-8012-c1f97cd20000" /> | <img width="1650" height="826" alt="image" src="https://github.com/user-attachments/assets/e705fb68-f125-43d8-9e33-a9247ec9354b" /> |

### ⚠️ Breaking Changes

- [ ] Yes
- [x] No

### 🔗 Related issue link

- Close https://github.com/antvis/S2/issues/3335

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
