### PR TITLE
docs: update video renderer api configuration across documentation

### DIFF
--- a/s2-site/docs/api/general/s2-data-config.en.md
+++ b/s2-site/docs/api/general/s2-data-config.en.md
@@ -125,7 +125,8 @@ Function description: Field metadata, configurable field alias and value formatt
 | prepareText | Perform asynchronous processing on the text before rendering           | (value: SimpleData) => Promise<string>                                                  |    |      |
 | fallback       | Fallback display for image loading failure          | string                                                   |          |          |
 | timeout        |                                                     | number                                                   | 10000    |          |
-| config         |                                                     | Partial<[ImageStyleProps](https://g.antv.antgroup.com/api/basic/image)> \| Partial<[HTMLVideoElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement)>\| [HTMLStyleProps](https://g.antv.antgroup.com/api/basic/html) |          |          |
+| config         | Configuration for image or video container          | Partial<[ImageStyleProps](https://g.antv.antgroup.com/api/basic/image)> \| Partial<[RectStyleProps](https://g.antv.antgroup.com/api/basic/rect)> |          |          |
+| videoConfig    | Video configuration, valid only when type is VIDEO | Partial<[HTMLVideoElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement)> | `{ loop: true, autoplay: false, preload: 'auto', crossOrigin: true, controls: false, muted: true }` |      |
 
 ### MiniChartData
 

--- a/s2-site/docs/api/general/s2-data-config.zh.md
+++ b/s2-site/docs/api/general/s2-data-config.zh.md
@@ -59,7 +59,8 @@ const s2DataConfig = {
 | prepareText | 渲染前对文本进行异步处理           | (value: SimpleData) => Promise<string>                                                  |    |      |
 | fallback       | 图片、视频加载失败的兜底展示         | string                                                   |        |      |
 | timeout        | 图片、视频加载超时时间            | number                                                   | 10000  |      |
-| config         | 图片、视频的配置项              | Partial<[ImageStyleProps](https://g.antv.antgroup.com/api/basic/image)> \| Partial<[HTMLVideoElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement)>\| [HTMLStyleProps](https://g.antv.antgroup.com/api/basic/html) |        |      |
+| config         | 图片、视频容器的配置项              | Partial<[ImageStyleProps](https://g.antv.antgroup.com/api/basic/image)> \| Partial<[RectStyleProps](https://g.antv.antgroup.com/api/basic/rect)> |        |      |
+| videoConfig    | 视频配置项，仅当 type 为 VIDEO 时生效 | Partial<[HTMLVideoElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement)> | `{ loop: true, autoplay: false, preload: 'auto', crossOrigin: true, controls: false, muted: true }` |      |
 
 <embed src="@/common/custom/customTreeNode.zh.md"></embed>
 <embed src="@/common/view-meta.zh.md"></embed>

--- a/s2-site/docs/manual/advanced/cell-render/video.en.md
+++ b/s2-site/docs/manual/advanced/cell-render/video.en.md
@@ -23,7 +23,7 @@ const s2DataConfig = {
       clickToPreview?: boolean, // Whether to enable click to preview
       prepareText?: (value: SimpleData) => Promise<string>, // Asynchronously process text before rendering
       config?: Partial<RectStyleProps>, // Video rectangle area configuration within the cell https://g.antv.antgroup.com/api/css/pattern#htmlvideoelement
-      videoConfig?: Partial<HTMLVideoElement> // https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement
+      videoConfig?: Partial<HTMLVideoElement> // https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement, default: { loop: true, autoplay: false, preload: 'auto', crossOrigin: true, controls: false, muted: true }
     }
   }
 }

--- a/s2-site/docs/manual/advanced/cell-render/video.zh.md
+++ b/s2-site/docs/manual/advanced/cell-render/video.zh.md
@@ -24,7 +24,7 @@ const s2DataConfig = {
       clickToPreview?: boolean, // 是否开启点击预览
       prepareText?: (value: SimpleData) => Promise<string>, // 渲染前对文本进行异步处理
       config?: Partial<RectStyleProps>, // 单元格内视频矩形区域配置 https://g.antv.antgroup.com/api/css/pattern#htmlvideoelement
-      videoConfig?: Partial<HTMLVideoElement> // https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement
+      videoConfig?: Partial<HTMLVideoElement> // https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement，默认值：{ loop: true, autoplay: false, preload: 'auto', crossOrigin: true, controls: false, muted: true }
     }
   }
 }


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix
<!-- 如果没有相关的 issue 需要关闭，请删除这一行 -->
- [ ] Solve the issue and close

🔧 Chore

- [ ] Test case
- [x] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

Based on the latest weekly commit analysis (Commit `8e42aff58` and recent `VideoRendererConfig` adjustments):
- Documented `videoConfig` in the `s2-data-config` API specification, adding missing configuration properties for `type: 'VIDEO'` that were previously unaccounted for.
- Added the correct default values for `videoConfig` (`{ loop: true, autoplay: false, preload: 'auto', crossOrigin: true, controls: false, muted: true }`) into the tutorials for both Chinese and English.
- Updated `config` documentation to include `RectStyleProps`.
- Symmetrically updated `.zh.md` and `.en.md` across the docs directory.

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### ⚠️ Breaking Changes

<!-- Does this PR introduce a breaking change? -->
<!-- 这个 PR 是否包含破坏性变更？如果有，请说明它对现有用户的影响以及如何进行迁移。 -->

- [ ] Yes
- [x] No

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [x] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.

---
*PR created automatically by Jules for task [16898877395320545996](https://jules.google.com/task/16898877395320545996) started by @Alexzjt*