### PR TITLE
fix: dataCell 始终按当前 meta.height 计算可展示行数

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
+++ b/packages/s2-core/__tests__/spreadsheet/__snapshots__/multi-line-text-spec.ts.snap
@@ -4385,13 +4385,12 @@ Array [
     "width": 96,
   },
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -5293,13 +5292,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for default sort header action icons 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
+    "actualText": "23672367236...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
     "height": 30,
     "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
+      "23672367236...",
     ],
     "originalText": 236723672361111,
     "width": 102,
@@ -7180,13 +7178,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should calculate correctly max text width for headerActionIcons 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
+    "actualText": "23672367236...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
     "height": 30,
     "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
+      "23672367236...",
     ],
     "originalText": 236723672361111,
     "width": 102,
@@ -8880,13 +8877,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should get correctly row cell height priority if actual text not wrap 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
+    "actualText": "23672367236...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
     "height": 30,
     "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
+      "23672367236...",
     ],
     "originalText": 236723672361111,
     "width": 102,
@@ -9578,13 +9574,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -9979,13 +9974,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style less than actual text height by colCell.height() 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -10938,13 +10932,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should not adaptive adjust cell height if custom cell style more than actual text height by colCell.heightByField 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -13182,13 +13175,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should render by infinity maxLines 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -14826,13 +14818,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should render by maxLinesByField 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
+    "actualText": "23672367236...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
     "height": 30,
     "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
+      "23672367236...",
     ],
     "originalText": 236723672361111,
     "width": 102,
@@ -15932,13 +15923,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should render three max text lines 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -16622,13 +16612,12 @@ Array [
     "width": 103,
   },
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
+    "actualText": "23672367236...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
     "height": 30,
     "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
+      "23672367236...",
     ],
     "originalText": 236723672361111,
     "width": 103,
@@ -17311,13 +17300,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should render two max text lines 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 99,
+    "actualText": "2367236723...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 77,
     "height": 30,
     "multiLineActualTexts": Array [
-      "23672367236",
-      "1111",
+      "2367236723...",
     ],
     "originalText": 236723672361111,
     "width": 96,
@@ -17909,13 +17897,12 @@ Array [
 exports[`SpreadSheet Multi Line Text Tests PivotSheet should use actual text height for large max line 5`] = `
 Array [
   Object {
-    "actualText": "236723672361111",
-    "actualTextHeight": 30,
-    "actualTextWidth": 100,
+    "actualText": "23672367236...",
+    "actualTextHeight": 15,
+    "actualTextWidth": 84,
     "height": 30,
     "multiLineActualTexts": Array [
-      "2367236723611",
-      "11",
+      "23672367236...",
     ],
     "originalText": 236723672361111,
     "width": 102,

--- a/packages/s2-core/src/cell/data-cell.ts
+++ b/packages/s2-core/src/cell/data-cell.ts
@@ -1,7 +1,7 @@
 import type { PointLike } from '@antv/g';
 import { find, first, get, isEmpty, isEqual, isObject, merge } from 'lodash';
 import { BaseCell } from '../cell/base-cell';
-import { ContentPositionParams, DEFAULT_STYLE } from '../common';
+import { ContentPositionParams } from '../common';
 import { EMPTY_PLACEHOLDER } from '../common/constant/basic';
 import {
   CellType,
@@ -542,8 +542,9 @@ export class DataCell extends BaseCell<ViewMeta> {
     return (
       rowCell?.maxLinesByField?.[this.meta.id] ??
       rowCell?.maxLinesByField?.[this.meta.rowId!] ??
+      // 透视表数值格继承行高，需按当前高度收缩 maxLines，避免高度不足时继续换行。
       this.getMaxLinesByCustomHeight({
-        isCustomHeight: this.meta.height !== DEFAULT_STYLE.dataCell?.height,
+        isCustomHeight: true,
       })
     );
   }


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix
<!-- 如果没有相关的 issue 需要关闭，请删除这一行 -->
- [x] Solve the issue and close #3337

🔧 Chore

- [x] Test case

### 📝 Description

改动点在 data-cell.ts (line 542)：DataCell 现在会始终按当前 meta.height 计算可展示行数，而不是只有“自定义高度”时才计算。

之前的问题是默认行高下 getResizedTextMaxLines() 返回 undefined，于是回退到你配置的 dataCell.maxLines: 10，导致文本继续按 10 行换行。现在会按当前行高收缩成 1 行，textOverflow: 'ellipsis' 才能生效。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌ <img width="1318" height="724" alt="image" src="https://github.com/user-attachments/assets/026f51cf-28b8-41e3-bf7e-834b994d1a99" />     | ✅   <img width="611" height="283" alt="image" src="https://github.com/user-attachments/assets/e9e99deb-eb70-4122-9177-045e16729653" />  |
