### PR TITLE
fix: 视频单元格宽度异常

### DIFF
--- a/packages/s2-core/__tests__/unit/renderer/renderer-factory-spec.ts
+++ b/packages/s2-core/__tests__/unit/renderer/renderer-factory-spec.ts
@@ -19,6 +19,7 @@ describe('SingletonRenderer.render 渲染器测试', () => {
         x: 0,
       })),
       getIconStyle: jest.fn(),
+      getMaxTextWidth: jest.fn(() => mockBBox.width),
       removeChild: jest.fn(),
     } as unknown as BaseCell<any>;
   });

--- a/packages/s2-core/src/common/constant/renderer.ts
+++ b/packages/s2-core/src/common/constant/renderer.ts
@@ -2,3 +2,5 @@ export enum CellRendererType {
   VIDEO = 'VIDEO',
   IMAGE = 'IMAGE',
 }
+
+export const VIDEO_RECT_NAME = 'videoRect';

--- a/packages/s2-core/src/interaction/base-interaction/click/preview-click.ts
+++ b/packages/s2-core/src/interaction/base-interaction/click/preview-click.ts
@@ -4,7 +4,10 @@ import { FederatedPointerEvent as CanvasEvent } from '@antv/g';
 import { get } from 'lodash';
 import type { BaseCell } from '../../../cell/base-cell';
 import { CellType, S2Event, S2_PREFIX_CLS } from '../../../common/constant';
-import { CellRendererType } from '../../../common/constant/renderer';
+import {
+  CellRendererType,
+  VIDEO_RECT_NAME,
+} from '../../../common/constant/renderer';
 import type { PreviewTheme } from '../../../common/interface';
 import { ImageRendererConfig } from '../../../common/interface';
 import { BaseEvent, BaseEventImplement } from '../../../interaction/base-event';
@@ -182,7 +185,13 @@ export class PreviewClick extends BaseEvent implements BaseEventImplement {
       cellRendererType === CellRendererType.IMAGE &&
       get(event.target, 'nodeName') !== 'image'
     ) {
-      // 如果点击的位置并不是图片，则不预览
+      return;
+    }
+
+    if (
+      cellRendererType === CellRendererType.VIDEO &&
+      get(event.target, 'name') !== VIDEO_RECT_NAME
+    ) {
       return;
     }
 

--- a/packages/s2-core/src/renderer/VideoRenderer.ts
+++ b/packages/s2-core/src/renderer/VideoRenderer.ts
@@ -1,14 +1,20 @@
 // 视频渲染器
 import { DisplayObjectConfig, Rect, RectStyleProps } from '@antv/g';
 import type { BaseCell } from '../cell';
+import { VIDEO_RECT_NAME } from '../common/constant/renderer';
 import { GuiIcon } from '../common/icons';
-import { VideoRendererConfig } from '../common/interface';
+import { CellClipBox, VideoRendererConfig } from '../common/interface';
 import { SimpleBBox } from '../engine';
+import { calculateImageSize } from '../utils/cell/customRenderer';
 import { BaseRenderer } from './BaseRenderer';
+
+// 部分浏览器 autoplay=false 时不解码首帧，seek 到此时间点强制解码以展示预览画面
+const VIDEO_PREVIEW_FRAME_TIME = 0.001;
 
 const defaultVideoConfig = {
   loop: true,
-  autoplay: true,
+  autoplay: false,
+  preload: 'auto',
   crossOrigin: true,
   controls: false,
   muted: true,
@@ -48,6 +54,8 @@ export class VideoRenderer extends BaseRenderer {
 
       video.onloadeddata = () => {
         clearTimeout(fallbackTimer);
+        video.pause();
+        video.currentTime = VIDEO_PREVIEW_FRAME_TIME;
         BaseRenderer.mediaCache.set(text, video);
 
         resolve(video);
@@ -70,28 +78,46 @@ export class VideoRenderer extends BaseRenderer {
     cell: BaseCell<SimpleBBox>,
     element: HTMLVideoElement | string,
   ): DisplayObjectConfig<RectStyleProps> {
-    const { x, y, width, height } = this.getCellInfo(cell);
-    let transform = '';
+    const { y, height } = cell.getBBoxByType(CellClipBox.CONTENT_BOX);
+    const availableWidth = Math.max(cell.getMaxTextWidth(), 0);
+    let videoWidth = availableWidth;
+    let videoHeight = height;
+    let fill: RectStyleProps['fill'] = 'transparent';
 
     if (element instanceof HTMLVideoElement) {
-      const scaleX = width / element.videoWidth;
-      const scaleY = height / element.videoHeight;
+      const calculated = calculateImageSize(
+        availableWidth,
+        height,
+        element.videoWidth,
+        element.videoHeight,
+      );
 
-      transform = `scale(${scaleX}, ${scaleY})`;
+      videoWidth = calculated.width;
+      videoHeight = calculated.height;
+
+      const scaleX = videoWidth / element.videoWidth;
+      const scaleY = videoHeight / element.videoHeight;
+
+      fill = {
+        image: element,
+        repetition: 'no-repeat',
+        transform: `scale(${scaleX}, ${scaleY})`,
+      };
     }
+
+    const { x: videoX } = cell.getContentPosition({
+      contentWidth: videoWidth,
+    });
+    const videoY = y + (height - videoHeight) / 2;
 
     // https://g.antv.antgroup.com/api/css/pattern
     return {
       style: {
-        x,
-        y,
-        width,
-        height,
-        fill: {
-          image: element,
-          repetition: 'no-repeat',
-          transform,
-        },
+        x: videoX,
+        y: videoY,
+        width: videoWidth,
+        height: videoHeight,
+        fill,
         ...renderer.config,
       },
     };
@@ -101,8 +127,13 @@ export class VideoRenderer extends BaseRenderer {
     cell: BaseCell<SimpleBBox>,
     config: DisplayObjectConfig<RectStyleProps>,
   ) {
-    const rect = new Rect(config);
-    const { x, y, width, height } = this.getCellInfo(cell);
+    const rect = new Rect({ ...config, name: VIDEO_RECT_NAME });
+    const { x, y, width, height } = config.style as {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    };
     const calcSize = Math.min(width, height) * 0.25;
 
     rect.appendChild(


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix
<!-- 如果没有相关的 issue 需要关闭，请删除这一行 -->
- [ ] Solve the issue and close

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->
1. 单元格渲染视频时未保持视频的宽高比
2. 单元格渲染视频时宽度撑满了单元格，导致同单元格的icon无法渲染
3. 视频单元格，点击空白区域仍然触发了视频播放

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| <img width="865" height="618" alt="image" src="https://github.com/user-attachments/assets/12f7f895-7a3b-49ed-8657-8edb8bf90412" />   | <img width="879" height="536" alt="image" src="https://github.com/user-attachments/assets/53f402e8-ff59-48c4-b6b6-03560c01bc55" />  |

### ⚠️ Breaking Changes

<!-- Does this PR introduce a breaking change? -->
<!-- 这个 PR 是否包含破坏性变更？如果有，请说明它对现有用户的影响以及如何进行迁移。 -->

- [ ] Yes
- [x] No

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [x] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
