### PR TITLE
fix: shift+wheel 横向滚动在云桌面环境下失效

### DIFF
--- a/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
+++ b/packages/s2-core/__tests__/spreadsheet/scroll-spec.ts
@@ -694,7 +694,7 @@ describe('Scroll Tests', () => {
       ).toBeFalsy();
     });
 
-    test('should scroll horizontally when shift key is held on Windows', async () => {
+    test('should scroll horizontally when shift key is held and deltaY has value (Windows behavior)', async () => {
       s2.setOptions({
         frozenRowHeader: true,
         style: {
@@ -723,16 +723,11 @@ describe('Scroll Tests', () => {
 
       s2.on(S2Event.GLOBAL_SCROLL, onScroll);
 
+      // Windows 行为: shift+wheel 时系统不转换方向, deltaY 有值, deltaX 为 0
       const wheelEvent = new WheelEvent('wheel', {
         deltaX: 0,
         deltaY: 20,
         shiftKey: true,
-      });
-
-      Object.defineProperty(window.navigator, 'userAgent', {
-        value: 'Windows',
-        configurable: true,
-        writable: true,
       });
 
       canvas.dispatchEvent(wheelEvent);
@@ -740,28 +735,82 @@ describe('Scroll Tests', () => {
       expect(onScroll).toHaveBeenCalled();
     });
 
-    test('should not scroll horizontally when shift key is held on macOS', async () => {
+    test('should scroll horizontally when shift key is held and system already converted to deltaX (cloud desktop / macOS behavior)', async () => {
+      s2.setOptions({
+        frozenRowHeader: true,
+        style: {
+          layoutWidthType: 'compact',
+          rowCfg: {
+            width: 200,
+          },
+        },
+      });
+
       const onScroll = jest.fn((...args) => {
         expect(args[0].rowHeaderScrollX).toBeGreaterThan(0);
         expect(args[0].scrollX).toBe(0);
         expect(args[0].scrollY).toBe(0);
       });
 
-      const wheelEvent = new WheelEvent('wheel', {
-        deltaX: 0,
-        deltaY: 20,
-        shiftKey: true,
-      });
+      s2.changeSheetSize(400, 300);
+      s2.render(false);
 
-      Object.defineProperty(window.navigator, 'userAgent', {
-        value: 'Mac OS',
-        configurable: true,
-        writable: true,
+      jest
+        .spyOn(s2.facet, 'isScrollOverTheCornerArea')
+        .mockImplementationOnce(() => true);
+      jest
+        .spyOn(s2.facet, 'isScrollOverTheViewport')
+        .mockImplementationOnce(() => true);
+
+      s2.on(S2Event.GLOBAL_SCROLL, onScroll);
+
+      // 云桌面/macOS 行为: 系统已将 shift+wheel 转换为横向滚动, deltaX 有值, deltaY 为 0
+      const wheelEvent = new WheelEvent('wheel', {
+        deltaX: 100,
+        deltaY: 0,
+        shiftKey: true,
       });
 
       canvas.dispatchEvent(wheelEvent);
       await sleep(200);
-      expect(onScroll).not.toHaveBeenCalled();
+      expect(onScroll).toHaveBeenCalled();
+    });
+
+    test('should not convert deltaX when system already handled shift+wheel conversion', async () => {
+      s2.setOptions({
+        frozenRowHeader: true,
+        style: {
+          layoutWidthType: 'compact',
+          rowCfg: {
+            width: 200,
+          },
+        },
+      });
+
+      s2.changeSheetSize(400, 300);
+      s2.render(false);
+
+      jest
+        .spyOn(s2.facet, 'isScrollOverTheCornerArea')
+        .mockImplementationOnce(() => true);
+      jest
+        .spyOn(s2.facet, 'isScrollOverTheViewport')
+        .mockImplementationOnce(() => true);
+
+      // 云桌面环境: 系统已转换, deltaX=-100, deltaY=0
+      // 不应该将 deltaX 覆盖为 0
+      const wheelEvent = new WheelEvent('wheel', {
+        deltaX: -100,
+        deltaY: 0,
+        shiftKey: true,
+      });
+
+      const onScroll = jest.fn();
+
+      s2.on(S2Event.GLOBAL_SCROLL, onScroll);
+      canvas.dispatchEvent(wheelEvent);
+      await sleep(200);
+      expect(onScroll).toHaveBeenCalled();
     });
 
     it('should not change init body overscrollBehavior style when render and destroyed', () => {

--- a/packages/s2-core/src/facet/base-facet.ts
+++ b/packages/s2-core/src/facet/base-facet.ts
@@ -55,7 +55,7 @@ import { getAdjustedRowScrollX, getAdjustedScrollOffset } from '../utils/facet';
 import { getAllChildCells } from '../utils/get-all-child-cells';
 import { getColsForGrid, getRowsForGrid } from '../utils/grid';
 import { diffPanelIndexes, type PanelIndexes } from '../utils/indexes';
-import { isMobile, isWindows } from '../utils/is-mobile';
+import { isMobile } from '../utils/is-mobile';
 import { CornerBBox } from './bbox/cornerBBox';
 import { PanelBBox } from './bbox/panelBBox';
 import {
@@ -986,9 +986,11 @@ export abstract class BaseFacet {
     let { deltaX, deltaY, offsetX, offsetY } = event;
     const { shiftKey } = event;
 
-    // Windows 环境，按住 shift 时，固定为水平方向滚动，macOS 环境默认有该行为
+    // 按住 shift 时，固定为水平方向滚动
+    // macOS 环境和部分云桌面环境，系统会自动将 shift+wheel 转换为横向滚动 (deltaX 有值, deltaY 为 0)，无需手动处理
+    // Windows 环境下系统不会自动转换 (deltaY 有值, deltaX 为 0)，需要手动将 deltaY 转为 deltaX
     // see https://github.com/antvis/S2/issues/2198
-    if (shiftKey && isWindows()) {
+    if (shiftKey && deltaY !== 0 && deltaX === 0) {
       offsetX = offsetX - deltaX + deltaY;
       deltaX = deltaY;
       offsetY -= deltaY;


### PR DESCRIPTION
云桌面系统已自动将 shift+wheel 转换为横向滚动(deltaX有值, deltaY为0), 但原逻辑依赖 isWindows() UA 判断，会错误地将有效的 deltaX 覆盖为 0。

改为基于实际事件值判断：仅当 deltaY 有值且 deltaX 为 0 时才手动转换，
兼容所有平台和云桌面环境。

### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->
<!-- 这个 PR 属于什么类型，请选中对应类型 [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix
<!-- 如果没有相关的 issue 需要关闭，请删除这一行 -->
- [x] Solve the issue and close

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description

<!-- What is this PR change point? What is the background? What problems have been solved? -->
<!-- 这个 PR 改动点是什么？背景是什么？解决了什么问题？-->

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ❌      | ✅     |

### ⚠️ Breaking Changes

<!-- Does this PR introduce a breaking change? -->
<!-- 这个 PR 是否包含破坏性变更？如果有，请说明它对现有用户的影响以及如何进行迁移。 -->

- [ ] Yes
- [x] No

### 🔗 Related issue link

<!-- If there is a related Issue/PR link -->
<!-- 如果有相关的 Issue/PR 链接，请关联上 -->

### 🔍 Self-Check before the merge

<!-- Please add test case, docs, and demos -->
<!-- 吾日三省吾身，有添加单元测试吗？有完善文档吗？有增加文档示例吗？-->

- [x] Add or update relevant docs.
- [x] Add or update relevant demos.
- [x] Add or update test case.
- [x] Add or update relevant TypeScript definitions.
